### PR TITLE
Add Current State Duration to HTTPcheck

### DIFF
--- a/modules/httpcheck/README.md
+++ b/modules/httpcheck/README.md
@@ -13,8 +13,11 @@ It produces the following charts:
  * timeout
  * bad content
  * bad status
+ 
+3. **HTTP Current State Duration** in seconds
+ * time
 
-3. **HTTP Response Body Length** in characters
+4. **HTTP Response Body Length** in characters
  * length
 
 ### check statuses

--- a/modules/httpcheck/charts.go
+++ b/modules/httpcheck/charts.go
@@ -52,4 +52,14 @@ var charts = Charts{
 			//{ID: "body_read_error", Name: "body read error"},
 		},
 	},
+	{
+		ID:    "current_state_duration",
+		Title: "HTTP Current State Duration",
+		Units: "seconds",
+		Fam:   "status",
+		Ctx:   "httpcheck.in_state",
+		Dims: Dims{
+			{ID: "in_state", Name: "time"},
+		},
+	},
 }

--- a/modules/httpcheck/collect.go
+++ b/modules/httpcheck/collect.go
@@ -43,6 +43,14 @@ func (hc *HTTPCheck) collect() (map[string]int64, error) {
 		hc.collectOKResponse(&mx, resp)
 	}
 
+	changed := hc.metrics.Status != mx.Status
+	if changed {
+		mx.InState = hc.UpdateEvery
+	} else {
+		mx.InState = hc.metrics.InState + hc.UpdateEvery
+	}
+	hc.metrics = mx
+
 	//if err == nil || mx.Status.RedirectError {
 	//	mx.ResponseTime = durationToMs(end)
 	//}

--- a/modules/httpcheck/httpcheck.go
+++ b/modules/httpcheck/httpcheck.go
@@ -55,9 +55,11 @@ type client interface {
 type HTTPCheck struct {
 	module.Base
 	Config           `yaml:",inline"`
+	UpdateEvery      int `yaml:"update_every"`
 	acceptedStatuses map[int]bool
 	reResponse       *regexp.Regexp
 	client           client
+	metrics          metrics
 }
 
 // Cleanup makes cleanup.

--- a/modules/httpcheck/metrics.go
+++ b/modules/httpcheck/metrics.go
@@ -2,6 +2,7 @@ package httpcheck
 
 type metrics struct {
 	Status         status `stm:""`
+	InState        int    `stm:"in_state"`
 	ResponseTime   int    `stm:"time"`
 	ResponseLength int    `stm:"length"`
 }


### PR DESCRIPTION
This adds the current state duration chart (from portcheck) to httpcheck as well. We needed this because we wanted to be able to alert on flapping HTTP checks (IE the HTTP checks are allowed to fail every so often but if they fail repeatedly in a time frame then there might be an underlying issue).