### PR TITLE
netdata/packaging: Adjust go.d version update process

### DIFF
--- a/.travis/netdata_sync.sh
+++ b/.travis/netdata_sync.sh
@@ -40,9 +40,9 @@ cd "${LOCAL_NETDATA_DIR}"
 
 echo "--- Preparing changes for ${NETDATA_GIT_URL} ---"
 cp "$CHECKSUM_FILE" packaging/go.d.checksums
-sed -i "s/GO_PACKAGE_VERSION=\".*\"/GO_PACKAGE_VERSION=\"${TRAVIS_TAG}\"/g" netdata-installer.sh
+echo "${TRAVIS_TAG}" > packaging/go.d.version
 git checkout -b new_go_d_version
-git add netdata-installer.sh packaging/go.d.checksums
+git add packaging/go.d.version ackaging/go.d.checksums
 git commit -m "installer: include go.d.plugin version ${TRAVIS_TAG}"
 
 echo "--- Pushing changes to ${NETDATA_GIT_URL} --- "

--- a/.travis/netdata_sync.sh
+++ b/.travis/netdata_sync.sh
@@ -42,7 +42,7 @@ echo "--- Preparing changes for ${NETDATA_GIT_URL} ---"
 cp "$CHECKSUM_FILE" packaging/go.d.checksums
 echo "${TRAVIS_TAG}" > packaging/go.d.version
 git checkout -b new_go_d_version
-git add packaging/go.d.version ackaging/go.d.checksums
+git add packaging/go.d.version packaging/go.d.checksums
 git commit -m "installer: include go.d.plugin version ${TRAVIS_TAG}"
 
 echo "--- Pushing changes to ${NETDATA_GIT_URL} --- "


### PR DESCRIPTION
As of https://github.com/netdata/netdata/pull/6557 we will be keeping go.d version within packaging/go.d.version,.
This PR changes where we make the modification, simple as that
[ci skip]