### PR TITLE
Add frontmatter to fix titles in docs site

### DIFF
--- a/modules/activemq/README.md
+++ b/modules/activemq/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "ActiveMQ monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/activemq/README.md
+sidebar_label: "ActiveMQ"
+-->
+
 # ActiveMQ monitoring with Netdata
 
 [`ActiveMQ`](https://activemq.apache.org/) is an open source message broker written in Java together with a full Java Message Service client.

--- a/modules/apache/README.md
+++ b/modules/apache/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "Apache monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/apache/README.md
+sidebar_label: "Apache"
+-->
+
 # Apache monitoring with Netdata
 
 [`Apache`](https://httpd.apache.org/) is an open-source HTTP server for modern operating systems including UNIX and Windows.

--- a/modules/bind/README.md
+++ b/modules/bind/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "Bind9 monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/bind/README.md
+sidebar_label: "Bind9"
+-->
+
 # Bind9 monitoring with Netdata
 
 [`Bind9`](https://www.isc.org/bind/) (or named) is a very flexible, full-featured DNS system. 

--- a/modules/cockroachdb/README.md
+++ b/modules/cockroachdb/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "CockroachDB monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/cockroachdb/README.md
+sidebar_label: "CockroachDB"
+-->
+
 # CockroachDB monitoring with Netdata
 
 [`CockroachDB`](https://www.cockroachlabs.com/)  is the SQL database for building global, scalable cloud services that survive disasters.

--- a/modules/consul/README.md
+++ b/modules/consul/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "Consul monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/consul/README.md
+sidebar_label: "Consul"
+-->
+
 # Consul monitoring with Netdata
 
 [`Consul`](https://www.consul.io/) is a service networking solution to connect and secure services across any runtime platform and public or private cloud.

--- a/modules/coredns/README.md
+++ b/modules/coredns/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "CoreDNS monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/coredns/README.md
+sidebar_label: "CoreDNS"
+-->
+
 # CoreDNS monitoring with Netdata
 
 [`CoreDNS`](https://coredns.io/) is a fast and flexible DNS server.

--- a/modules/dnsmasq_dhcp/README.md
+++ b/modules/dnsmasq_dhcp/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "Dnsmasq DHCP monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/dnsmasq_dhcp/README.md
+sidebar_label: "Dnsmasq DHCP"
+-->
+
 # Dnsmasq DHCP monitoring with Netdata
 
 [`Dnsmasq`](http://www.thekelleys.org.uk/dnsmasq/doc.html) is a lightweight, easy to configure, DNS forwarder and DHCP server.

--- a/modules/dnsquery/README.md
+++ b/modules/dnsquery/README.md
@@ -1,4 +1,10 @@
-# DNS queries monitoring with Netdata
+<!--
+title: "DNS query monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/dnsquery/README.md
+sidebar_label: "DNS queries"
+-->
+
+# DNS query monitoring with Netdata
 
 This module provides DNS query RTT in milliseconds.
 

--- a/modules/docker_engine/README.md
+++ b/modules/docker_engine/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "Docker Engine monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/docker_engine/README.md
+sidebar_label: "Docker Engine"
+-->
+
 # Docker Engine monitoring with Netdata
 
 [`Docker Engine`](https://docs.docker.com/engine/) is the industry’s de facto container runtime that runs on various Linux (CentOS, Debian, Fedora, Oracle Linux, RHEL, SUSE, and Ubuntu) and Windows Server operating systems.

--- a/modules/dockerhub/README.md
+++ b/modules/dockerhub/README.md
@@ -1,4 +1,10 @@
-# Docker Hub repositories monitoring with Netdata
+<!--
+title: "Docker Hub repository monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/dockerhub/README.md
+sidebar_label: "Docker Hub repositories"
+-->
+
+# Docker Hub repository monitoring with Netdata
 
 [`Docker Hub`](https://docs.docker.com/docker-hub/) is a service provided by Docker for finding and sharing container images with your team.
  

--- a/modules/fluentd/README.md
+++ b/modules/fluentd/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "Fluentd monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/fluentd/README.md
+sidebar_label: "Fluentd"
+-->
+
 # Fluentd monitoring with Netdata
 
 [`Fluentd`](https://www.fluentd.org/) is an open source data collector for unified logging layer.

--- a/modules/freeradius/README.md
+++ b/modules/freeradius/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "FreeRADIUS monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/freeradius/README.md
+sidebar_label: "FreeRADIUS"
+-->
+
 # FreeRADIUS monitoring with Netdata
 
 [`FreeRADIUS`](https://freeradius.org/) is a modular, high performance free RADIUS suite.

--- a/modules/hdfs/README.md
+++ b/modules/hdfs/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "HDFS monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/hdfs/README.md
+sidebar_label: "HDFS monitoring with Netdata"
+-->
+
 # HDFS monitoring with Netdata
 
 The [`Hadoop Distributed File System (HDFS)`](https://hadoop.apache.org/docs/r1.2.1/hdfs_design.html) is a distributed file system designed to run on commodity hardware.

--- a/modules/hdfs/README.md
+++ b/modules/hdfs/README.md
@@ -1,7 +1,7 @@
 <!--
 title: "HDFS monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/hdfs/README.md
-sidebar_label: "HDFS monitoring with Netdata"
+sidebar_label: "HDFS"
 -->
 
 # HDFS monitoring with Netdata

--- a/modules/httpcheck/README.md
+++ b/modules/httpcheck/README.md
@@ -1,4 +1,10 @@
-# Any HTTP endpoints monitoring with Netdata
+<!--
+title: "HTTP endpoint monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/httpcheck/README.md
+sidebar_label: "HTTP endpoints"
+-->
+
+# HTTP endpoint monitoring with Netdata
 
 This module monitors one or more http servers availability and response time.
 

--- a/modules/k8s_kubelet/README.md
+++ b/modules/k8s_kubelet/README.md
@@ -1,4 +1,10 @@
-# K8S Kubelet monitoring with Netdata
+<!--
+title: "Kubelet monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/k8s_kubelet/README.md
+sidebar_label: "Kubelet"
+-->
+
+# Kubelet monitoring with Netdata
 
 [`Kubelet`](https://kubernetes.io/docs/concepts/overview/components/#kubelet) is an agent that runs on each node in the cluster. It makes sure that containers are running in a pod.
 

--- a/modules/k8s_kubeproxy/README.md
+++ b/modules/k8s_kubeproxy/README.md
@@ -1,4 +1,10 @@
-# K8S Kube-proxy monitoring with Netdata
+<!--
+title: "kube-proxy monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/k8s_kubeproxy/README.md
+sidebar_label: "kube-proxy"
+-->
+
+# kube-proxy monitoring with Netdata
 
 [`Kube-proxy`](https://kubernetes.io/docs/concepts/overview/components/#kube-proxy) is a network proxy that runs on each each node in your cluster, implementing part of the Kubernetes Service.
 

--- a/modules/lighttpd/README.md
+++ b/modules/lighttpd/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "Lighttpd monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/lighttpd/README.md
+sidebar_label: "Lighttpd"
+-->
+
 # Lighttpd monitoring with Netdata
 
 [`Lighttpd`](https://www.lighttpd.net/) is an open-source web server optimized for speed-critical environments while remaining standards-compliant, secure and flexible

--- a/modules/lighttpd2/README.md
+++ b/modules/lighttpd2/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "Lighttpd2 monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/lighttpd2/README.md
+sidebar_label: "Lighttpd2"
+-->
+
 # Lighttpd2 monitoring with Netdata
 
 [`Lighttpd2`](https://redmine.lighttpd.net/projects/lighttpd2) is a work in progress version of open-source web server.

--- a/modules/logstash/README.md
+++ b/modules/logstash/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "Logstash monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/logstash/README.md
+sidebar_label: "Logstash"
+-->
+
 # Logstash monitoring with Netdata
 
 [`Logstash`](https://www.elastic.co/products/logstash) is an open-source data processing pipeline that allows you to collect, process, and load data into `Elasticsearch`.

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "MySQL monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/mysql/README.md
+sidebar_label: "MySQL"
+-->
+
 # MySQL monitoring with Netdata
 
 [`MySQL`](https://www.mysql.com/) is an open-source relational database management system.

--- a/modules/nginx/README.md
+++ b/modules/nginx/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "NGINX monitoring"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/nginx/README.md
+sidebar_label: "NGINX"
+-->
+
 # NGINX monitoring with Netdata
 
 [`NGINX`](https://www.nginx.com/) is a web server which can also be used as a reverse proxy, load balancer, mail proxy and HTTP cache. 

--- a/modules/openvpn/README.md
+++ b/modules/openvpn/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "OpenVPN monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/openvpn/README.md
+sidebar_label: "OpenVPN"
+-->
+
 # OpenVPN monitoring with Netdata
 
 [`OpenVPN`](https://openvpn.net/) is an open-source commercial software that implements virtual private network techniques to create secure point-to-point or site-to-site connections in routed or bridged configurations and remote access facilities.

--- a/modules/phpdaemon/README.md
+++ b/modules/phpdaemon/README.md
@@ -1,6 +1,12 @@
-# Phpdaemon monitoring with Netdata
+<!--
+title: "phpDaemon monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/phpdaemon/README.md
+sidebar_label: "phpDaemon"
+-->
 
-[`phpdaemon`](https://github.com/kakserpom/phpdaemon) is an asynchronous server-side framework for Web and network applications implemented in PHP using libevent.
+# phpDaemon monitoring with Netdata
+
+[`phpDaemon`](https://github.com/kakserpom/phpdaemon) is an asynchronous server-side framework for Web and network applications implemented in PHP using libevent.
 
 This module collects `phpdaemon` workers statistics via http.
 

--- a/modules/phpfpm/README.md
+++ b/modules/phpfpm/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "PHP-FPM monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/phpfpm/README.md
+sidebar_label: "PHP-FPM"
+-->
+
 # PHP-FPM monitoring with Netdata
 
 [`PHP-FPM`](https://php-fpm.org/) is an alternative PHP FastCGI implementation with some additional features useful for sites of any size, especially busier sites.

--- a/modules/pihole/README.md
+++ b/modules/pihole/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "Pi-hole monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/pihole/README.md
+sidebar_label: "Pi-hole"
+-->
+
 # Pi-hole monitoring with Netdata
 
 [`Pi-hole`](https://pi-hole.net) is a Linux network-level advertisement and Internet tracker blocking application which acts as a DNS sinkhole, intended for use on a private network.

--- a/modules/portcheck/README.md
+++ b/modules/portcheck/README.md
@@ -1,4 +1,10 @@
-# Any TCP endpoint monitoring with Netdata
+<!--
+title: "TCP endpoint monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/portcheck/README.md
+sidebar_label: "TCP endpoints"
+-->
+
+# TCP endpoint monitoring with Netdata
 
 This module will monitors one or more TCP services availability and response time.
 

--- a/modules/pulsar/README.md
+++ b/modules/pulsar/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "Apache Pulsar monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/pulsar/README.md
+sidebar_label: "Apache Pulsar"
+-->
+
 # Apache Pulsar monitoring with Netdata
 
 [`Apache Pulsar`](http://pulsar.apache.org/) is an open-source distributed pub-sub messaging system.

--- a/modules/pulsar/README.md
+++ b/modules/pulsar/README.md
@@ -1,7 +1,7 @@
 <!--
 title: "Apache Pulsar monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/pulsar/README.md
-sidebar_label: "Apache Pulsar"
+sidebar_label: "Pulsar"
 -->
 
 # Apache Pulsar monitoring with Netdata

--- a/modules/rabbitmq/README.md
+++ b/modules/rabbitmq/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "RabbitMQ monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/rabbitmq/README.md
+sidebar_label: "RabbitMQ monitoring with Netdata"
+-->
+
 # RabbitMQ monitoring with Netdata
 
 [`RabbitMQ`](https://www.rabbitmq.com/) is the open source message broker.

--- a/modules/rabbitmq/README.md
+++ b/modules/rabbitmq/README.md
@@ -1,7 +1,7 @@
 <!--
 title: "RabbitMQ monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/rabbitmq/README.md
-sidebar_label: "RabbitMQ monitoring with Netdata"
+sidebar_label: "RabbitMQ"
 -->
 
 # RabbitMQ monitoring with Netdata

--- a/modules/scaleio/README.md
+++ b/modules/scaleio/README.md
@@ -1,7 +1,7 @@
 <!--
 title: "ScaleIO monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/scaleio/README.md
-sidebar_label: "scaleio"
+sidebar_label: "ScaleIO"
 -->
 
 # ScaleIO monitoring with Netdata

--- a/modules/scaleio/README.md
+++ b/modules/scaleio/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "ScaleIO monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/scaleio/README.md
+sidebar_label: "scaleio"
+-->
+
 # ScaleIO monitoring with Netdata
 
 [`Dell EMC ScaleIO`](https://www.dellemc.com/en-us/storage/data-storage/software-defined-storage.htm) is a software-defined storage product from Dell EMC that creates a server-based storage area network from local application server storage using existing customer hardware or EMC servers.

--- a/modules/solr/README.md
+++ b/modules/solr/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "Solr monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/solr/README.md
+sidebar_label: "Solr"
+-->
+
 # Solr monitoring with Netdata
 
 [`Solr`](https://lucene.apache.org/solr/) is an open-source enterprise-search platform, written in Java, from the Apache Lucene project.

--- a/modules/springboot2/README.md
+++ b/modules/springboot2/README.md
@@ -1,4 +1,10 @@
-# Any Spring Boot 2 application monitoring with Netdata
+<!--
+title: "Java Spring Boot 2 application monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/springboot2/README.md
+sidebar_label: "Java Spring Boot 2 applications"
+-->
+
+# Java Spring Boot 2 application monitoring with Netdata
 
 This module monitors one or more Java Spring-boot 2 applications depending on configuration.
 Netdata can be used to monitor running Java [Spring Boot 2](https://spring.io/) applications that expose their metrics with the use of the **Spring Boot Actuator** included in Spring Boot library.

--- a/modules/squidlog/README.md
+++ b/modules/squidlog/README.md
@@ -1,4 +1,10 @@
-# Squid logs monitoring with Netdata
+<!--
+title: "Web server log (Squid) monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/squidlog/README.md
+sidebar_label: "Web server logs (Squid)"
+-->
+
+# Squid log monitoring with Netdata
 
 [`Squid`](http://www.squid-cache.org/) is a caching and forwarding HTTP web proxy.
 

--- a/modules/tengine/README.md
+++ b/modules/tengine/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "Tengine monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/tengine/README.md
+sidebar_label: "Tengine"
+-->
+
 # Tengine monitoring with Netdata
 
 [`Tengine`](https://tengine.taobao.org/) is a web server originated by Taobao, the largest e-commerce website in Asia. It is based on the Nginx HTTP server and has many advanced features.

--- a/modules/unbound/README.md
+++ b/modules/unbound/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "Unbound monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/unbound/README.md
+sidebar_label: "Unbound"
+-->
+
 # Unbound monitoring with Netdata
 
 [`Unbound`](https://nlnetlabs.nl/projects/unbound/about/) is a validating, recursive, and caching DNS resolver product from NLnet Labs.

--- a/modules/vcsa/README.md
+++ b/modules/vcsa/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "vCenter Server Appliance monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/vsca/README.md
+sidebar_label: "vCenter Server Appliance"
+-->
+
 # vCenter Server Appliance monitoring with Netdata
 
 The [`vCenter Server Appliance`](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcsa.doc/GUID-223C2821-BD98-4C7A-936B-7DBE96291BA4.html) using [`Health API`](https://code.vmware.com/apis/60/vcenter-server-appliance-management) is a preconfigured Linux virtual machine, which is optimized for running VMware vCenter Server® and the associated services on Linux.

--- a/modules/vernemq/README.md
+++ b/modules/vernemq/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "VerneMQ monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/vernemq/README.md
+sidebar_label: "VerneMQ"
+-->
+
 # VerneMQ monitoring with Netdata
 
 [`VerneMQ`](https://vernemq.com/) is a scalable and open source MQTT broker that connects IoT, M2M, Mobile, and web applications.

--- a/modules/vsphere/README.md
+++ b/modules/vsphere/README.md
@@ -1,4 +1,10 @@
-# VMware vCenter Server (vSphere) monitoring with Netdata
+<!--
+title: "vCenter Server monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/vsphere/README.md
+sidebar_label: "vCenter Servers"
+-->
+
+# vCenter Server monitoring with Netdata
 
 [`VMware vCenter Server`](https://www.vmware.com/products/vcenter-server.html) is advanced server management software that provides a centralized platform for controlling your VMware vSphere environments.
 

--- a/modules/weblog/README.md
+++ b/modules/weblog/README.md
@@ -1,4 +1,10 @@
-# Apache/NGINX logs monitoring with Netdata
+<!--
+title: "Web server log (Apache, NGINX) monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/weblog/README.md
+sidebar_label: "Web server logs (Apache, NGINX)"
+-->
+
+# Web log (Apache, NGINX) monitoring with Netdata
 
 This module parses [`Apache`](https://httpd.apache.org/) and [`NGINX`](https://nginx.org/en/) web servers logs.
 

--- a/modules/whoisquery/README.md
+++ b/modules/whoisquery/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "Whois domain expiry monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/whoisquery/README.md
+sidebar_label: "Whois domain expiry"
+-->
+
 # Whois domain expiry monitoring with Netdata
 
 This collector module checks the remaining time until a domain is expired.

--- a/modules/wmi/README.md
+++ b/modules/wmi/README.md
@@ -1,4 +1,10 @@
-# Windows Machines monitoring with Netdata
+<!--
+title: "Windows machine monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/wmi/README.md
+sidebar_label: "Windows machines"
+-->
+
+# Windows machine monitoring with Netdata
 
 This module will monitor one or more Windows machines, using the [wmi_exporter](https://github.com/martinlindhe/wmi_exporter).
 

--- a/modules/x509check/README.md
+++ b/modules/x509check/README.md
@@ -1,4 +1,10 @@
-# x509 certificates monitoring with Netdata
+<!--
+title: "x509 certificate monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/x509check/README.md
+sidebar_label: "x509 certificates"
+-->
+
+# x509 certificate monitoring with Netdata
 
 This module checks the time until a x509 certificate expiration and its revocation status.
 

--- a/modules/zookeeper/README.md
+++ b/modules/zookeeper/README.md
@@ -1,10 +1,10 @@
 <!--
-title: "ZooKeeper monitoring with Netdata"
+title: "Apache ZooKeeper monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/zookeeper/README.md
 sidebar_label: "ZooKeeper"
 -->
 
-# ZooKeeper monitoring with Netdata
+# Apache ZooKeeper monitoring with Netdata
 
 [`ZooKeeper`](https://zookeeper.apache.org/) is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services. 
 

--- a/modules/zookeeper/README.md
+++ b/modules/zookeeper/README.md
@@ -1,3 +1,9 @@
+<!--
+title: "ZooKeeper monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/zookeeper/README.md
+sidebar_label: "ZooKeeper"
+-->
+
 # ZooKeeper monitoring with Netdata
 
 [`ZooKeeper`](https://zookeeper.apache.org/) is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services. 


### PR DESCRIPTION
Connected to netdata/netdata-learn-docusaurus#108 and netdata/netdata#8936. This should be merged first, then 8936, and then 108.

This PR adds frontmatter to all the README files so that they show the correct title in the navigation and on individual pages in the docs. I've also changed their names in the sidebar to reflect the service/app being monitored, not the module's name.