### PR TITLE
scaleio: Remove numOfScsiInitiators

### DIFF
--- a/modules/scaleio/README.md
+++ b/modules/scaleio/README.md
@@ -6,6 +6,7 @@ This module will monitor one or more [ScaleIO (VxFlex OS)](https://www.dellemc.c
 Module was tested on:
  - VxFlex OS REST API v2.5
  - VxFlex OS v2.6.1.1_113
+ - VxFlex OS 3.0.0.1_134
 
 ### charts/collected metrics
 

--- a/modules/scaleio/README.md
+++ b/modules/scaleio/README.md
@@ -6,7 +6,7 @@ This module will monitor one or more [ScaleIO (VxFlex OS)](https://www.dellemc.c
 Module was tested on:
  - VxFlex OS REST API v2.5
  - VxFlex OS v2.6.1.1_113
- - VxFlex OS 3.0.0.1_134
+ - VxFlex OS 3.0.0.1_134, REST API v3.0
 
 ### charts/collected metrics
 

--- a/modules/scaleio/queries.go
+++ b/modules/scaleio/queries.go
@@ -62,7 +62,6 @@ var (
         "numOfMappedToAllVolumes",
         "numOfProtectionDomains",
         "numOfRfcacheDevices",
-        "numOfScsiInitiators",
         "numOfSdc",
         "numOfSds",
         "numOfSnapshots",

--- a/modules/scaleio/queries.go
+++ b/modules/scaleio/queries.go
@@ -62,6 +62,9 @@ var (
         "numOfMappedToAllVolumes",
         "numOfProtectionDomains",
         "numOfRfcacheDevices",
+	// Starting from version 3 of ScaleIO/VxFlex API numOfScsiInitiators property is removed.
+	// Reference: VxFlex OS v3.x REST API Reference Guide.pdf
+	// "numOfScsiInitiators",
         "numOfSdc",
         "numOfSds",
         "numOfSnapshots",


### PR DESCRIPTION
It is not in use and breaks ScaleIO/VxFlex v3 monitoring

Fixes: netdata/netdata#6475