### PR TITLE
freeradius reject metrics decoding fix

### DIFF
--- a/modules/freeradius/freeradius.go
+++ b/modules/freeradius/freeradius.go
@@ -122,7 +122,7 @@ func decodeServerResponse(resp *radius.Packet) map[string]int64 {
 	return map[string]int64{
 		"access-requests":               int64(FreeRADIUSTotalAccessRequests_Get(resp)),
 		"access-accepts":                int64(FreeRADIUSTotalAccessAccepts_Get(resp)),
-		"access-rejects":                int64(FreeRADIUSTotalAccessRequests_Get(resp)),
+		"access-rejects":                int64(FreeRADIUSTotalAccessRejects_Get(resp)),
 		"access-challenges":             int64(FreeRADIUSTotalAccessChallenges_Get(resp)),
 		"auth-responses":                int64(FreeRADIUSTotalAuthResponses_Get(resp)),
 		"auth-duplicate-requests":       int64(FreeRADIUSTotalAuthDuplicateRequests_Get(resp)),
@@ -132,7 +132,7 @@ func decodeServerResponse(resp *radius.Packet) map[string]int64 {
 		"auth-unknown-types":            int64(FreeRADIUSTotalAuthUnknownTypes_Get(resp)),
 		"proxy-access-requests":         int64(FreeRADIUSTotalProxyAccessRequests_Get(resp)),
 		"proxy-access-accepts":          int64(FreeRADIUSTotalProxyAccessAccepts_Get(resp)),
-		"proxy-access-rejects":          int64(FreeRADIUSTotalProxyAccessRequests_Get(resp)),
+		"proxy-access-rejects":          int64(FreeRADIUSTotalProxyAccessRejects_Get(resp)),
 		"proxy-access-challenges":       int64(FreeRADIUSTotalProxyAccessChallenges_Get(resp)),
 		"proxy-auth-responses":          int64(FreeRADIUSTotalProxyAuthResponses_Get(resp)),
 		"proxy-auth-duplicate-requests": int64(FreeRADIUSTotalProxyAuthDuplicateRequests_Get(resp)),

--- a/modules/freeradius/freeradius_test.go
+++ b/modules/freeradius/freeradius_test.go
@@ -98,7 +98,7 @@ func (m mockOKRadiusServer) Exchange(ctx context.Context, packet *radius.Packet,
 
 	_ = FreeRADIUSTotalAccessRequests_Add(resp, 10)
 	_ = FreeRADIUSTotalAccessAccepts_Add(resp, 10)
-	_ = FreeRADIUSTotalAccessRequests_Add(resp, 10)
+	_ = FreeRADIUSTotalAccessRejects_Add(resp, 10)
 	_ = FreeRADIUSTotalAccessChallenges_Add(resp, 10)
 	_ = FreeRADIUSTotalAuthResponses_Add(resp, 10)
 	_ = FreeRADIUSTotalAuthDuplicateRequests_Add(resp, 10)
@@ -108,7 +108,7 @@ func (m mockOKRadiusServer) Exchange(ctx context.Context, packet *radius.Packet,
 	_ = FreeRADIUSTotalAuthUnknownTypes_Add(resp, 10)
 	_ = FreeRADIUSTotalProxyAccessRequests_Add(resp, 10)
 	_ = FreeRADIUSTotalProxyAccessAccepts_Add(resp, 10)
-	_ = FreeRADIUSTotalProxyAccessRequests_Add(resp, 10)
+	_ = FreeRADIUSTotalProxyAccessRejects_Add(resp, 10)
 	_ = FreeRADIUSTotalProxyAccessChallenges_Add(resp, 10)
 	_ = FreeRADIUSTotalProxyAuthResponses_Add(resp, 10)
 	_ = FreeRADIUSTotalProxyAuthDuplicateRequests_Add(resp, 10)


### PR DESCRIPTION
- Replace incorrect function calls for decoding 'access-rejects' and 'proxy-access-rejects'  #337 .