### PR TITLE
Fix broken link to documentation

### DIFF
--- a/modules/whoisquery/README.md
+++ b/modules/whoisquery/README.md
@@ -8,7 +8,7 @@ This collector produces the following chart:
 
 ## Configuration
 Edit the `go.d/whoisquery.conf` configuration file using `edit-config` from the your agent's [config
-directory](../../../../docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory


### PR DESCRIPTION
One-line fix to align the new whois collector with the rest of the links throughout the repo. This one is broken on the Learn site.