### PR TITLE
GatherMetrics rename

### DIFF
--- a/godplugin/plugin_test.go
+++ b/godplugin/plugin_test.go
@@ -37,7 +37,7 @@ func TestPlugin_Serve(t *testing.T) {
 					},
 				}
 			},
-			GatherMetricsFunc: func() map[string]int64 {
+			CollectFunc: func() map[string]int64 {
 				return map[string]int64{
 					"id1": 1,
 					"id2": 2,

--- a/modules/apache/apache.go
+++ b/modules/apache/apache.go
@@ -96,7 +96,7 @@ func (a *Apache) Init() bool {
 
 // Check makes check
 func (a *Apache) Check() bool {
-	if len(a.GatherMetrics()) == 0 {
+	if len(a.Collect()) == 0 {
 		return false
 	}
 
@@ -124,8 +124,8 @@ func (a Apache) Charts() *modules.Charts {
 	return charts
 }
 
-// GatherMetrics gathers metrics
-func (a *Apache) GatherMetrics() map[string]int64 {
+// Collect collects metrics
+func (a *Apache) Collect() map[string]int64 {
 	resp, err := a.doRequest()
 
 	if err != nil {

--- a/modules/apache/apache_test.go
+++ b/modules/apache/apache_test.go
@@ -71,7 +71,7 @@ func TestApache_Cleanup(t *testing.T) {
 	New().Cleanup()
 }
 
-func TestApache_GatherMetrics(t *testing.T) {
+func TestApache_Collect(t *testing.T) {
 	ts := httptest.NewServer(
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
@@ -87,7 +87,7 @@ func TestApache_GatherMetrics(t *testing.T) {
 
 	require.True(t, mod.Init())
 	require.True(t, mod.Check())
-	require.NotNil(t, mod.GatherMetrics())
+	require.NotNil(t, mod.Collect())
 
 	expected := map[string]int64{
 		assign(totalAccesses):       575,

--- a/modules/example/example.go
+++ b/modules/example/example.go
@@ -6,6 +6,15 @@ import (
 	"github.com/netdata/go.d.plugin/modules"
 )
 
+func init() {
+	creator := modules.Creator{
+		DisabledByDefault: true,
+		Create:            func() modules.Module { return New() },
+	}
+
+	modules.Register("example", creator)
+}
+
 // New creates Example with default values
 func New() *Example {
 	return &Example{
@@ -38,19 +47,10 @@ func (Example) Charts() *Charts {
 	return charts.Copy()
 }
 
-// GatherMetrics gathers metrics
-func (e *Example) GatherMetrics() map[string]int64 {
+// Collect collects metrics
+func (e *Example) Collect() map[string]int64 {
 	e.metrics["random0"] = rand.Int63n(100)
 	e.metrics["random1"] = rand.Int63n(100)
 
 	return e.metrics
-}
-
-func init() {
-	creator := modules.Creator{
-		DisabledByDefault: true,
-		Create:            func() modules.Module { return New() },
-	}
-
-	modules.Register("example", creator)
 }

--- a/modules/example/example_test.go
+++ b/modules/example/example_test.go
@@ -35,8 +35,8 @@ func TestExample_Cleanup(t *testing.T) {
 	mod.Cleanup()
 }
 
-func TestExample_GatherMetrics(t *testing.T) {
+func TestExample_Collect(t *testing.T) {
 	mod := New()
 
-	assert.NotNil(t, mod.GatherMetrics())
+	assert.NotNil(t, mod.Collect())
 }

--- a/modules/httpcheck/httpcheck.go
+++ b/modules/httpcheck/httpcheck.go
@@ -14,6 +14,15 @@ import (
 	"github.com/netdata/go.d.plugin/pkg/web"
 )
 
+func init() {
+	creator := modules.Creator{
+		UpdateEvery: 5,
+		Create:      func() modules.Module { return New() },
+	}
+
+	modules.Register("httpcheck", creator)
+}
+
 type state string
 
 var (
@@ -127,8 +136,8 @@ func (hc HTTPCheck) Charts() *Charts {
 
 }
 
-// GatherMetrics gathers metrics
-func (hc *HTTPCheck) GatherMetrics() map[string]int64 {
+// Collect collects metrics
+func (hc *HTTPCheck) Collect() map[string]int64 {
 	hc.metrics.reset()
 
 	resp, err := hc.doRequest()
@@ -193,13 +202,4 @@ func parseErr(err error) state {
 	}
 
 	return unknown
-}
-
-func init() {
-	creator := modules.Creator{
-		UpdateEvery: 5,
-		Create:      func() modules.Module { return New() },
-	}
-
-	modules.Register("httpcheck", creator)
 }

--- a/modules/httpcheck/httpcheck_test.go
+++ b/modules/httpcheck/httpcheck_test.go
@@ -38,7 +38,7 @@ func TestHTTPCheck_Cleanup(t *testing.T) {
 	New().Cleanup()
 }
 
-func TestHTTPCheck_GatherMetrics(t *testing.T) {
+func TestHTTPCheck_Collect(t *testing.T) {
 	mod := New()
 
 	srv := httptest.NewServer(myHandler{})
@@ -46,7 +46,7 @@ func TestHTTPCheck_GatherMetrics(t *testing.T) {
 
 	mod.URL = srv.URL
 	mod.Init()
-	assert.NotNil(t, mod.GatherMetrics())
+	assert.NotNil(t, mod.Collect())
 }
 
 func TestHTTPCheck_ResponseSuccess(t *testing.T) {

--- a/modules/job.go
+++ b/modules/job.go
@@ -195,7 +195,7 @@ func (j *Job) runOnce() {
 	curTime := time.Now()
 	sinceLastRun := calcSinceLastRun(curTime, j.prevRun)
 
-	metrics := j.gatherMetrics()
+	metrics := j.collect()
 
 	if j.panicked {
 		j.observer.RemoveFromQueue(j.FullName())
@@ -218,14 +218,14 @@ func (j Job) AutoDetectionRetry() int {
 	return j.AutoDetectRetry
 }
 
-func (j *Job) gatherMetrics() (result map[string]int64) {
+func (j *Job) collect() (result map[string]int64) {
 	defer func() {
 		if r := recover(); r != nil {
 			j.Errorf("PANIC: %v", r)
 			j.panicked = true
 		}
 	}()
-	return j.module.GatherMetrics()
+	return j.module.Collect()
 }
 
 func (j *Job) processMetrics(metrics map[string]int64, startTime time.Time, sinceLastRun int) bool {

--- a/modules/job_test.go
+++ b/modules/job_test.go
@@ -176,7 +176,7 @@ func TestJob_MainLoop(t *testing.T) {
 				},
 			}
 		},
-		GatherMetricsFunc: func() map[string]int64 {
+		CollectFunc: func() map[string]int64 {
 			return map[string]int64{
 				"id1": 1,
 				"id2": 2,
@@ -203,8 +203,8 @@ func TestJob_MainLoop(t *testing.T) {
 
 func TestJob_MainLoop_Panic(t *testing.T) {
 	m := &MockModule{
-		GatherMetricsFunc: func() map[string]int64 {
-			panic("panic in GatherMetrics")
+		CollectFunc: func() map[string]int64 {
+			panic("panic in Collect")
 		},
 	}
 	job := testNewJob()

--- a/modules/mock.go
+++ b/modules/mock.go
@@ -4,11 +4,11 @@ package modules
 type MockModule struct {
 	Base
 
-	InitFunc          func() bool
-	CheckFunc         func() bool
-	ChartsFunc        func() *Charts
-	GatherMetricsFunc func() map[string]int64
-	CleanupDone       bool
+	InitFunc    func() bool
+	CheckFunc   func() bool
+	ChartsFunc  func() *Charts
+	CollectFunc func() map[string]int64
+	CleanupDone bool
 }
 
 // Init invokes InitFunc
@@ -35,12 +35,12 @@ func (m MockModule) Charts() *Charts {
 	return m.ChartsFunc()
 }
 
-// GatherMetrics invokes GetDataDunc
-func (m MockModule) GatherMetrics() map[string]int64 {
-	if m.GatherMetricsFunc == nil {
+// Collect invokes CollectDunc
+func (m MockModule) Collect() map[string]int64 {
+	if m.CollectFunc == nil {
 		return nil
 	}
-	return m.GatherMetricsFunc()
+	return m.CollectFunc()
 }
 
 // Cleanup sets CleanupDone to true

--- a/modules/mock_test.go
+++ b/modules/mock_test.go
@@ -32,15 +32,15 @@ func TestMockModule_Charts(t *testing.T) {
 	assert.True(t, c == m.Charts())
 }
 
-func TestMockModule_GatherMetrics(t *testing.T) {
+func TestMockModule_Collect(t *testing.T) {
 	m := &MockModule{}
 	d := map[string]int64{
 		"1": 1,
 	}
 
-	assert.Nil(t, m.GatherMetrics())
-	m.GatherMetricsFunc = func() map[string]int64 { return d }
-	assert.Equal(t, d, m.GatherMetrics())
+	assert.Nil(t, m.Collect())
+	m.CollectFunc = func() map[string]int64 { return d }
+	assert.Equal(t, d, m.Collect())
 }
 
 func TestMockModule_Cleanup(t *testing.T) {

--- a/modules/module.go
+++ b/modules/module.go
@@ -18,8 +18,8 @@ type Module interface {
 	// Make sure not to share returned instance.
 	Charts() *Charts
 
-	// GatherMetrics returns metrics.
-	GatherMetrics() map[string]int64
+	// Collect collects metrics.
+	Collect() map[string]int64
 
 	// SetLogger SetLogger
 	SetLogger(l *logger.Logger)

--- a/modules/nginx/nginx.go
+++ b/modules/nginx/nginx.go
@@ -73,7 +73,7 @@ func (n *Nginx) Init() bool {
 
 // Check makes check
 func (n *Nginx) Check() bool {
-	return n.GatherMetrics() != nil
+	return len(n.Collect()) > 0
 }
 
 // Charts creates Charts
@@ -81,8 +81,8 @@ func (Nginx) Charts() *Charts {
 	return charts.Copy()
 }
 
-// GatherMetrics gathers metrics
-func (n *Nginx) GatherMetrics() map[string]int64 {
+// Collect collects metrics
+func (n *Nginx) Collect() map[string]int64 {
 	resp, err := n.doRequest()
 
 	if err != nil {

--- a/modules/nginx/nginx_test.go
+++ b/modules/nginx/nginx_test.go
@@ -44,7 +44,7 @@ func TestNginx_Cleanup(t *testing.T) {
 	New().Cleanup()
 }
 
-func TestNginx_GatherMetrics(t *testing.T) {
+func TestNginx_Collect(t *testing.T) {
 	ts := httptest.NewServer(
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
@@ -60,7 +60,7 @@ func TestNginx_GatherMetrics(t *testing.T) {
 
 	assert.True(t, mod.Init())
 
-	metrics := mod.GatherMetrics()
+	metrics := mod.Collect()
 	assert.NotNil(t, metrics)
 
 	expected := map[string]int64{

--- a/modules/portcheck/portcheck.go
+++ b/modules/portcheck/portcheck.go
@@ -10,6 +10,15 @@ import (
 	"github.com/netdata/go.d.plugin/pkg/utils"
 )
 
+func init() {
+	creator := modules.Creator{
+		UpdateEvery: 5,
+		Create:      func() modules.Module { return New() },
+	}
+
+	modules.Register("portcheck", creator)
+}
+
 type state string
 
 var (
@@ -131,8 +140,8 @@ func (tc PortCheck) Charts() *Charts {
 	return &charts
 }
 
-// GatherMetrics gathers metrics
-func (tc *PortCheck) GatherMetrics() map[string]int64 {
+// Collect collects metrics
+func (tc *PortCheck) Collect() map[string]int64 {
 	for _, p := range tc.ports {
 		tc.doCh <- p
 	}
@@ -152,13 +161,4 @@ func (tc *PortCheck) GatherMetrics() map[string]int64 {
 	}
 
 	return tc.metrics
-}
-
-func init() {
-	creator := modules.Creator{
-		UpdateEvery: 5,
-		Create:      func() modules.Module { return New() },
-	}
-
-	modules.Register("portcheck", creator)
 }

--- a/modules/portcheck/portcheck_test.go
+++ b/modules/portcheck/portcheck_test.go
@@ -54,7 +54,7 @@ func TestPortCheck_Charts(t *testing.T) {
 	assert.NotNil(t, New().Charts())
 }
 
-func TestPortCheck_GatherMetrics(t *testing.T) {
+func TestPortCheck_Collect(t *testing.T) {
 	mod := New()
 	defer mod.Cleanup()
 
@@ -80,7 +80,7 @@ func TestPortCheck_GatherMetrics(t *testing.T) {
 		"instate_3002": 5,
 	}
 
-	rv := mod.GatherMetrics()
+	rv := mod.Collect()
 
 	require.NotNil(t, rv)
 
@@ -104,7 +104,7 @@ func TestPortCheck_ServerOK(t *testing.T) {
 
 	defer srv.close()
 
-	assert.NotNil(t, mod.GatherMetrics())
+	assert.NotNil(t, mod.Collect())
 
 	for _, p := range mod.ports {
 		assert.True(t, p.state == success)
@@ -121,7 +121,7 @@ func TestPortCheck_ServerBAD(t *testing.T) {
 
 	tc.Init()
 
-	assert.NotNil(t, tc.GatherMetrics())
+	assert.NotNil(t, tc.Collect())
 
 	for _, p := range tc.ports {
 		assert.True(t, p.state == failed)

--- a/modules/rabbitmq/rabbitmq.go
+++ b/modules/rabbitmq/rabbitmq.go
@@ -126,7 +126,7 @@ func (r *Rabbitmq) Init() bool {
 
 // Check makes check
 func (r *Rabbitmq) Check() bool {
-	return len(r.GatherMetrics()) > 0
+	return len(r.Collect()) > 0
 }
 
 // Charts creates Charts
@@ -134,14 +134,14 @@ func (Rabbitmq) Charts() *Charts {
 	return charts.Copy()
 }
 
-// GatherMetrics gathers stats
-func (r *Rabbitmq) GatherMetrics() map[string]int64 {
-	if err := r.gather(r.reqOverview, &r.overview); err != nil {
+// Collect collects stats
+func (r *Rabbitmq) Collect() map[string]int64 {
+	if err := r.collect(r.reqOverview, &r.overview); err != nil {
 		r.Error(err)
 		return nil
 	}
 
-	if err := r.gather(r.reqNodes, &r.nodes); err != nil {
+	if err := r.collect(r.reqNodes, &r.nodes); err != nil {
 		r.Error(err)
 		return nil
 	}
@@ -165,7 +165,7 @@ func (r *Rabbitmq) doRequest(req *http.Request) (*http.Response, error) {
 	return r.client.Do(req)
 }
 
-func (r *Rabbitmq) gather(req *http.Request, stats interface{}) error {
+func (r *Rabbitmq) collect(req *http.Request, stats interface{}) error {
 	resp, err := r.doRequest(req)
 
 	if err != nil {

--- a/modules/rabbitmq/rabbitmq_test.go
+++ b/modules/rabbitmq/rabbitmq_test.go
@@ -69,7 +69,7 @@ func TestRabbitmq_Charts(t *testing.T) {
 	assert.NotNil(t, New().Charts())
 }
 
-func TestRabbitmq_GatherMetrics(t *testing.T) {
+func TestRabbitmq_Collect(t *testing.T) {
 	ts := httptest.NewServer(
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
@@ -87,7 +87,7 @@ func TestRabbitmq_GatherMetrics(t *testing.T) {
 
 	require.True(t, mod.Init())
 	require.True(t, mod.Check())
-	require.NotZero(t, mod.GatherMetrics())
+	require.NotZero(t, mod.Collect())
 
 	expected := map[string]int64{
 		"message_stats_ack":                    1,

--- a/modules/springboot2/springboot2.go
+++ b/modules/springboot2/springboot2.go
@@ -77,8 +77,8 @@ func (SpringBoot2) Charts() *Charts {
 	return charts.Copy()
 }
 
-// GatherMetrics gathers metrics
-func (s *SpringBoot2) GatherMetrics() map[string]int64 {
+// Collect collects metrics
+func (s *SpringBoot2) Collect() map[string]int64 {
 	rawMetrics, err := s.prom.Scrape()
 	if err != nil {
 		return nil

--- a/modules/springboot2/springboot2_test.go
+++ b/modules/springboot2/springboot2_test.go
@@ -33,7 +33,7 @@ func TestSpringboot2(t *testing.T) {
 
 	assert.True(t, module.Check())
 
-	data := module.GatherMetrics()
+	data := module.Collect()
 
 	assert.EqualValues(
 		t,


### PR DESCRIPTION
`GatherMetrics` => `Collect`

I was thinking of renaming `modules` to `collectors`, but no, they should stay as modules for the consistent across all plugins.