### PR TITLE
bump go-orch: fix adjust min update every

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/likexian/whois-go v1.7.1
 	github.com/likexian/whois-parser-go v1.14.5
 	github.com/miekg/dns v1.1.29
-	github.com/netdata/go-orchestrator v0.0.0-20200608113243-b833425a78d7
+	github.com/netdata/go-orchestrator v0.0.0-20200608224039-8f1e1f11e819
 	github.com/prometheus/common v0.10.0 // indirect
 	github.com/prometheus/prometheus v2.5.0+incompatible
 	github.com/stretchr/testify v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/mreiferson/go-httpclient v0.0.0-20160630210159-31f0106b4474/go.mod h1
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/netdata/go-orchestrator v0.0.0-20200608113243-b833425a78d7 h1:wlupx4p8b26FfVKnC26nPKfXA4XKI06AqwV5UmaytsU=
 github.com/netdata/go-orchestrator v0.0.0-20200608113243-b833425a78d7/go.mod h1:RqCYHCESfeQCIP9jl/0mFMDpqt9WLbVXoUDydFmT39M=
+github.com/netdata/go-orchestrator v0.0.0-20200608224039-8f1e1f11e819 h1:iAAZtgD3Km198ADLhBiu46u1/0ggRQDwwrDLngD1An0=
+github.com/netdata/go-orchestrator v0.0.0-20200608224039-8f1e1f11e819/go.mod h1:RqCYHCESfeQCIP9jl/0mFMDpqt9WLbVXoUDydFmT39M=
 github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYXnNPJ8l7uZxf45rWW1a/uME32OF0rhiYGNQ2oF2E=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
really need to consider moving orchestrator back to this repo 🤣 

bugfix: https://github.com/netdata/go-orchestrator/pull/43