### PR TITLE
netdata/go.d: Attempt to fix build-id errors during RPM build

### DIFF
--- a/hack/go-build.sh
+++ b/hack/go-build.sh
@@ -9,7 +9,7 @@ VERSION="${TRAVIS_TAG}"
 : "${VERSION:=$(git describe --tags --always --dirty)}"
 GOFLAGS=${GOFLAGS:-}
 GLDFLAGS=${GLDFLAGS:-}
-GLDFLAGS="$GLDFLAGS -X main.version=$VERSION"
+GLDFLAGS="$GLDFLAGS -X main.version=$VERSION -linkmode=external"
 
 echo "Building binaries for version: $VERSION"
 if [[ "${WHICH}" != "all" ]]; then


### PR DESCRIPTION
 Attempt to fix build-id errors during RPM build as per https://github.com/rpm-software-management/rpm/issues/367 recommendation