### PR TITLE
fix springboot2 metrics name

### DIFF
--- a/modules/springboot2/springboot2.go
+++ b/modules/springboot2/springboot2.go
@@ -111,8 +111,8 @@ func (s *SpringBoot2) Collect() map[string]int64 {
 	gatherResponse(rawMetrics, &m)
 
 	// threads
-	m.ThreadsDaemon.Set(rawMetrics.FindByName("jvm_threads_daemon").Max())
-	m.Threads.Set(rawMetrics.FindByName("jvm_threads_live").Max())
+	m.ThreadsDaemon.Set(rawMetrics.FindByNames("jvm_threads_daemon", "jvm_threads_daemon_threads").Max())
+	m.Threads.Set(rawMetrics.FindByNames("jvm_threads_live", "jvm_threads_live_threads").Max())
 
 	// heap memory
 	gatherHeap(rawMetrics.FindByName("jvm_memory_used_bytes"), &m.HeapUsed)

--- a/modules/springboot2/tests/testdata2.txt
+++ b/modules/springboot2/tests/testdata2.txt
@@ -1,0 +1,193 @@
+# HELP jvm_classes_loaded_classes The number of classes that are currently loaded in the Java virtual machine
+# TYPE jvm_classes_loaded_classes gauge
+jvm_classes_loaded_classes 12360.0
+# HELP process_files_open_files The open file descriptor count
+# TYPE process_files_open_files gauge
+process_files_open_files 46.0
+# HELP jvm_memory_used_bytes The amount of used memory
+# TYPE jvm_memory_used_bytes gauge
+jvm_memory_used_bytes{area="heap",id="Tenured Gen",} 4.0122672E7
+jvm_memory_used_bytes{area="heap",id="Eden Space",} 1.805296E7
+jvm_memory_used_bytes{area="nonheap",id="Metaspace",} 6.6824752E7
+jvm_memory_used_bytes{area="nonheap",id="Code Cache",} 2.6224704E7
+jvm_memory_used_bytes{area="heap",id="Survivor Space",} 302704.0
+jvm_memory_used_bytes{area="nonheap",id="Compressed Class Space",} 8236936.0
+# HELP system_cpu_count The number of processors available to the Java virtual machine
+# TYPE system_cpu_count gauge
+system_cpu_count 1.0
+# HELP process_cpu_usage The "recent cpu usage" for the Java Virtual Machine process
+# TYPE process_cpu_usage gauge
+process_cpu_usage 0.0
+# HELP tomcat_sessions_alive_max_seconds
+# TYPE tomcat_sessions_alive_max_seconds gauge
+tomcat_sessions_alive_max_seconds 0.0
+# HELP tomcat_global_sent_bytes_total
+# TYPE tomcat_global_sent_bytes_total counter
+tomcat_global_sent_bytes_total{name="http-nio-17001",} 7.06007212E8
+# HELP jvm_threads_states_threads The current number of threads having NEW state
+# TYPE jvm_threads_states_threads gauge
+jvm_threads_states_threads{state="runnable",} 10.0
+jvm_threads_states_threads{state="blocked",} 0.0
+jvm_threads_states_threads{state="waiting",} 22.0
+jvm_threads_states_threads{state="timed-waiting",} 4.0
+jvm_threads_states_threads{state="new",} 0.0
+jvm_threads_states_threads{state="terminated",} 0.0
+# HELP process_start_time_seconds Start time of the process since unix epoch.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.552476492313E9
+# HELP tomcat_sessions_active_max_sessions
+# TYPE tomcat_sessions_active_max_sessions gauge
+tomcat_sessions_active_max_sessions 0.0
+# HELP jvm_gc_live_data_size_bytes Size of old generation memory pool after a full GC
+# TYPE jvm_gc_live_data_size_bytes gauge
+jvm_gc_live_data_size_bytes 3.1908592E7
+# HELP spring_integration_channels The number of message channels
+# TYPE spring_integration_channels gauge
+spring_integration_channels 6.0
+# HELP system_cpu_usage The "recent cpu usage" for the whole system
+# TYPE system_cpu_usage gauge
+system_cpu_usage 0.047619047619047616
+# HELP jvm_classes_unloaded_classes_total The total number of classes unloaded since the Java virtual machine has started execution
+# TYPE jvm_classes_unloaded_classes_total counter
+jvm_classes_unloaded_classes_total 0.0
+# HELP jvm_memory_max_bytes The maximum amount of memory in bytes that can be used for memory management
+# TYPE jvm_memory_max_bytes gauge
+jvm_memory_max_bytes{area="heap",id="Tenured Gen",} 6.61323776E8
+jvm_memory_max_bytes{area="heap",id="Eden Space",} 2.64568832E8
+jvm_memory_max_bytes{area="nonheap",id="Metaspace",} -1.0
+jvm_memory_max_bytes{area="nonheap",id="Code Cache",} 2.5165824E8
+jvm_memory_max_bytes{area="heap",id="Survivor Space",} 3.3030144E7
+jvm_memory_max_bytes{area="nonheap",id="Compressed Class Space",} 1.073741824E9
+# HELP logback_events_total Number of error level events that made it to the logs
+# TYPE logback_events_total counter
+logback_events_total{level="warn",} 1.0
+logback_events_total{level="debug",} 0.0
+logback_events_total{level="error",} 0.0
+logback_events_total{level="trace",} 0.0
+logback_events_total{level="info",} 30.0
+# HELP jvm_gc_max_data_size_bytes Max size of old generation memory pool
+# TYPE jvm_gc_max_data_size_bytes gauge
+jvm_gc_max_data_size_bytes 6.61323776E8
+# HELP tomcat_sessions_created_sessions_total
+# TYPE tomcat_sessions_created_sessions_total counter
+tomcat_sessions_created_sessions_total 0.0
+# HELP process_files_max_files The maximum file descriptor count
+# TYPE process_files_max_files gauge
+process_files_max_files 1006500.0
+# HELP spring_integration_sources The number of message sources
+# TYPE spring_integration_sources gauge
+spring_integration_sources 5.0
+# HELP tomcat_global_request_seconds
+# TYPE tomcat_global_request_seconds summary
+tomcat_global_request_seconds_count{name="http-nio-17001",} 57744.0
+tomcat_global_request_seconds_sum{name="http-nio-17001",} 113.513
+# HELP tomcat_sessions_active_current_sessions
+# TYPE tomcat_sessions_active_current_sessions gauge
+tomcat_sessions_active_current_sessions 0.0
+# HELP tomcat_global_error_total
+# TYPE tomcat_global_error_total counter
+tomcat_global_error_total{name="http-nio-17001",} 0.0
+# HELP jvm_threads_daemon_threads The current number of live daemon threads
+# TYPE jvm_threads_daemon_threads gauge
+jvm_threads_daemon_threads 22.0
+# HELP jvm_gc_memory_allocated_bytes_total Incremented for an increase in the size of the young generation memory pool after one GC to before the next
+# TYPE jvm_gc_memory_allocated_bytes_total counter
+jvm_gc_memory_allocated_bytes_total 2.7071024304E10
+# HELP http_server_requests_seconds
+# TYPE http_server_requests_seconds summary
+http_server_requests_seconds_count{exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",} 57717.0
+http_server_requests_seconds_sum{exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",} 108.648599202
+http_server_requests_seconds_count{exception="None",method="GET",outcome="SUCCESS",status="200",uri="/search/form",} 13.0
+http_server_requests_seconds_sum{exception="None",method="GET",outcome="SUCCESS",status="200",uri="/search/form",} 2.504856475
+http_server_requests_seconds_count{exception="None",method="GET",outcome="SUCCESS",status="200",uri="/search/",} 1.0
+http_server_requests_seconds_sum{exception="None",method="GET",outcome="SUCCESS",status="200",uri="/search/",} 5.959808087
+http_server_requests_seconds_count{exception="None",method="GET",outcome="SUCCESS",status="200",uri="/**/favicon.ico",} 9.0
+http_server_requests_seconds_sum{exception="None",method="GET",outcome="SUCCESS",status="200",uri="/**/favicon.ico",} 0.0506538
+http_server_requests_seconds_count{exception="None",method="GET",outcome="CLIENT_ERROR",status="404",uri="/**",} 4.0
+http_server_requests_seconds_sum{exception="None",method="GET",outcome="CLIENT_ERROR",status="404",uri="/**",} 0.00875155
+# HELP http_server_requests_seconds_max
+# TYPE http_server_requests_seconds_max gauge
+http_server_requests_seconds_max{exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",} 0.007270684
+http_server_requests_seconds_max{exception="None",method="GET",outcome="SUCCESS",status="200",uri="/search/form",} 0.0
+http_server_requests_seconds_max{exception="None",method="GET",outcome="SUCCESS",status="200",uri="/search/",} 0.0
+http_server_requests_seconds_max{exception="None",method="GET",outcome="SUCCESS",status="200",uri="/**/favicon.ico",} 0.0
+http_server_requests_seconds_max{exception="None",method="GET",outcome="CLIENT_ERROR",status="404",uri="/**",} 0.0
+# HELP jvm_buffer_total_capacity_bytes An estimate of the total capacity of the buffers in this pool
+# TYPE jvm_buffer_total_capacity_bytes gauge
+jvm_buffer_total_capacity_bytes{id="direct",} 278528.0
+jvm_buffer_total_capacity_bytes{id="mapped",} 0.0
+# HELP spring_integration_handlers The number of message handlers
+# TYPE spring_integration_handlers gauge
+spring_integration_handlers 5.0
+# HELP jvm_gc_memory_promoted_bytes_total Count of positive increases in the size of the old generation memory pool before GC to after GC
+# TYPE jvm_gc_memory_promoted_bytes_total counter
+jvm_gc_memory_promoted_bytes_total 2.4583704E7
+# HELP jvm_buffer_count_buffers An estimate of the number of buffers in the pool
+# TYPE jvm_buffer_count_buffers gauge
+jvm_buffer_count_buffers{id="direct",} 15.0
+jvm_buffer_count_buffers{id="mapped",} 0.0
+# HELP jvm_memory_committed_bytes The amount of memory in bytes that is committed for the Java virtual machine to use
+# TYPE jvm_memory_committed_bytes gauge
+jvm_memory_committed_bytes{area="heap",id="Tenured Gen",} 5.3182464E7
+jvm_memory_committed_bytes{area="heap",id="Eden Space",} 2.1430272E7
+jvm_memory_committed_bytes{area="nonheap",id="Metaspace",} 7.0803456E7
+jvm_memory_committed_bytes{area="nonheap",id="Code Cache",} 2.6804224E7
+jvm_memory_committed_bytes{area="heap",id="Survivor Space",} 2621440.0
+jvm_memory_committed_bytes{area="nonheap",id="Compressed Class Space",} 8953856.0
+# HELP tomcat_global_request_max_seconds
+# TYPE tomcat_global_request_max_seconds gauge
+tomcat_global_request_max_seconds{name="http-nio-17001",} 6.049
+# HELP process_uptime_seconds The uptime of the Java virtual machine
+# TYPE process_uptime_seconds gauge
+process_uptime_seconds 45501.125
+# HELP tomcat_threads_config_max_threads
+# TYPE tomcat_threads_config_max_threads gauge
+tomcat_threads_config_max_threads{name="http-nio-17001",} 200.0
+# HELP jvm_buffer_memory_used_bytes An estimate of the memory that the Java virtual machine is using for this buffer pool
+# TYPE jvm_buffer_memory_used_bytes gauge
+jvm_buffer_memory_used_bytes{id="direct",} 278529.0
+jvm_buffer_memory_used_bytes{id="mapped",} 0.0
+# HELP http_client_requests_seconds Timer of WebClient operation
+# TYPE http_client_requests_seconds summary
+http_client_requests_seconds_count{clientName="search.example.com",method="GET",status="IO_ERROR",uri="/dictionary",} 1.0
+http_client_requests_seconds_sum{clientName="search.example.com",method="GET",status="IO_ERROR",uri="/dictionary",} 2.258042154
+http_client_requests_seconds_count{clientName="api.search.example.com",method="GET",status="200",uri="/v1/items",} 2.0
+http_client_requests_seconds_sum{clientName="api.search.example.com",method="GET",status="200",uri="/v1/items",} 0.305785165
+# HELP http_client_requests_seconds_max Timer of WebClient operation
+# TYPE http_client_requests_seconds_max gauge
+http_client_requests_seconds_max{clientName="search.example.com",method="GET",status="IO_ERROR",uri="/dictionary",} 0.0
+http_client_requests_seconds_max{clientName="api.search.example.com",method="GET",status="200",uri="/v1/items",} 0.0
+# HELP tomcat_global_received_bytes_total
+# TYPE tomcat_global_received_bytes_total counter
+tomcat_global_received_bytes_total{name="http-nio-17001",} 0.0
+# HELP jvm_threads_peak_threads The peak live thread count since the Java virtual machine started or peak was reset
+# TYPE jvm_threads_peak_threads gauge
+jvm_threads_peak_threads 36.0
+# HELP jvm_threads_live_threads The current number of live threads including both daemon and non-daemon threads
+# TYPE jvm_threads_live_threads gauge
+jvm_threads_live_threads 36.0
+# HELP system_load_average_1m The sum of the number of runnable entities queued to available processors and the number of runnable entities running on the available processors averaged over a period of time
+# TYPE system_load_average_1m gauge
+system_load_average_1m 0.02
+# HELP tomcat_threads_current_threads
+# TYPE tomcat_threads_current_threads gauge
+tomcat_threads_current_threads{name="http-nio-17001",} 10.0
+# HELP tomcat_sessions_expired_sessions_total
+# TYPE tomcat_sessions_expired_sessions_total counter
+tomcat_sessions_expired_sessions_total 0.0
+# HELP tomcat_sessions_rejected_sessions_total
+# TYPE tomcat_sessions_rejected_sessions_total counter
+tomcat_sessions_rejected_sessions_total 0.0
+# HELP jvm_gc_pause_seconds Time spent in GC pause
+# TYPE jvm_gc_pause_seconds summary
+jvm_gc_pause_seconds_count{action="end of major GC",cause="Metadata GC Threshold",} 1.0
+jvm_gc_pause_seconds_sum{action="end of major GC",cause="Metadata GC Threshold",} 0.1
+jvm_gc_pause_seconds_count{action="end of minor GC",cause="Allocation Failure",} 1269.0
+jvm_gc_pause_seconds_sum{action="end of minor GC",cause="Allocation Failure",} 5.909
+# HELP jvm_gc_pause_seconds_max Time spent in GC pause
+# TYPE jvm_gc_pause_seconds_max gauge
+jvm_gc_pause_seconds_max{action="end of major GC",cause="Metadata GC Threshold",} 0.0
+jvm_gc_pause_seconds_max{action="end of minor GC",cause="Allocation Failure",} 0.004
+# HELP tomcat_threads_busy_threads
+# TYPE tomcat_threads_busy_threads gauge
+tomcat_threads_busy_threads{name="http-nio-17001",} 1.0

--- a/pkg/prometheus/metrics.go
+++ b/pkg/prometheus/metrics.go
@@ -72,7 +72,24 @@ func (m Metrics) FindByName(name string) Metrics {
 	return m[from:until]
 }
 
-// match finds metrics where it's label matches given matcher.
+// FindByNames finds metrics where it's __name__ label matches given any of names.
+// It expects the metrics is sorted.
+// Complexity: O(log(N))
+func (m Metrics) FindByNames(names ...string) Metrics {
+	switch len(names) {
+	case 0:
+		return Metrics{}
+	case 1:
+		return m.FindByName(names[0])
+	}
+	var result Metrics
+	for _, name := range names {
+		result = append(result, m.FindByName(name)...)
+	}
+	return result
+}
+
+// Match match finds metrics where it's label matches given matcher.
 // It does NOT expect the metrics is sorted.
 // Complexity: O(N)
 func (m Metrics) Match(matcher *labels.Matcher) Metrics {
@@ -90,6 +107,9 @@ func (m Metrics) Match(matcher *labels.Matcher) Metrics {
 // It do NOT expect the metrics is sorted.
 // Complexity: O(N)
 func (m Metrics) Max() float64 {
+	if len(m) == 0 {
+		return 0
+	}
 	max := -math.MaxFloat64
 	for _, kv := range m {
 		if max < kv.Value {

--- a/pkg/prometheus/metrics_test.go
+++ b/pkg/prometheus/metrics_test.go
@@ -73,8 +73,17 @@ func TestMetrics_Add(t *testing.T) {
 
 func TestMetrics_FindByName(t *testing.T) {
 	m := testMetrics()
-
+	m.Sort()
+	assert.Len(t, Metrics{}.FindByName(testName1), 0)
 	assert.Len(t, m.FindByName(testName1), len(m)-1)
+}
+
+func TestMetrics_FindByNames(t *testing.T) {
+	m := testMetrics()
+	m.Sort()
+	assert.Len(t, m.FindByNames(), 0)
+	assert.Len(t, m.FindByNames(testName1), len(m)-1)
+	assert.Len(t, m.FindByNames(testName1, testName2), len(m))
 }
 
 func TestMetrics_Len(t *testing.T) {
@@ -121,10 +130,15 @@ func TestMetrics_Reset(t *testing.T) {
 }
 
 func TestMetrics_Sort(t *testing.T) {
-	m := testMetrics()
-
-	m.Sort()
-	assert.Equal(t, testName2, m[0].Name())
+	{
+		m := testMetrics()
+		m.Sort()
+		assert.Equal(t, testName2, m[0].Name())
+	}
+	{
+		m := Metrics{}
+		assert.Equal(t, 0, m.Max())
+	}
 }
 
 func TestMetrics_Swap(t *testing.T) {

--- a/pkg/prometheus/metrics_test.go
+++ b/pkg/prometheus/metrics_test.go
@@ -137,7 +137,7 @@ func TestMetrics_Sort(t *testing.T) {
 	}
 	{
 		m := Metrics{}
-		assert.Equal(t, 0, m.Max())
+		assert.Equal(t, 0.0, m.Max())
 	}
 }
 


### PR DESCRIPTION
some springboot2 use `jvm_threads_daemon` while others use `jvm_threads_daemon_threads`