### PR TITLE
Markdown syntax fixes

### DIFF
--- a/modules/coredns/README.md
+++ b/modules/coredns/README.md
@@ -1,67 +1,43 @@
-# coredns
+# CoreDNS
 
-This module will monitor one or more coredns instances.
-
+This module will monitor one or more CoreDNS instances.
 
 It produces the following charts:
 
-<br>
 Summary:
 
-1. **Number Of DNS Requests** in requests/s
+1.  **Number Of DNS Requests** in requests/s
+2.  **Number Of DNS Responses** in responses/s
+3.  **Number Of Processed And Dropped DNS Requests** in requests/s
+4.  **Number Of Dropped DNS Requests Because Of No Matching Zone** in requests/s
+5.  **Number Of Panics** in panics/s
+6.  **Number Of DNS Requests Per Transport Protocol** in requests/s
+7.  **Number Of DNS Requests Per IP Family** in requests/s
+8.  **Number Of DNS Requests Per Type** in requests/s
+9.  **Number Of DNS Responses Per Rcode** in responses/s
 
-2. **Number Of DNS Responses** in responses/s
-
-3. **Number Of Processed And Dropped DNS Requests** in requests/s
-
-4. **Number Of Dropped DNS Requests Because Of No Matching Zone** in requests/s
-
-5. **Number Of Panics** in panics/s
-
-6. **Number Of DNS Requests Per Transport Protocol** in requests/s
-
-7. **Number Of DNS Requests Per IP Family** in requests/s
-
-8. **Number Of DNS Requests Per Type** in requests/s
- 
-9. **Number Of DNS Responses Per Rcode** in responses/s
-
-<br> 
 Per Server (if configured):
 
-1. **Number Of DNS Requests** in requests/s
+1.  **Number Of DNS Requests** in requests/s
+2.  **Number Of DNS Responses** in responses/s
+3.  **Number Of Processed And Dropped DNS Requests** in requests/s
+4.  **Number Of DNS Requests Per Transport Protocol** in requests/s
+5.  **Number Of DNS Requests Per IP Family** in requests/s
+6.  **Number Of DNS Requests Per Type** in requests/s
+7.  **Number Of DNS Responses Per Rcode** in responses/s
 
-2. **Number Of DNS Responses** in responses/s
-
-3. **Number Of Processed And Dropped DNS Requests** in requests/s
-
-4. **Number Of DNS Requests Per Transport Protocol** in requests/s
-
-5. **Number Of DNS Requests Per IP Family** in requests/s
-
-6. **Number Of DNS Requests Per Type** in requests/s
- 
-7. **Number Of DNS Responses Per Rcode** in responses/s
-
-<br> 
 Per Zone (if configured):
 
-1. **Number Of DNS Requests** in requests/s
+1.  **Number Of DNS Requests** in requests/s
+2.  **Number Of DNS Responses** in responses/s
+3.  **Number Of DNS Requests Per Transport Protocol** in requests/s
+4.  **Number Of DNS Requests Per IP Family** in requests/s
+5.  **Number Of DNS Requests Per Type** in requests/s
+6.  **Number Of DNS Responses Per Rcode** in responses/s
 
-2. **Number Of DNS Responses** in responses/s
+## Configuration
 
-3. **Number Of DNS Requests Per Transport Protocol** in requests/s
-
-4. **Number Of DNS Requests Per IP Family** in requests/s
-
-5. **Number Of DNS Requests Per Type** in requests/s
- 
-6. **Number Of DNS Responses Per Rcode** in responses/s
-
-
-### configuration
-
-Needs only `url` to coredns metric-address.
+The module eeeds only the `url` to a CoreDNS `metrics-address`.
 
 Here is an example:
 
@@ -74,8 +50,6 @@ jobs:
     url : http://100.64.0.1:9153/metrics
 ```
 
-For all available options please see module [configuration file](https://github.com/netdata/go.d.plugin/blob/master/config/go.d/coredns.conf).
+For all available options, please see the module's [configuration file](https://github.com/netdata/go.d.plugin/blob/master/config/go.d/coredns.conf).
 
-Without configuration, module attempts to connect to `http://127.0.0.1:9153/metrics`
-
----
+Without configuration, the module attempts to connect to `http://127.0.0.1:9153/metrics`.

--- a/modules/docker_engine/README.md
+++ b/modules/docker_engine/README.md
@@ -3,77 +3,76 @@
 This module will monitor one or more Docker engines.
 
 **Requirements:**
- * docker with enabled [`metric-address`](https://docs.docker.com/config/thirdparty/prometheus/)
 
+-   Docker with enabled [`metric-address`](https://docs.docker.com/config/thirdparty/prometheus/)
 
 It produces the following charts:
 
-1. **Container Actions** in actions/s
- * changes
- * commits
- * create
- * delete
- * start
+1.  **Container Actions** in actions/s
+    -   changes
+    -   commits
+    -   create
+    -   delete
+    -   start
 
-2. **Container States** in number of containers in state
- * running
- * paused
- * stopped
+2.  **Container States** in number of containers in state
+    -   running
+    -   paused
+    -   stopped
  
-3. **Builder Builds Fails By Reason** in fails/s
- * build_canceled
- * build_target_not_reachable_error
- * command_not_supported_error
- * dockerfile_empty_error
- * dockerfile_syntax_error
- * error_processing_commands_error
- * missing_onbuild_arguments_error
- * unknown_instruction_error
+3.  **Builder Builds Fails By Reason** in fails/s
+    -   build_canceled
+    -   build_target_not_reachable_error
+    -   command_not_supported_error
+    -   dockerfile_empty_error
+    -   dockerfile_syntax_error
+    -   error_processing_commands_error
+    -   missing_onbuild_arguments_error
+    -   unknown_instruction_error
  
-4. **Health Checks** in events/s
- * fails
+4.  **Health Checks** in events/s
+    -   fails
 
-<br>
+If Docker is running in in [Swarm mode](https://docs.docker.com/engine/swarm/) and the instance is a Swarm manager,
+Netdata will add additional charts:
 
-If docker in [swarm mode](https://docs.docker.com/engine/swarm/) and the instance is swarm manager additional charts will be added:
+1.  **Swarm Manager Leader** in bool
+    -   is_leader
 
-1. **Swarm Manager Leader** in bool
- * is_leader
-
-2. **Swarm Manager Object Store** in count
- * nodes
- * services
- * tasks
- * networks
- * secrets
- * configs
+2.  **Swarm Manager Object Store** in count
+    -   nodes
+    -   services
+    -   tasks
+    -   networks
+    -   secrets
+    -   configs
  
-3. **Swarm Manager Nodes Per State** in count
- * ready
- * down
- * unknown
- * disconnected
+3.  **Swarm Manager Nodes Per State** in count
+    -   ready
+    -   down
+    -   unknown
+    -   disconnected
  
-4. **Swarm Manager Tasks Per State** in count
- * running
- * failed
- * ready
- * rejected
- * starting
- * shutdown
- * new
- * orphaned
- * preparing
- * pending
- * complete
- * remove
- * accepted
- * assigned
+4.  **Swarm Manager Tasks Per State** in count
+    -   running
+    -   failed
+    -   ready
+    -   rejected
+    -   starting
+    -   shutdown
+    -   new
+    -   orphaned
+    -   preparing
+    -   pending
+    -   complete
+    -   remove
+    -   accepted
+    -   assigned
 
-### configuration
+## Configuration
 
-For all available options please see module [configuration file](https://github.com/netdata/go.d.plugin/blob/master/config/go.d/docker_engine.conf).
-___
+For all available options, please see the module's [configuration
+file](https://github.com/netdata/go.d.plugin/blob/master/config/go.d/docker_engine.conf).
 
 Needs only `url` to docker metric-address.
 
@@ -89,5 +88,3 @@ jobs:
 ```
 
 Without configuration, module attempts to connect to `http://127.0.0.1:9323/metrics`
-
----


### PR DESCRIPTION
As I've been working on the Learn site I began pulling all the `.md` files from this repo to build the site, much like what the current docs site does, but the Learn site's Markdown parser failed on these two files.

So, I've cleaned them up and even aligned them with the core repo's Markdown linter :stuck_out_tongue: 