### PR TITLE
pihole: gravity list last update fix

### DIFF
--- a/modules/pihole/client/client_test.go
+++ b/modules/pihole/client/client_test.go
@@ -71,6 +71,8 @@ func TestClient_SummaryRaw(t *testing.T) {
 	rv, err := client.SummaryRaw()
 	require.NoError(t, err)
 
+	var absolute int64 = 1560443834
+
 	expected := &SummaryRaw{
 		DomainsBeingBlocked: 1,
 		DNSQueriesToday:     1,
@@ -90,8 +92,8 @@ func TestClient_SummaryRaw(t *testing.T) {
 		Status:              "enabled",
 		GravityLastUpdated: struct {
 			FileExists bool `json:"file_exists"`
-			Absolute   int64
-		}{FileExists: true, Absolute: 1560443834},
+			Absolute   *int64
+		}{FileExists: true, Absolute: &absolute},
 	}
 
 	assert.Equal(t, expected, rv)

--- a/modules/pihole/client/types.go
+++ b/modules/pihole/client/types.go
@@ -9,6 +9,28 @@ type version struct {
 	Version int
 }
 
+/*
+if the gravity.list file exists
+
+{
+    "file_exists": true,
+    "absolute": 1561159378,
+    "relative": {
+        "days": "2",
+        "hours": "07",
+        "minutes": "40"
+    }
+}
+
+
+if the gravity.list file not exists
+
+{
+    "file_exists": false
+}
+
+*/
+
 // SummaryRaw represents summary statistics int raw format (no number formatting applied).
 type SummaryRaw struct {
 	DomainsBeingBlocked int64   `json:"domains_being_blocked"`
@@ -29,7 +51,7 @@ type SummaryRaw struct {
 	Status              string  `json:"status"`
 	GravityLastUpdated  struct {
 		FileExists bool `json:"file_exists"`
-		Absolute   int64
+		Absolute   *int64
 	} `json:"gravity_last_updated"`
 }
 

--- a/modules/pihole/collect.go
+++ b/modules/pihole/collect.go
@@ -31,7 +31,10 @@ func collectSummary(mx map[string]int64, pmx *piholeMetrics) {
 	mx["ads_blocked_today"] = pmx.summary.AdsBlockedToday
 	mx["ads_percentage_today"] = int64(pmx.summary.AdsPercentageToday * 100)
 	mx["domains_being_blocked"] = pmx.summary.DomainsBeingBlocked
-	mx["blocklist_last_update"] = time.Now().Unix() - pmx.summary.GravityLastUpdated.Absolute
+	// GravityLastUpdated.Absolute is <nil> if the file is not exists (deleted/moved)
+	if pmx.summary.GravityLastUpdated.Absolute != nil {
+		mx["blocklist_last_update"] = time.Now().Unix() - *pmx.summary.GravityLastUpdated.Absolute
+	}
 	mx["dns_queries_today"] = pmx.summary.DNSQueriesToday
 	mx["queries_forwarded"] = pmx.summary.QueriesForwarded
 	mx["queries_cached"] = pmx.summary.QueriesCached

--- a/modules/pihole/pihole_test.go
+++ b/modules/pihole/pihole_test.go
@@ -106,16 +106,16 @@ func TestPihole_Collect(t *testing.T) {
 	require.NotNil(t, job.Charts())
 
 	expected := map[string]int64{
-		"A":                     0,
-		"AAAA":                  0,
-		"ANY":                   0,
-		"PTR":                   0,
-		"SOA":                   0,
-		"SRV":                   0,
-		"TXT":                   0,
-		"ads_blocked_today":     0,
-		"ads_percentage_today":  0,
-		"blocklist_last_update": 1561019970,
+		"A":                    0,
+		"AAAA":                 0,
+		"ANY":                  0,
+		"PTR":                  0,
+		"SOA":                  0,
+		"SRV":                  0,
+		"TXT":                  0,
+		"ads_blocked_today":    0,
+		"ads_percentage_today": 0,
+		// "blocklist_last_update": 1561019970,
 		"destination_d1":        3329,
 		"destination_d2":        6659,
 		"dns_queries_today":     0,
@@ -133,8 +133,8 @@ func TestPihole_Collect(t *testing.T) {
 		"unique_clients":        0,
 	}
 
-	collected := job.Collect()
-	expected["blocklist_last_update"] = collected["blocklist_last_update"]
+	//collected := job.Collect()
+	// expected["blocklist_last_update"] = collected["blocklist_last_update"]
 
 	assert.Equal(t, expected, job.Collect())
 }
@@ -155,9 +155,9 @@ func TestPihole_Collect_OnlySummary(t *testing.T) {
 	require.NotNil(t, job.Charts())
 
 	expected := map[string]int64{
-		"ads_blocked_today":     0,
-		"ads_percentage_today":  0,
-		"blocklist_last_update": 1561019970,
+		"ads_blocked_today":    0,
+		"ads_percentage_today": 0,
+		// "blocklist_last_update": 1561019970,
 		"dns_queries_today":     0,
 		"domains_being_blocked": 0,
 		"file_exists":           0,
@@ -167,8 +167,8 @@ func TestPihole_Collect_OnlySummary(t *testing.T) {
 		"unique_clients":        0,
 	}
 
-	collected := job.Collect()
-	expected["blocklist_last_update"] = collected["blocklist_last_update"]
+	//collected := job.Collect()
+	//expected["blocklist_last_update"] = collected["blocklist_last_update"]
 
 	assert.Equal(t, expected, job.Collect())
 }


### PR DESCRIPTION
This PR fixes gravity.list update time calculation when the file is not exists.

Before the PR:
 - wrong time reported

After the PR:
 - value is not reported

if gravity list exists:
```json
{
    "file_exists": true,
    "absolute": 1561159378,
    "relative": {
        "days": "2",
        "hours": "07",
        "minutes": "40"
    }
}
```

if not (deleted, moved)

```json
{
    "file_exists": false
}
```
