### PR TITLE
pulsar: disable topic chart by default

### DIFF
--- a/modules/pulsar/README.md
+++ b/modules/pulsar/README.md
@@ -67,7 +67,8 @@ If replication is configured and `replicationMetricsEnabled` is set to true:
 
 ### Topic
 
-Topic charts are only available when `exposeTopicLevelMetricsInPrometheus` is set to true.
+Topic charts are only available when `exposeTopicLevelMetricsInPrometheus` is set to true. In addition, you need 
+to set `topic_filer` configuration option. If you have a lot of topics this is highly unrecommended.
 
 -   Producers in `producers`
 -   Subscriptions in `producers`

--- a/modules/pulsar/pulsar.go
+++ b/modules/pulsar/pulsar.go
@@ -30,6 +30,10 @@ func New() *Pulsar {
 			},
 			Client: web.Client{Timeout: web.Duration{Duration: time.Second}},
 		},
+		TopicFiler: matcher.SimpleExpr{
+			Includes: nil,
+			Excludes: []string{"*"},
+		},
 	}
 	return &Pulsar{
 		Config:             config,


### PR DESCRIPTION
TODO: it is impossible to chart if there are a lot of subscriptions/topics (chart are kind of broken). I guess we need to remove it this option and show only summary chart.