### PR TITLE
Enable disabled modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ If you have time and willing to help, there are a lof of ways to contribute:
 | [phpfpm](https://github.com/netdata/go.d.plugin/tree/master/modules/phpfpm)               | `PHP-FPM`                  | yes     |
 | [pihole](https://github.com/netdata/go.d.plugin/tree/master/modules/pihole)               | `Pi-hole`                  |         |
 | [portcheck](https://github.com/netdata/go.d.plugin/tree/master/modules/portcheck)         | `Any TCP Endpoint`         |         |
+| [prometheus](https://github.com/netdata/go.d.plugin/tree/master/modules/prometheus)       | `Any Prometheus Endpoint`  |         |
 | [pulsar](https://github.com/netdata/go.d.plugin/tree/master/modules/portcheck)            | `Apache Pulsar`            |         |
 | [rabbitmq](https://github.com/netdata/go.d.plugin/tree/master/modules/rabbitmq)           | `RabbitMQ`                 | yes     |
 | [scaleio](https://github.com/netdata/go.d.plugin/tree/master/modules/scaleio)             | `Dell EMC ScaleIO`         |         |
@@ -65,7 +66,7 @@ If you have time and willing to help, there are a lof of ways to contribute:
 | [vernemq](https://github.com/netdata/go.d.plugin/tree/master/modules/vernemq)             | `VerneMQ`                  |         | 
 | [vsphere](https://github.com/netdata/go.d.plugin/tree/master/modules/vsphere)             | `VMware vCenter Server`    |         |
 | [web_log](https://github.com/netdata/go.d.plugin/tree/master/modules/weblog)              | `Apache/NGINX`             | yes     |
-| [whoisquery](https://github.com/netdata/go.d.plugin/tree/master/modules/whoisquery)              | `Domain Expiry`             | yes     |
+| [whoisquery](https://github.com/netdata/go.d.plugin/tree/master/modules/whoisquery)       | `Domain Expiry`            | yes     |
 | [wmi](https://github.com/netdata/go.d.plugin/tree/master/modules/wmi)                     | `Windows Machines`         |         |
 | [x509check](https://github.com/netdata/go.d.plugin/tree/master/modules/x509check)         | `Digital Certificates`     |         |
 | [zookeeper](https://github.com/netdata/go.d.plugin/tree/master/modules/zookeeper)         | `ZooKeeper`                |         |

--- a/README.md
+++ b/README.md
@@ -24,71 +24,52 @@ If you have time and willing to help, there are a lof of ways to contribute:
 
 ## Available modules
 
-| Name                                                                                      | Monitors                   | Disabled|
-| :---------------------------------------------------------------------------------------- | :------------------------- | :-------|
-| [activemq](https://github.com/netdata/go.d.plugin/tree/master/modules/activemq)           | `ActiveMQ`                 |         |
-| [apache](https://github.com/netdata/go.d.plugin/tree/master/modules/apache)               | `Apache`                   | yes     |
-| [bind](https://github.com/netdata/go.d.plugin/tree/master/modules/bind)                   | `ISC Bind`                 | yes     |
-| [cockroachdb](https://github.com/netdata/go.d.plugin/tree/master/modules/cockroachdb)     | `CockroachDB`              |         | 
-| [consul](https://github.com/netdata/go.d.plugin/tree/master/modules/consul)               | `Consul`                   |         |
-| [coredns](https://github.com/netdata/go.d.plugin/tree/master/modules/coredns)             | `CoreDNS`                  |         |
-| [dnsmasq_dhcp](https://github.com/netdata/go.d.plugin/tree/master/modules/dnsmasq_dhcp)   | `Dnsmasq`                  |         |
-| [dns_query](https://github.com/netdata/go.d.plugin/tree/master/modules/dnsquery)          | `DNS Query RTT`            |         |
-| [docker_engine](https://github.com/netdata/go.d.plugin/tree/master/modules/docker_engine) | `Docker Engine`            |         |
-| [dockerhub](https://github.com/netdata/go.d.plugin/tree/master/modules/dockerhub)         | `Docker Hub`               |         |
-| [example](https://github.com/netdata/go.d.plugin/tree/master/modules/example)             | -                          | yes     | 
-| [fluentd](https://github.com/netdata/go.d.plugin/tree/master/modules/fluentd)             | `Fluentd`                  |         |
-| [freeradius](https://github.com/netdata/go.d.plugin/tree/master/modules/freeradius)       | `FreeRADIUS`               | yes     |
-| [hdfs](https://github.com/netdata/go.d.plugin/tree/master/modules/hdfs)                   | `HDFS`                     |         |
-| [httpcheck](https://github.com/netdata/go.d.plugin/tree/master/modules/httpcheck)         | `Any HTTP Endpoint`        |         |
-| [k8s_kubelet](https://github.com/netdata/go.d.plugin/tree/master/modules/k8s_kubelet)     | `Kubelet`                  |         |
-| [k8s_kubeproxy](https://github.com/netdata/go.d.plugin/tree/master/modules/k8s_kubeproxy) | `Kube-proxy`               |         |
-| [lighttpd](https://github.com/netdata/go.d.plugin/tree/master/modules/lighttpd)           | `Lighttpd`                 | yes     |
-| [lighttpd2](https://github.com/netdata/go.d.plugin/tree/master/modules/lighttpd2)         | `Lighttpd2`                |         |
-| [logstash](https://github.com/netdata/go.d.plugin/tree/master/modules/logstash)           | `Logstash`                 |         |
-| [mysql](https://github.com/netdata/go.d.plugin/tree/master/modules/mysql)                 | `MySQL`                    | yes     |
-| [nginx](https://github.com/netdata/go.d.plugin/tree/master/modules/nginx)                 | `NGINX`                    | yes     |
-| [openvpn](https://github.com/netdata/go.d.plugin/tree/master/modules/openvpn)             | `OpenVPN`                  | yes     |
-| [phpdaemon](https://github.com/netdata/go.d.plugin/tree/master/modules/phpdaemon)         | `phpDaemon`                |         |
-| [phpfpm](https://github.com/netdata/go.d.plugin/tree/master/modules/phpfpm)               | `PHP-FPM`                  | yes     |
-| [pihole](https://github.com/netdata/go.d.plugin/tree/master/modules/pihole)               | `Pi-hole`                  |         |
-| [portcheck](https://github.com/netdata/go.d.plugin/tree/master/modules/portcheck)         | `Any TCP Endpoint`         |         |
-| [prometheus](https://github.com/netdata/go.d.plugin/tree/master/modules/prometheus)       | `Any Prometheus Endpoint`  |         |
-| [pulsar](https://github.com/netdata/go.d.plugin/tree/master/modules/portcheck)            | `Apache Pulsar`            |         |
-| [rabbitmq](https://github.com/netdata/go.d.plugin/tree/master/modules/rabbitmq)           | `RabbitMQ`                 | yes     |
-| [scaleio](https://github.com/netdata/go.d.plugin/tree/master/modules/scaleio)             | `Dell EMC ScaleIO`         |         |
-| [solr](https://github.com/netdata/go.d.plugin/tree/master/modules/solr)                   | `Solr`                     |         |
-| [squidlog](https://github.com/netdata/go.d.plugin/tree/master/modules/squidlog)           | `Squid`                    | yes     |
-| [springboot2](https://github.com/netdata/go.d.plugin/tree/master/modules/springboot2)     | `Spring Boot2`             |         |
-| [tengine](https://github.com/netdata/go.d.plugin/tree/master/modules/tengine)             | `Tengine`                  |         |
-| [unbound](https://github.com/netdata/go.d.plugin/tree/master/modules/unbound)             | `Unbound`                  |         |
-| [vcsa](https://github.com/netdata/go.d.plugin/tree/master/modules/vcsa)                   | `vCenter Server Appliance` |         |
-| [vernemq](https://github.com/netdata/go.d.plugin/tree/master/modules/vernemq)             | `VerneMQ`                  |         | 
-| [vsphere](https://github.com/netdata/go.d.plugin/tree/master/modules/vsphere)             | `VMware vCenter Server`    |         |
-| [web_log](https://github.com/netdata/go.d.plugin/tree/master/modules/weblog)              | `Apache/NGINX`             | yes     |
-| [whoisquery](https://github.com/netdata/go.d.plugin/tree/master/modules/whoisquery)       | `Domain Expiry`            | yes     |
-| [wmi](https://github.com/netdata/go.d.plugin/tree/master/modules/wmi)                     | `Windows Machines`         |         |
-| [x509check](https://github.com/netdata/go.d.plugin/tree/master/modules/x509check)         | `Digital Certificates`     |         |
-| [zookeeper](https://github.com/netdata/go.d.plugin/tree/master/modules/zookeeper)         | `ZooKeeper`                |         |
-
-## Why disabled? How to enable?
-
-We are in process of migrating collectors from `python` to `go`.
-
-Configurations are incompatible. All rewritten in `go` modules are disabled by default.
-This is a temporary solution, we are working on it.
-
-To enable module please do the following:
-
--   explicitly disable python module in `python.d.conf`
--   explicitly enable go module in `go.d.conf`
--   move python module jobs to go module configuration file (change syntax, see go module configuration file for details).
--   restart `netdata.service`
-
-If case of problems:
-
--   check `error.log` for module related errors (`grep <module name> error.log`)
--   run plugin in [debug mode](#troubleshooting)
+| Name                                                                                      | Monitors                   |
+| :---------------------------------------------------------------------------------------- | :------------------------- |
+| [activemq](https://github.com/netdata/go.d.plugin/tree/master/modules/activemq)           | `ActiveMQ`                 |
+| [apache](https://github.com/netdata/go.d.plugin/tree/master/modules/apache)               | `Apache`                   |
+| [bind](https://github.com/netdata/go.d.plugin/tree/master/modules/bind)                   | `ISC Bind`                 |
+| [cockroachdb](https://github.com/netdata/go.d.plugin/tree/master/modules/cockroachdb)     | `CockroachDB`              | 
+| [consul](https://github.com/netdata/go.d.plugin/tree/master/modules/consul)               | `Consul`                   |
+| [coredns](https://github.com/netdata/go.d.plugin/tree/master/modules/coredns)             | `CoreDNS`                  |
+| [dnsmasq_dhcp](https://github.com/netdata/go.d.plugin/tree/master/modules/dnsmasq_dhcp)   | `Dnsmasq`                  |
+| [dns_query](https://github.com/netdata/go.d.plugin/tree/master/modules/dnsquery)          | `DNS Query RTT`            |
+| [docker_engine](https://github.com/netdata/go.d.plugin/tree/master/modules/docker_engine) | `Docker Engine`            |
+| [dockerhub](https://github.com/netdata/go.d.plugin/tree/master/modules/dockerhub)         | `Docker Hub`               |
+| [example](https://github.com/netdata/go.d.plugin/tree/master/modules/example)             | -                          | 
+| [fluentd](https://github.com/netdata/go.d.plugin/tree/master/modules/fluentd)             | `Fluentd`                  |
+| [freeradius](https://github.com/netdata/go.d.plugin/tree/master/modules/freeradius)       | `FreeRADIUS`               |
+| [hdfs](https://github.com/netdata/go.d.plugin/tree/master/modules/hdfs)                   | `HDFS`                     |
+| [httpcheck](https://github.com/netdata/go.d.plugin/tree/master/modules/httpcheck)         | `Any HTTP Endpoint`        |
+| [k8s_kubelet](https://github.com/netdata/go.d.plugin/tree/master/modules/k8s_kubelet)     | `Kubelet`                  |
+| [k8s_kubeproxy](https://github.com/netdata/go.d.plugin/tree/master/modules/k8s_kubeproxy) | `Kube-proxy`               |
+| [lighttpd](https://github.com/netdata/go.d.plugin/tree/master/modules/lighttpd)           | `Lighttpd`                 |
+| [lighttpd2](https://github.com/netdata/go.d.plugin/tree/master/modules/lighttpd2)         | `Lighttpd2`                |
+| [logstash](https://github.com/netdata/go.d.plugin/tree/master/modules/logstash)           | `Logstash`                 |
+| [mysql](https://github.com/netdata/go.d.plugin/tree/master/modules/mysql)                 | `MySQL`                    |
+| [nginx](https://github.com/netdata/go.d.plugin/tree/master/modules/nginx)                 | `NGINX`                    |
+| [openvpn](https://github.com/netdata/go.d.plugin/tree/master/modules/openvpn)             | `OpenVPN`                  |
+| [phpdaemon](https://github.com/netdata/go.d.plugin/tree/master/modules/phpdaemon)         | `phpDaemon`                |
+| [phpfpm](https://github.com/netdata/go.d.plugin/tree/master/modules/phpfpm)               | `PHP-FPM`                  |
+| [pihole](https://github.com/netdata/go.d.plugin/tree/master/modules/pihole)               | `Pi-hole`                  |
+| [prometheus](https://github.com/netdata/go.d.plugin/tree/master/modules/prometheus)       | `Any Prometheus Endpoint`  |
+| [portcheck](https://github.com/netdata/go.d.plugin/tree/master/modules/portcheck)         | `Any TCP Endpoint`         |
+| [pulsar](https://github.com/netdata/go.d.plugin/tree/master/modules/portcheck)            | `Apache Pulsar`            |
+| [rabbitmq](https://github.com/netdata/go.d.plugin/tree/master/modules/rabbitmq)           | `RabbitMQ`                 |
+| [scaleio](https://github.com/netdata/go.d.plugin/tree/master/modules/scaleio)             | `Dell EMC ScaleIO`         |
+| [solr](https://github.com/netdata/go.d.plugin/tree/master/modules/solr)                   | `Solr`                     |
+| [squidlog](https://github.com/netdata/go.d.plugin/tree/master/modules/squidlog)           | `Squid`                    |
+| [springboot2](https://github.com/netdata/go.d.plugin/tree/master/modules/springboot2)     | `Spring Boot2`             |
+| [tengine](https://github.com/netdata/go.d.plugin/tree/master/modules/tengine)             | `Tengine`                  |
+| [unbound](https://github.com/netdata/go.d.plugin/tree/master/modules/unbound)             | `Unbound`                  |
+| [vcsa](https://github.com/netdata/go.d.plugin/tree/master/modules/vcsa)                   | `vCenter Server Appliance` |
+| [vernemq](https://github.com/netdata/go.d.plugin/tree/master/modules/vernemq)             | `VerneMQ`                  | 
+| [vsphere](https://github.com/netdata/go.d.plugin/tree/master/modules/vsphere)             | `VMware vCenter Server`    |
+| [web_log](https://github.com/netdata/go.d.plugin/tree/master/modules/weblog)              | `Apache/NGINX`             |
+| [whoisquery](https://github.com/netdata/go.d.plugin/tree/master/modules/whoisquery)       | `Domain Expiry`            |
+| [wmi](https://github.com/netdata/go.d.plugin/tree/master/modules/wmi)                     | `Windows Machines`         |
+| [x509check](https://github.com/netdata/go.d.plugin/tree/master/modules/x509check)         | `Digital Certificates`     |
+| [zookeeper](https://github.com/netdata/go.d.plugin/tree/master/modules/zookeeper)         | `ZooKeeper`                |
 
 ## Configuration
 
@@ -114,15 +95,17 @@ Plugin CLI:
 
 ```sh
 Usage:
-  go.d.plugin [OPTIONS] [update every]
+  orchestrator [OPTIONS] [update every]
 
 Application Options:
-  -d, --debug    debug mode
-  -m, --modules= modules name (default: all)
-  -c, --config=  config dir
+  -m, --modules=    module name to run (default: all)
+  -c, --config-dir= config dir to read
+  -w, --watch-path= config path to watch
+  -d, --debug       debug mode
+  -v, --version     display the version and exit
 
 Help Options:
-  -h, --help     Show this help message
+  -h, --help        Show this help message
 ```
 
 To debug specific module:

--- a/config/go.d.conf
+++ b/config/go.d.conf
@@ -42,6 +42,7 @@ modules:
 #  phpfpm: yes
 #  pihole: yes
 #  portcheck: yes
+#  prometheus: yes
 #  pulsar: yes
 #  rabbitmq: yes
 #  scaleio: yes

--- a/modules/apache/apache.go
+++ b/modules/apache/apache.go
@@ -10,9 +10,6 @@ import (
 
 func init() {
 	creator := module.Creator{
-		Defaults: module.Defaults{
-			Disabled: true,
-		},
 		Create: func() module.Module { return New() },
 	}
 

--- a/modules/bind/bind.go
+++ b/modules/bind/bind.go
@@ -13,9 +13,6 @@ import (
 
 func init() {
 	creator := module.Creator{
-		Defaults: module.Defaults{
-			Disabled: true,
-		},
 		Create: func() module.Module { return New() },
 	}
 

--- a/modules/freeradius/freeradius.go
+++ b/modules/freeradius/freeradius.go
@@ -12,9 +12,6 @@ import (
 
 func init() {
 	creator := module.Creator{
-		Defaults: module.Defaults{
-			Disabled: true,
-		},
 		Create: func() module.Module { return New() },
 	}
 

--- a/modules/lighttpd/lighttpd.go
+++ b/modules/lighttpd/lighttpd.go
@@ -10,9 +10,6 @@ import (
 
 func init() {
 	creator := module.Creator{
-		Defaults: module.Defaults{
-			Disabled: true,
-		},
 		Create: func() module.Module { return New() },
 	}
 

--- a/modules/mysql/mysql.go
+++ b/modules/mysql/mysql.go
@@ -12,9 +12,6 @@ import (
 
 func init() {
 	creator := module.Creator{
-		Defaults: module.Defaults{
-			Disabled: true,
-		},
 		Create: func() module.Module { return New() },
 	}
 	module.Register("mysql", creator)

--- a/modules/nginx/nginx.go
+++ b/modules/nginx/nginx.go
@@ -10,9 +10,6 @@ import (
 
 func init() {
 	creator := module.Creator{
-		Defaults: module.Defaults{
-			Disabled: true,
-		},
 		Create: func() module.Module { return New() },
 	}
 

--- a/modules/phpfpm/phpfpm.go
+++ b/modules/phpfpm/phpfpm.go
@@ -11,9 +11,6 @@ import (
 
 func init() {
 	creator := module.Creator{
-		Defaults: module.Defaults{
-			Disabled: true,
-		},
 		Create: func() module.Module { return New() },
 	}
 

--- a/modules/rabbitmq/rabbitmq.go
+++ b/modules/rabbitmq/rabbitmq.go
@@ -11,9 +11,6 @@ import (
 
 func init() {
 	creator := module.Creator{
-		Defaults: module.Defaults{
-			Disabled: true,
-		},
 		Create: func() module.Module { return New() },
 	}
 

--- a/modules/squidlog/squidlog.go
+++ b/modules/squidlog/squidlog.go
@@ -8,9 +8,6 @@ import (
 
 func init() {
 	creator := module.Creator{
-		Defaults: module.Defaults{
-			Disabled: true,
-		},
 		Create: func() module.Module { return New() },
 	}
 

--- a/modules/weblog/weblog.go
+++ b/modules/weblog/weblog.go
@@ -8,9 +8,6 @@ import (
 
 func init() {
 	creator := module.Creator{
-		Defaults: module.Defaults{
-			Disabled: true,
-		},
 		Create: func() module.Module { return New() },
 	}
 


### PR DESCRIPTION
File lock job registry was added
- python.d: https://github.com/netdata/netdata/pull/9564
- go.d: https://github.com/netdata/go-orchestrator/pull/45
- netdata daemon lock dir: https://github.com/netdata/netdata/pull/9584

It should be relatively safe to enable all rewritten in go python modules.