### PR TITLE
Fix markdown syntax HDFS/Zookeeper module pages

### DIFF
--- a/modules/hdfs/README.md
+++ b/modules/hdfs/README.md
@@ -1,51 +1,54 @@
 # hdfs
 
-This module will monitor one or more [`Hadoop Distributed File System`](https://hadoop.apache.org/docs/r1.2.1/hdfs_design.html) (HDFS) nodes depending on configuration.
+This module monitors one or more [`Hadoop Distributed File
+System`](https://hadoop.apache.org/docs/r1.2.1/hdfs_design.html) (HDFS) nodes, depending on your configuration.
 
-It access HDFS metrics over `Java Management Extensions` (JMX) through the web interface of an HDFS daemon.
+Netdata accesses HDFS metrics over `Java Management Extensions` (JMX) through the web interface of an HDFS daemon.
 
 **Requirements:**
- * `hdfs` node with accessible `/jmx` endpoint
+
+-   `hdfs` node with accessible `/jmx` endpoint
 
 It produces the following charts for `namenode`:
-  - Heap Memory in `MiB`
-  - GC Events in `events/s`
-  - GC Time in `ms`
-  - Number of Times That the GC Threshold is Exceeded in `events/s`
-  - Number of Threads in `num`
-  - Number of Logs in `logs/s`
-  - RPC Bandwidth in `kilobits/s`
-  - RPC Calls in `calls/s`
-  - RPC Open Connections in `connections`
-  - RPC Call Queue Length in `num`
-  - RPC Avg Queue Time in `ms`
-  - RPC Avg Processing Time in `ms`
-  - Capacity Across All Datanodes in `KiB`
-  - Used Capacity Across All Datanodes in `KiB`
-  - Number of Concurrent File Accesses (read/write) Across All DataNodes in `load`
-  - Number of Volume Failures Across All Datanodes in `events/s`
-  - Number of Tracked Files in `num`
-  - Number of Allocated Blocks in the System in `num`
-  - Number of Problem Blocks (can point to an unhealthy cluster) in `num`
-  - Number of Data Nodes By Status in `num`
+
+-   Heap Memory in `MiB`
+-   GC Events in `events/s`
+-   GC Time in `ms`
+-   Number of Times That the GC Threshold is Exceeded in `events/s`
+-   Number of Threads in `num`
+-   Number of Logs in `logs/s`
+-   RPC Bandwidth in `kilobits/s`
+-   RPC Calls in `calls/s`
+-   RPC Open Connections in `connections`
+-   RPC Call Queue Length in `num`
+-   RPC Avg Queue Time in `ms`
+-   RPC Avg Processing Time in `ms`
+-   Capacity Across All Datanodes in `KiB`
+-   Used Capacity Across All Datanodes in `KiB`
+-   Number of Concurrent File Accesses (read/write) Across All DataNodes in `load`
+-   Number of Volume Failures Across All Datanodes in `events/s`
+-   Number of Tracked Files in `num`
+-   Number of Allocated Blocks in the System in `num`
+-   Number of Problem Blocks (can point to an unhealthy cluster) in `num`
+-   Number of Data Nodes By Status in `num`
   
 It produces the following charts for `datanode`:
-  - Heap Memory in `MiB`
-  - GC Events in `events/s`
-  - GC Time in `ms`
-  - Number of Times That the GC Threshold is Exceeded in `events/s`
-  - Number of Threads in `num`
-  - Number of Logs in `logs/s`
-  - RPC Bandwidth in `kilobits/s`
-  - RPC Calls in `calls/s`
-  - RPC Open Connections in `connections`
-  - RPC Call Queue Length in `num`
-  - RPC Avg Queue Time in `ms`
-  - RPC Avg Processing Time in `ms`
-  - Capacity in `KiB`
-  - Used Capacity in `KiB`
-  - Bandwidth in `KiB/s`
-  
+
+-   Heap Memory in `MiB`
+-   GC Events in `events/s`
+-   GC Time in `ms`
+-   Number of Times That the GC Threshold is Exceeded in `events/s`
+-   Number of Threads in `num`
+-   Number of Logs in `logs/s`
+-   RPC Bandwidth in `kilobits/s`
+-   RPC Calls in `calls/s`
+-   RPC Open Connections in `connections`
+-   RPC Call Queue Length in `num`
+-   RPC Avg Queue Time in `ms`
+-   RPC Avg Processing Time in `ms`
+-   Capacity in `KiB`
+-   Used Capacity in `KiB`
+-   Bandwidth in `KiB/s`
 
 ### configuration
 
@@ -62,6 +65,6 @@ jobs:
     url     : http://127.0.0.1:9864/jmx
 ```
 
-For all available options please see module [configuration file](https://github.com/netdata/go.d.plugin/blob/master/config/go.d/hdfs.conf).
+For all available options, please see the module [configuration file](https://github.com/netdata/go.d.plugin/blob/master/config/go.d/hdfs.conf).
 
 ---

--- a/modules/zookeeper/README.md
+++ b/modules/zookeeper/README.md
@@ -1,24 +1,25 @@
 # zookeeper
 
-This module will monitor one or more [`Zookeeper`](https://zookeeper.apache.org/) servers depending on configuration.
+This module monitors one or more [`Zookeeper`](https://zookeeper.apache.org/) servers, depending on your configuration.
 
 **Requirements:**
- * `Zookeeper` with accessible client port
- * whitelisted `mntr` command
+
+-   `Zookeeper` with accessible client port
+-   whitelisted `mntr` command
 
 It produces the following charts:
-  - Outstanding Requests in `requests`
-  - Requests Latency in `ms`
-  - Alive Connections in `connections`
-  - Packets in `pps`
-  - Open File Descriptors in `file descriptors`
-  - Number of Nodes in `nodes`
-  - Number of Watches in `watches`
-  - Approximate Data Tree Size in `KiB`
-  - Server State in `state`
- 
 
-### configuration
+-   Outstanding Requests in `requests`
+-   Requests Latency in `ms`
+-   Alive Connections in `connections`
+-   Packets in `pps`
+-   Open File Descriptors in `file descriptors`
+-   Number of Nodes in `nodes`
+-   Number of Watches in `watches`
+-   Approximate Data Tree Size in `KiB`
+-   Server State in `state`
+
+### Configuration
 
 Needs only `address` to server's client port.
 
@@ -33,6 +34,6 @@ jobs:
     address : 203.0.113.10:2182
 ```
 
-For all available options please see module [configuration file](https://github.com/netdata/go.d.plugin/blob/master/config/go.d/zookeeper.conf).
+For all available options, please see the module [configuration file](https://github.com/netdata/go.d.plugin/blob/master/config/go.d/zookeeper.conf).
 
 ---


### PR DESCRIPTION
Hey @ilyam8, I noticed that the READMEs for the new HDFS and Zookeeper modules, once they get generated by our docs site, don't render correctly. The unordered list gets turned into a big, messy paragraph.

Here's a picture of how the HDFS page looks right now:

![image](https://user-images.githubusercontent.com/1153921/66163768-eabc6f00-e5e5-11e9-8853-28adf3491dc7.png)

I cleaned up the syntax and tested it out on a local build of the docs site and things work as expected after these changes.

Not sure _why_ GitHub and mkdocs render Markdown quite so differently, but that's for another time...