### PR TITLE
plugin hearbeat

### DIFF
--- a/godplugin/loopqueue.go
+++ b/godplugin/loopqueue.go
@@ -7,6 +7,12 @@ type loopQueue struct {
 	queue []Job
 }
 
+func (q *loopQueue) len() int {
+	q.mux.Lock()
+	defer q.mux.Unlock()
+	return len(q.queue)
+}
+
 func (q *loopQueue) add(job Job) {
 	q.mux.Lock()
 	defer q.mux.Unlock()

--- a/godplugin/plugin.go
+++ b/godplugin/plugin.go
@@ -1,6 +1,7 @@
 package godplugin
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"os/signal"
@@ -90,6 +91,14 @@ func (p *Plugin) Serve() {
 
 	for _, job := range p.createJobs() {
 		p.jobCh <- job
+	}
+
+	// NOTE: temporary workaround
+	// `go.d.plugin` process doesn't die after `kill -9 <netdata pid>` if there is no active jobs
+	if len(p.loopQueue.queue) == 0 {
+		log.Info("no jobs to run. Exit...")
+		_, _ = fmt.Fprint(os.Stdout, "DISABLE")
+		os.Exit(0)
 	}
 
 	p.mainLoop()

--- a/godplugin/plugin.go
+++ b/godplugin/plugin.go
@@ -95,7 +95,7 @@ func (p *Plugin) Serve() {
 
 	// NOTE: temporary workaround
 	// `go.d.plugin` process doesn't die after `kill -9 <netdata pid>` if there is no active jobs
-	if len(p.loopQueue.queue) == 0 {
+	if p.loopQueue.len() == 0 {
 		log.Info("no jobs to run. Exit...")
 		_, _ = fmt.Fprint(os.Stdout, "DISABLE")
 		os.Exit(0)

--- a/godplugin/plugin.go
+++ b/godplugin/plugin.go
@@ -93,8 +93,9 @@ func (p *Plugin) Serve() {
 		p.jobCh <- job
 	}
 
-	// NOTE: temporary workaround
+	// FIXME: temporary workaround
 	// `go.d.plugin` process doesn't die after `kill -9 <netdata pid>` if there is no active jobs
+	// this breaks autodetection jobs
 	if p.loopQueue.len() == 0 {
 		log.Info("no jobs to run. Exit...")
 		_, _ = fmt.Fprint(os.Stdout, "DISABLE")


### PR DESCRIPTION
> if you kill netdata with -9, netdata will immediately exit without killing its plugins. So, the only way for a plugin to exit is to detect that writing to its stdout gives errors.