### PR TITLE
coredns, kubelet fixes

### DIFF
--- a/config/go.d/coredns.conf
+++ b/config/go.d/coredns.conf
@@ -181,3 +181,4 @@
 # [ JOBS ]
 jobs:
   - url: http://127.0.0.1:9153/metrics
+  - url: http://kube-dns.kube-system.svc.cluster.local:9153/metrics

--- a/config/go.d/k8s_kubelet.conf
+++ b/config/go.d/k8s_kubelet.conf
@@ -155,3 +155,5 @@
 # [ JOBS ]
 jobs:
   - url: http://127.0.0.1:10255/metrics
+  - url: https://localhost:10250/metrics
+    tls_skip_verify: yes

--- a/modules/k8s_kubelet/testdata/token.txt
+++ b/modules/k8s_kubelet/testdata/token.txt
@@ -1,0 +1,1 @@
+8zU5Emm58tPGShVkwTK3ZLn0d4I

--- a/modules/rabbitmq/client.go
+++ b/modules/rabbitmq/client.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	overviewURLPath = "/api/overview"
-	nodeURLPath     = "/api/nodes"
+	nodeURLPath     = "/api/nodes/"
 	vhostsURLPath   = "/api/vhosts"
 )
 

--- a/modules/rabbitmq/rabbitmq_test.go
+++ b/modules/rabbitmq/rabbitmq_test.go
@@ -26,7 +26,7 @@ func newTestRabbitMQHTTPServer() *httptest.Server {
 					w.WriteHeader(404)
 				case "/api/overview":
 					_, _ = w.Write(testOverviewData)
-				case "/api/node/rabbit@rbt0":
+				case "/api/nodes/rabbit@rbt0":
 					_, _ = w.Write(testNodeData)
 				case "/api/vhosts":
 					_, _ = w.Write(testVhostsData)


### PR DESCRIPTION
Fixes: netdata/netdata#7188

This PR:
 - coredns: new job `http://kube-dns.kube-system.svc.cluster.local:9153/metrics`
 - kubelet: new job  `https://localhost:10250/metrics`
 - kubelet: reads `/var/run/secrets/kubernetes.io/serviceaccount/token` and uses bearer token authorization doing api calls.
 - rabbitmq: fix `/api/nodes` call