### PR TITLE
module/prometheus: add more jobs

### DIFF
--- a/config/go.d/prometheus.conf
+++ b/config/go.d/prometheus.conf
@@ -153,115 +153,1312 @@
 #
 # [ JOBS ]
 jobs:
-  # Databases
-  # https://prometheus.io/docs/instrumenting/exporters/#databases
-  - name: aerospike_exporter_local
-    url: 'http://127.0.0.1:9145/metrics'
-  - name: clickhouse_exporter_local
-    url: 'http://127.0.0.1:9363/metrics'
-  - name: consul_exporter_local
-    url: 'http://127.0.0.1:9107/metrics'
-  - name: couchbase_exporter_local
-    url: 'http://127.0.0.1:9420/metrics'
-  - name: couchdb_exporter_local
-    url: 'http://127.0.0.1:9984/metrics'
-  - name: elasticsearch_exporter_local
-    url: 'http://127.0.0.1:9114/metrics'
-  - name: eventstore_exporter_local
-    url: 'http://127.0.0.1:9448/metrics'
-  - name: memcached_exporter_local
-    url: 'http://127.0.0.1:9150/metrics'
-  - name: mysqld_exporter_local
-    url: 'http://127.0.0.1:9104/metrics'
-  - name: opentsdb_exporter_local
-    url: 'http://127.0.0.1:9250/metrics'
-  - name: oracledb_exporter_local
-    url: 'http://127.0.0.1:9161/metrics'
-  - name: pgbouncer_exporter_local
-    url: 'http://127.0.0.1:9127/metrics'
-  - name: postgresql_exporter_local
-    url: 'http://127.0.0.1:9187/metrics'
-  - name: proxysql_exporter_local
-    url: 'http://127.0.0.1:42004/metrics'
-  - name: ravendb_exporter_local
-    url: 'http://127.0.0.1:9440/metrics'
-  - name: redis_exporter_local
-    url: 'http://127.0.0.1:9121/metrics'
-  - name: rethinkdb_exporter_local
-    url: 'http://127.0.0.1:9123/metrics'
-  - name: sql_exporter_local
-    url: 'http://127.0.0.1:9237/metrics'
-
-  # Hardware related
-  # https://prometheus.io/docs/instrumenting/exporters/#hardware-related
+  # https://github.com/prometheus/prometheus/wiki/Default-port-allocations
   - name: node_exporter_local
-    url: 'http://127.0.0.1:9100/metrics'
-  - name: nvidia_gpu_exporter_local
-    url: 'http://127.0.0.1:9445/metrics'
-
-  # Messaging systems
-  # https://prometheus.io/docs/instrumenting/exporters/#messaging-systems
-  - name: emq_exporter_local
-    url: 'http://127.0.0.1:9540/metrics'
-  - name: gearman_exporter_local
-    url: 'http://127.0.0.1:9418/metrics'
-  - name: ibmmq_exporter_local
-    url: 'http://127.0.0.1:9157/metrics'
-  - name: kafka_exporter_local
-    url: 'http://127.0.0.1:9308/metrics'
-  - name: nats_exporter_local
-    url: 'http://127.0.0.1:9148/metrics'
-  - name: mirth_exporter_local
-    url: 'http://127.0.0.1:9140/metrics'
-  - name: mqtt_blackbox_exporter_local
-    url: 'http://127.0.0.1:9214/metrics'
-  - name: rabbitmq_exporter_local
-    url: 'http://127.0.0.1:9419/metrics'
-  - name: solace_exporter_local
-    url: 'http://127.0.0.1:9628/metrics'
-
-  # Storage
-  # https://prometheus.io/docs/instrumenting/exporters/#storage
-  - name: ceph_exporter_local
-    url: 'http://127.0.0.1:9128/metrics'
-  - name: ceph_radosgw_exporter_local
-    url: 'http://127.0.0.1:9242/metrics'
-  - name: glusterfs_exporter_local
-    url: 'http://127.0.0.1:9713/metrics'
-  - name: hadoop_hdfs_exporter_local
-    url: 'http://127.0.0.1:9709/metrics'
-  - name: lustre_exporter_local
-    url: 'http://127.0.0.1:9169/metrics'
-
-  # HTTP
-  # https://prometheus.io/docs/instrumenting/exporters/#http
-  - name: apache_exporter_local
-    url: 'http://127.0.0.1:9117/metrics'
+      url: 'http://127.0.0.1:9100/metrics'
   - name: haproxy_exporter_local
     url: 'http://127.0.0.1:9101/metrics'
-  - name: nginx_vts_exporter_local
-    url: 'http://127.0.0.1:9913/metrics'
-  - name: passenger_exporter_local
-    url: 'http://127.0.0.1:9149/metrics'
-  - name: squid_exporter_local
-    url: 'http://127.0.0.1:9301/metrics'
-  - name: tinyproxy_exporter_local
-    url: 'http://127.0.0.1:9240/metrics'
+  - name: statsd_exporter_local
+    url: 'http://127.0.0.1:9102/metrics'
+  - name: collectd_exporter_local
+    url: 'http://127.0.0.1:9103/metrics'
+  - name: mysqld_exporter_local
+    url: 'http://127.0.0.1:9104/metrics'
+  - name: mesos_exporter_local
+    url: 'http://127.0.0.1:9105/metrics'
+  - name: cloudwatch_exporter_local
+    url: 'http://127.0.0.1:9106/metrics'
+  - name: consul_exporter_local
+    url: 'http://127.0.0.1:9107/metrics'
+  - name: graphite_exporter_local
+    url: 'http://127.0.0.1:9108/metrics'
+  - name: graphite_exporter_local
+    url: 'http://127.0.0.1:9109/metrics'
+  - name: blackbox_exporter_local
+    url: 'http://127.0.0.1:9110/metrics'
+  - name: expvar_exporter_local
+    url: 'http://127.0.0.1:9111/metrics'
+  - name: promacct_pcap-based_network_traffic_accounting_local
+    url: 'http://127.0.0.1:9112/metrics'
+  - name: nginx_exporter_local
+    url: 'http://127.0.0.1:9113/metrics'
+  - name: elasticsearch_exporter_local
+    url: 'http://127.0.0.1:9114/metrics'
+  - name: blackbox_exporter_local
+    url: 'http://127.0.0.1:9115/metrics'
+  - name: snmp_exporter_local
+    url: 'http://127.0.0.1:9116/metrics'
+  - name: apache_exporter_local
+    url: 'http://127.0.0.1:9117/metrics'
+  - name: jenkins_exporter_local
+    url: 'http://127.0.0.1:9118/metrics'
+  - name: bind_exporter_local
+    url: 'http://127.0.0.1:9119/metrics'
+  - name: powerdns_exporter_local
+    url: 'http://127.0.0.1:9120/metrics'
+  - name: redis_exporter_local
+    url: 'http://127.0.0.1:9121/metrics'
+  - name: influxdb_exporter_local
+    url: 'http://127.0.0.1:9122/metrics'
+  - name: rethinkdb_exporter_local
+    url: 'http://127.0.0.1:9123/metrics'
+  - name: freebsd_sysctl_exporter_local
+    url: 'http://127.0.0.1:9124/metrics'
+  - name: statsd_exporter_local
+    url: 'http://127.0.0.1:9125/metrics'
+  - name: new_relic_exporter_local
+    url: 'http://127.0.0.1:9126/metrics'
+  - name: pgbouncer_exporter_local
+    url: 'http://127.0.0.1:9127/metrics'
+  - name: ceph_exporter_local
+    url: 'http://127.0.0.1:9128/metrics'
+  - name: haproxy_log_exporter_local
+    url: 'http://127.0.0.1:9129/metrics'
+  - name: unifi_poller_local
+    url: 'http://127.0.0.1:9130/metrics'
   - name: varnish_exporter_local
     url: 'http://127.0.0.1:9131/metrics'
+  - name: airflow_exporter_local
+    url: 'http://127.0.0.1:9132/metrics'
+  - name: fritz!box_exporter_local
+    url: 'http://127.0.0.1:9133/metrics'
+  - name: zfs_exporter_local
+    url: 'http://127.0.0.1:9134/metrics'
+  - name: rtorrent_exporter_local
+    url: 'http://127.0.0.1:9135/metrics'
+  - name: collins_exporter_local
+    url: 'http://127.0.0.1:9136/metrics'
+  - name: silicondust_hdhomerun_exporter_local
+    url: 'http://127.0.0.1:9137/metrics'
+  - name: heka_exporter_local
+    url: 'http://127.0.0.1:9138/metrics'
+  - name: azure_sql_exporter_local
+    url: 'http://127.0.0.1:9139/metrics'
+  - name: mirth_exporter_local
+    url: 'http://127.0.0.1:9140/metrics'
+  - name: zookeeper_exporter_local
+    url: 'http://127.0.0.1:9141/metrics'
+  - name: big-ip_exporter_local
+    url: 'http://127.0.0.1:9142/metrics'
+  - name: cloudmonitor_exporter_local
+    url: 'http://127.0.0.1:9143/metrics'
+  - name: aerospike_exporter_local
+    url: 'http://127.0.0.1:9145/metrics'
+  - name: icecast_exporter_local
+    url: 'http://127.0.0.1:9146/metrics'
+  - name: nginx_request_exporter_local
+    url: 'http://127.0.0.1:9147/metrics'
+  - name: nats_exporter_local
+    url: 'http://127.0.0.1:9148/metrics'
+  - name: passenger_exporter_local
+    url: 'http://127.0.0.1:9149/metrics'
+  - name: memcached_exporter_local
+    url: 'http://127.0.0.1:9150/metrics'
+  - name: varnish_request_exporter_local
+    url: 'http://127.0.0.1:9151/metrics'
+  - name: command_runner_exporter_local
+    url: 'http://127.0.0.1:9152/metrics'
+  - name: coredns_local
+    url: 'http://127.0.0.1:9153/metrics'
+  - name: postfix_exporter_local
+    url: 'http://127.0.0.1:9154/metrics'
+  - name: vsphere_graphite_local
+    url: 'http://127.0.0.1:9155/metrics'
   - name: webdriver_exporter_local
     url: 'http://127.0.0.1:9156/metrics'
-
-  # Logging
-  # https://prometheus.io/docs/instrumenting/exporters/#logging
+  - name: ibm_mq_exporter_local
+    url: 'http://127.0.0.1:9157/metrics'
+  - name: pingdom_exporter_local
+    url: 'http://127.0.0.1:9158/metrics'
+  - name: apache_flink_exporter_local
+    url: 'http://127.0.0.1:9160/metrics'
+  - name: oracle_db_exporter_local
+    url: 'http://127.0.0.1:9161/metrics'
+  - name: apcupsd_exporter_local
+    url: 'http://127.0.0.1:9162/metrics'
+  - name: zgres_exporter_local
+    url: 'http://127.0.0.1:9163/metrics'
+  - name: s6_exporter_local
+    url: 'http://127.0.0.1:9164/metrics'
+  - name: keepalived_exporter_local
+    url: 'http://127.0.0.1:9165/metrics'
+  - name: dovecot_exporter_local
+    url: 'http://127.0.0.1:9166/metrics'
+  - name: unbound_exporter_local
+    url: 'http://127.0.0.1:9167/metrics'
+  - name: gitlab-monitor_local
+    url: 'http://127.0.0.1:9168/metrics'
+  - name: lustre_exporter_local
+    url: 'http://127.0.0.1:9169/metrics'
+  - name: docker_hub_exporter_local
+    url: 'http://127.0.0.1:9170/metrics'
+  - name: github_exporter_local
+    url: 'http://127.0.0.1:9171/metrics'
+  - name: script_exporter_local
+    url: 'http://127.0.0.1:9172/metrics'
+  - name: rancher_exporter_local
+    url: 'http://127.0.0.1:9173/metrics'
+  - name: docker-cloud_exporter_local
+    url: 'http://127.0.0.1:9174/metrics'
+  - name: saltstack_exporter_local
+    url: 'http://127.0.0.1:9175/metrics'
+  - name: openvpn_exporter_local
+    url: 'http://127.0.0.1:9176/metrics'
+  - name: libvirt_exporter_local
+    url: 'http://127.0.0.1:9177/metrics'
+  - name: stream_exporter_local
+    url: 'http://127.0.0.1:9178/metrics'
+  - name: shield_exporter_local
+    url: 'http://127.0.0.1:9179/metrics'
+  - name: scylladb_exporter_local
+    url: 'http://127.0.0.1:9180/metrics'
+  - name: openstack_ceilometer_exporter_local
+    url: 'http://127.0.0.1:9181/metrics'
+  - name: wmi_exporter_local
+    url: 'http://127.0.0.1:9182/metrics'
+  - name: openstack_exporter_local
+    url: 'http://127.0.0.1:9183/metrics'
+  - name: twitch_exporter_local
+    url: 'http://127.0.0.1:9184/metrics'
+  - name: kafka_topic_exporter_local
+    url: 'http://127.0.0.1:9185/metrics'
+  - name: cloud_foundry_firehose_exporter_local
+    url: 'http://127.0.0.1:9186/metrics'
+  - name: postgresql_exporter_local
+    url: 'http://127.0.0.1:9187/metrics'
+  - name: crypto_exporter_local
+    url: 'http://127.0.0.1:9188/metrics'
+  - name: hetzner_cloud_csi_driver_nodes_local
+    url: 'http://127.0.0.1:9189/metrics'
+  - name: bosh_exporter_local
+    url: 'http://127.0.0.1:9190/metrics'
+  - name: netflow_exporter_local
+    url: 'http://127.0.0.1:9191/metrics'
+  - name: ceph_exporter_local
+    url: 'http://127.0.0.1:9192/metrics'
+  - name: cloud_foundry_exporter_local
+    url: 'http://127.0.0.1:9193/metrics'
+  - name: bosh_tsdb_exporter_local
+    url: 'http://127.0.0.1:9194/metrics'
+  - name: maxscale_exporter_local
+    url: 'http://127.0.0.1:9195/metrics'
+  - name: upnp_internet_gateway_device_exporter_local
+    url: 'http://127.0.0.1:9196/metrics'
+  - name: logstash_exporter_local
+    url: 'http://127.0.0.1:9198/metrics'
+  - name: cloudflare_exporter_local
+    url: 'http://127.0.0.1:9199/metrics'
+  - name: pacemaker_exporter_local
+    url: 'http://127.0.0.1:9202/metrics'
+  - name: domain_exporter_local
+    url: 'http://127.0.0.1:9203/metrics'
+  - name: pcsensor_temper_exporter_local
+    url: 'http://127.0.0.1:9204/metrics'
+  - name: nextcloud_exporter_local
+    url: 'http://127.0.0.1:9205/metrics'
+  - name: elasticsearch_exporter_local
+    url: 'http://127.0.0.1:9206/metrics'
+  - name: mysql_exporter_local
+    url: 'http://127.0.0.1:9207/metrics'
+  - name: kafka_consumer_group_exporter_local
+    url: 'http://127.0.0.1:9208/metrics'
+  - name: fastnetmon_advanced_exporter_local
+    url: 'http://127.0.0.1:9209/metrics'
+  - name: netatmo_exporter_local
+    url: 'http://127.0.0.1:9210/metrics'
+  - name: dnsbl-exporter_local
+    url: 'http://127.0.0.1:9211/metrics'
+  - name: digitalocean_exporter_local
+    url: 'http://127.0.0.1:9212/metrics'
+  - name: custom_exporter_local
+    url: 'http://127.0.0.1:9213/metrics'
+  - name: mqtt_blackbox_exporter_local
+    url: 'http://127.0.0.1:9214/metrics'
+  - name: prometheus_graphite_bridge_local
+    url: 'http://127.0.0.1:9215/metrics'
+  - name: mongodb_exporter_local
+    url: 'http://127.0.0.1:9216/metrics'
+  - name: consul_agent_exporter_local
+    url: 'http://127.0.0.1:9217/metrics'
+  - name: promql-guard_local
+    url: 'http://127.0.0.1:9218/metrics'
+  - name: ssl_certificate_exporter_local
+    url: 'http://127.0.0.1:9219/metrics'
+  - name: netapp_trident_exporter_local
+    url: 'http://127.0.0.1:9220/metrics'
+  - name: proxmox_ve_exporter_local
+    url: 'http://127.0.0.1:9221/metrics'
+  - name: aws_ecs_exporter_local
+    url: 'http://127.0.0.1:9222/metrics'
+  - name: bladepsgi_exporter_local
+    url: 'http://127.0.0.1:9223/metrics'
   - name: fluentd_exporter_local
     url: 'http://127.0.0.1:9224/metrics'
-
-  # Software
-  # https://prometheus.io/docs/instrumenting/exporters/#software-exposing-prometheus-metrics
-  - name: ceph_manager_local
+  - name: mailexporter_local
+    url: 'http://127.0.0.1:9225/metrics'
+  - name: allas_local
+    url: 'http://127.0.0.1:9226/metrics'
+  - name: proc_exporter_local
+    url: 'http://127.0.0.1:9227/metrics'
+  - name: flussonic_exporter_local
+    url: 'http://127.0.0.1:9228/metrics'
+  - name: gitlab-workhorse_local
+    url: 'http://127.0.0.1:9229/metrics'
+  - name: network_ups_tools_exporter_local
+    url: 'http://127.0.0.1:9230/metrics'
+  - name: solr_exporter_local
+    url: 'http://127.0.0.1:9231/metrics'
+  - name: osquery_exporter_local
+    url: 'http://127.0.0.1:9232/metrics'
+  - name: mgmt_exporter_local
+    url: 'http://127.0.0.1:9233/metrics'
+  - name: mosquitto_exporter_local
+    url: 'http://127.0.0.1:9234/metrics'
+  - name: gitlab-pages_exporter_local
+    url: 'http://127.0.0.1:9235/metrics'
+  - name: gitlab_gitaly_exporter_local
+    url: 'http://127.0.0.1:9236/metrics'
+  - name: sql_exporter_local
+    url: 'http://127.0.0.1:9237/metrics'
+  - name: uwsgi_expoter_local
+    url: 'http://127.0.0.1:9238/metrics'
+  - name: surfboard_exporter_local
+    url: 'http://127.0.0.1:9239/metrics'
+  - name: tinyproxy_exporter_local
+    url: 'http://127.0.0.1:9240/metrics'
+  - name: arangodb_exporter_local
+    url: 'http://127.0.0.1:9241/metrics'
+  - name: ceph_radosgw_usage_exporter_local
+    url: 'http://127.0.0.1:9242/metrics'
+  - name: chef_compliance_exporter_local
+    url: 'http://127.0.0.1:9243/metrics'
+  - name: moby_container_exporter_local
+    url: 'http://127.0.0.1:9244/metrics'
+  - name: naemon_/_nagios_exporter_local
+    url: 'http://127.0.0.1:9245/metrics'
+  - name: smartpi_local
+    url: 'http://127.0.0.1:9246/metrics'
+  - name: sphinx_exporter_local
+    url: 'http://127.0.0.1:9247/metrics'
+  - name: freebsd_gstat_exporter_local
+    url: 'http://127.0.0.1:9248/metrics'
+  - name: apache_flink_metrics_reporter_local
+    url: 'http://127.0.0.1:9249/metrics'
+  - name: opentsdb_exporter_local
+    url: 'http://127.0.0.1:9250/metrics'
+  - name: sensu_exporter_local
+    url: 'http://127.0.0.1:9251/metrics'
+  - name: gitlab_runner_exporter_local
+    url: 'http://127.0.0.1:9252/metrics'
+  - name: php-fpm_exporter_local
+    url: 'http://127.0.0.1:9253/metrics'
+  - name: kafka_burrow_exporter_local
+    url: 'http://127.0.0.1:9254/metrics'
+  - name: google_stackdriver_exporter_local
+    url: 'http://127.0.0.1:9255/metrics'
+  - name: td-agent_exporter_local
+    url: 'http://127.0.0.1:9256/metrics'
+  - name: s_m_a_r_t__exporter_local
+    url: 'http://127.0.0.1:9257/metrics'
+  - name: hello_sense_exporter_local
+    url: 'http://127.0.0.1:9258/metrics'
+  - name: azure_resources_exporter_local
+    url: 'http://127.0.0.1:9259/metrics'
+  - name: buildkite_exporter_local
+    url: 'http://127.0.0.1:9260/metrics'
+  - name: grafana_exporter_local
+    url: 'http://127.0.0.1:9261/metrics'
+  - name: bloomsky_exporter_local
+    url: 'http://127.0.0.1:9262/metrics'
+  - name: vmware_guest_exporter_local
+    url: 'http://127.0.0.1:9263/metrics'
+  - name: nest_exporter_local
+    url: 'http://127.0.0.1:9264/metrics'
+  - name: weather_exporter_local
+    url: 'http://127.0.0.1:9265/metrics'
+  - name: openhab_exporter_local
+    url: 'http://127.0.0.1:9266/metrics'
+  - name: nagios_livestatus_exporter_local
+    url: 'http://127.0.0.1:9267/metrics'
+  - name: cratedb_remote_remote_read/write_adapter_local
+    url: 'http://127.0.0.1:9268/metrics'
+  - name: fluent-agent-lite_exporter_local
+    url: 'http://127.0.0.1:9269/metrics'
+  - name: jmeter_exporter_local
+    url: 'http://127.0.0.1:9270/metrics'
+  - name: pagespeed_exporter_local
+    url: 'http://127.0.0.1:9271/metrics'
+  - name: vmware_exporter_local
+    url: 'http://127.0.0.1:9272/metrics'
+  - name: kubernetes_persistentvolume_disk_usage_exporter_local
+    url: 'http://127.0.0.1:9274/metrics'
+  - name: nrpe_exporter_local
+    url: 'http://127.0.0.1:9275/metrics'
+  - name: githubql_exporter_local
+    url: 'http://127.0.0.1:9276/metrics'
+  - name: azure_monitor_exporter_local
+    url: 'http://127.0.0.1:9276/metrics'
+  - name: mongo_collection_exporter_local
+    url: 'http://127.0.0.1:9277/metrics'
+  - name: crypto_miner_exporter_local
+    url: 'http://127.0.0.1:9278/metrics'
+  - name: instaclustr_exporter_local
+    url: 'http://127.0.0.1:9279/metrics'
+  - name: citrix_netscaler_exporter_local
+    url: 'http://127.0.0.1:9280/metrics'
+  - name: fastd_exporter_local
+    url: 'http://127.0.0.1:9281/metrics'
+  - name: freeswitch_exporter_local
+    url: 'http://127.0.0.1:9282/metrics'
+  - name: ceph_ceph-mgr_prometheus_plugin_local
     url: 'http://127.0.0.1:9283/metrics'
-  - name: haproxy_local
+  - name: gobetween_local
+    url: 'http://127.0.0.1:9284/metrics'
+  - name: database_exporter_local
+    url: 'http://127.0.0.1:9285/metrics'
+  - name: vdo_compression_and_deduplication_exporter_local
+    url: 'http://127.0.0.1:9286/metrics'
+  - name: ceph_iscsi_gateway_statistics_local
+    url: 'http://127.0.0.1:9287/metrics'
+  - name: consrv_local
+    url: 'http://127.0.0.1:9288/metrics'
+  - name: lovoos_ipmi_exporter_local
+    url: 'http://127.0.0.1:9289/metrics'
+  - name: soundclouds_ipmi_exporter_local
+    url: 'http://127.0.0.1:9290/metrics'
+  - name: ibm_z_hmc_exporter_local
+    url: 'http://127.0.0.1:9291/metrics'
+  - name: netapp_ontap_api_exporter_local
+    url: 'http://127.0.0.1:9292/metrics'
+  - name: connection_status_exporter_local
+    url: 'http://127.0.0.1:9293/metrics'
+  - name: miflora_/_flower_care_exporter_local
+    url: 'http://127.0.0.1:9294/metrics'
+  - name: freifunk_exporter_local
+    url: 'http://127.0.0.1:9295/metrics'
+  - name: odbc_exporter_local
+    url: 'http://127.0.0.1:9296/metrics'
+  - name: machbase_exporter_local
+    url: 'http://127.0.0.1:9297/metrics'
+  - name: generic_exporter_local
+    url: 'http://127.0.0.1:9298/metrics'
+  - name: exporter_aggregator_local
+    url: 'http://127.0.0.1:9299/metrics'
+  - name: squid_exporter_local
+    url: 'http://127.0.0.1:9301/metrics'
+  - name: faucet_sdn_faucet_exporter_local
+    url: 'http://127.0.0.1:9302/metrics'
+  - name: faucet_sdn_gauge_exporter_local
+    url: 'http://127.0.0.1:9303/metrics'
+  - name: logstash_exporter_local
+    url: 'http://127.0.0.1:9304/metrics'
+  - name: go-ethereum_exporter_local
+    url: 'http://127.0.0.1:9305/metrics'
+  - name: kyototycoon_exporter_local
+    url: 'http://127.0.0.1:9306/metrics'
+  - name: audisto_exporter_local
+    url: 'http://127.0.0.1:9307/metrics'
+  - name: kafka_exporter_local
+    url: 'http://127.0.0.1:9308/metrics'
+  - name: fluentd_exporter_local
+    url: 'http://127.0.0.1:9309/metrics'
+  - name: open_vswitch_exporter_local
+    url: 'http://127.0.0.1:9310/metrics'
+  - name: iota_exporter_local
+    url: 'http://127.0.0.1:9311/metrics'
+  - name: cloudprober_exporter_local
+    url: 'http://127.0.0.1:9313/metrics'
+  - name: eris_exporter_local
+    url: 'http://127.0.0.1:9314/metrics'
+  - name: centrifugo_exporter_local
+    url: 'http://127.0.0.1:9315/metrics'
+  - name: tado_exporter_local
+    url: 'http://127.0.0.1:9316/metrics'
+  - name: tellstick_local_exporter_local
+    url: 'http://127.0.0.1:9317/metrics'
+  - name: conntrack_exporter_local
+    url: 'http://127.0.0.1:9318/metrics'
+  - name: flexlm_exporter_local
+    url: 'http://127.0.0.1:9319/metrics'
+  - name: consul_telemetry_exporter_local
+    url: 'http://127.0.0.1:9320/metrics'
+  - name: spring_boot_actuator_exporter_local
+    url: 'http://127.0.0.1:9321/metrics'
+  - name: haproxy_abuser_exporter_local
+    url: 'http://127.0.0.1:9322/metrics'
+  - name: docker_prometheus_metrics_local
+    url: 'http://127.0.0.1:9323/metrics'
+  - name: bird_routing_daemon_exporter_local
+    url: 'http://127.0.0.1:9324/metrics'
+  - name: ovirt_exporter_local
+    url: 'http://127.0.0.1:9325/metrics'
+  - name: junos_exporter_local
+    url: 'http://127.0.0.1:9326/metrics'
+  - name: s3_exporter_local
+    url: 'http://127.0.0.1:9327/metrics'
+  - name: openldap_syncrepl_exporter_local
+    url: 'http://127.0.0.1:9328/metrics'
+  - name: cups_exporter_local
+    url: 'http://127.0.0.1:9329/metrics'
+  - name: openldap_metrics_exporter_local
+    url: 'http://127.0.0.1:9330/metrics'
+  - name: influx-spout_prometheus_metrics_local
+    url: 'http://127.0.0.1:9331/metrics'
+  - name: network_exporter_local
+    url: 'http://127.0.0.1:9332/metrics'
+  - name: vault_pki_exporter_local
+    url: 'http://127.0.0.1:9333/metrics'
+  - name: ejabberd_exporter_local
+    url: 'http://127.0.0.1:9334/metrics'
+  - name: nexsan_exporter_local
+    url: 'http://127.0.0.1:9335/metrics'
+  - name: mediacom_internet_usage_exporter_local
+    url: 'http://127.0.0.1:9336/metrics'
+  - name: mqttgateway_local
+    url: 'http://127.0.0.1:9337/metrics'
+  - name: aws_s3_exporter_local
+    url: 'http://127.0.0.1:9339/metrics'
+  - name: financial_quotes_exporter_local
+    url: 'http://127.0.0.1:9340/metrics'
+  - name: slurm_exporter_local
+    url: 'http://127.0.0.1:9341/metrics'
+  - name: frr_exporter_local
+    url: 'http://127.0.0.1:9342/metrics'
+  - name: gridserver_exporter_local
+    url: 'http://127.0.0.1:9343/metrics'
+  - name: mqtt_exporter_local
+    url: 'http://127.0.0.1:9344/metrics'
+  - name: ruckus_smartzone_exporter_local
+    url: 'http://127.0.0.1:9345/metrics'
+  - name: ping_exporter_local
+    url: 'http://127.0.0.1:9346/metrics'
+  - name: junos_exporter_local
+    url: 'http://127.0.0.1:9347/metrics'
+  - name: bigquery_exporter_local
+    url: 'http://127.0.0.1:9348/metrics'
+  - name: configurable_elasticsearch_query_exporter_local
+    url: 'http://127.0.0.1:9349/metrics'
+  - name: thousandeyes_exporter_local
+    url: 'http://127.0.0.1:9350/metrics'
+  - name: wal-e/wal-g_exporter_local
+    url: 'http://127.0.0.1:9351/metrics'
+  - name: nature_remo_exporter_local
+    url: 'http://127.0.0.1:9352/metrics'
+  - name: ceph_exporter_local
+    url: 'http://127.0.0.1:9353/metrics'
+  - name: deluge_exporter_local
+    url: 'http://127.0.0.1:9354/metrics'
+  - name: nightwatch_js_exporter_local
+    url: 'http://127.0.0.1:9355/metrics'
+  - name: pacemaker_exporter_local
+    url: 'http://127.0.0.1:9356/metrics'
+  - name: p1_exporter_local
+    url: 'http://127.0.0.1:9357/metrics'
+  - name: performance_counters_exporter_local
+    url: 'http://127.0.0.1:9358/metrics'
+  - name: sidekiq_prometheus_local
+    url: 'http://127.0.0.1:9359/metrics'
+  - name: powershell_exporter_local
+    url: 'http://127.0.0.1:9360/metrics'
+  - name: scaleway_sd_exporter_local
+    url: 'http://127.0.0.1:9361/metrics'
+  - name: cisco_exporter_local
+    url: 'http://127.0.0.1:9362/metrics'
+  - name: clickhouse_local
+    url: 'http://127.0.0.1:9363/metrics'
+  - name: continent8_exporter_local
+    url: 'http://127.0.0.1:9364/metrics'
+  - name: cumulus_linux_exporter_local
+    url: 'http://127.0.0.1:9365/metrics'
+  - name: haproxy_stick_table_exporter_local
+    url: 'http://127.0.0.1:9366/metrics'
+  - name: teamspeak3_exporter_local
+    url: 'http://127.0.0.1:9367/metrics'
+  - name: ethereum_client_exporter_local
+    url: 'http://127.0.0.1:9368/metrics'
+  - name: prometheus_pushprox_local
+    url: 'http://127.0.0.1:9369/metrics'
+  - name: u-bmc_local
+    url: 'http://127.0.0.1:9370/metrics'
+  - name: conntrack-stats-exporter_local
+    url: 'http://127.0.0.1:9371/metrics'
+  - name: appmetrics/prometheus_local
+    url: 'http://127.0.0.1:9372/metrics'
+  - name: gcp_service_discovery_local
+    url: 'http://127.0.0.1:9373/metrics'
+  - name: smokeping_prober_local
+    url: 'http://127.0.0.1:9374/metrics'
+  - name: particle_exporter_local
+    url: 'http://127.0.0.1:9375/metrics'
+  - name: falco_local
+    url: 'http://127.0.0.1:9376/metrics'
+  - name: cisco_aci_exporter_local
+    url: 'http://127.0.0.1:9377/metrics'
+  - name: etcd_grpc_proxy_exporter_local
+    url: 'http://127.0.0.1:9378/metrics'
+  - name: etcd_exporter_local
+    url: 'http://127.0.0.1:9379/metrics'
+  - name: mythtv_exporter_local
+    url: 'http://127.0.0.1:9380/metrics'
+  - name: kafka_zookeeper_exporter_local
+    url: 'http://127.0.0.1:9381/metrics'
+  - name: frrouting_exporter_local
+    url: 'http://127.0.0.1:9382/metrics'
+  - name: aws_health_exporter_local
+    url: 'http://127.0.0.1:9383/metrics'
+  - name: aws_sqs_exporter_local
+    url: 'http://127.0.0.1:9384/metrics'
+  - name: apcupsdexporter_local
+    url: 'http://127.0.0.1:9385/metrics'
+  - name: httpd-exporter_local
+    url: 'http://127.0.0.1:9386/metrics'
+  - name: tankerkönig_api_exporter_local
+    url: 'http://127.0.0.1:9386/metrics'
+  - name: sabnzbd_exporter_local
+    url: 'http://127.0.0.1:9387/metrics'
+  - name: linode_exporter_local
+    url: 'http://127.0.0.1:9388/metrics'
+  - name: scylla-cluster-tests_exporter_local
+    url: 'http://127.0.0.1:9389/metrics'
+  - name: kannel_exporter_local
+    url: 'http://127.0.0.1:9390/metrics'
+  - name: concourse_prometheus_metrics_local
+    url: 'http://127.0.0.1:9391/metrics'
+  - name: generic_command_line_output_exporter_local
+    url: 'http://127.0.0.1:9392/metrics'
+  - name: patroni_exporter_local
+    url: 'http://127.0.0.1:9393/metrics'
+  - name: alertmanager_github_webhook_receiver_local
+    url: 'http://127.0.0.1:9393/metrics'
+  - name: ruby_prometheus_exporter_local
+    url: 'http://127.0.0.1:9394/metrics'
+  - name: ldap_exporter_local
+    url: 'http://127.0.0.1:9395/metrics'
+  - name: monerod_exporter_local
+    url: 'http://127.0.0.1:9396/metrics'
+  - name: comap_local
+    url: 'http://127.0.0.1:9397/metrics'
+  - name: open_hardware_monitor_exporter_local
+    url: 'http://127.0.0.1:9398/metrics'
+  - name: prometheus_sql_exporter_local
+    url: 'http://127.0.0.1:9399/metrics'
+  - name: ripe_atlas_exporter_local
+    url: 'http://127.0.0.1:9400/metrics'
+  - name: 1-wire_exporter_local
+    url: 'http://127.0.0.1:9401/metrics'
+  - name: google_cloud_platform_exporter_local
+    url: 'http://127.0.0.1:9402/metrics'
+  - name: zerto_exporter_local
+    url: 'http://127.0.0.1:9403/metrics'
+  - name: jmx_exporter_local
+    url: 'http://127.0.0.1:9404/metrics'
+  - name: discourse_exporter_local
+    url: 'http://127.0.0.1:9405/metrics'
+  - name: hhvm_exporter_local
+    url: 'http://127.0.0.1:9406/metrics'
+  - name: obs_studio_exporter_local
+    url: 'http://127.0.0.1:9407/metrics'
+  - name: rds_enhanced_monitoring_exporter_local
+    url: 'http://127.0.0.1:9408/metrics'
+  - name: ovn-kubernetes_master_exporter_local
+    url: 'http://127.0.0.1:9409/metrics'
+  - name: ovn-kubernetes_node_exporter_local
+    url: 'http://127.0.0.1:9410/metrics'
+  - name: softether_exporter_local
+    url: 'http://127.0.0.1:9411/metrics'
+  - name: sentry_exporter_local
+    url: 'http://127.0.0.1:9412/metrics'
+  - name: mogilefs_exporter_local
+    url: 'http://127.0.0.1:9413/metrics'
+  - name: homey_exporter_local
+    url: 'http://127.0.0.1:9414/metrics'
+  - name: cloudwatch_read_adapter_local
+    url: 'http://127.0.0.1:9415/metrics'
+  - name: hp_ilo_metrics_exporter_local
+    url: 'http://127.0.0.1:9416/metrics'
+  - name: ethtool_exporter_local
+    url: 'http://127.0.0.1:9417/metrics'
+  - name: gearman_exporter_local
+    url: 'http://127.0.0.1:9418/metrics'
+  - name: rabbitmq_exporter_local
+    url: 'http://127.0.0.1:9419/metrics'
+  - name: couchbase_exporter_local
+    url: 'http://127.0.0.1:9420/metrics'
+  - name: apicast_local
+    url: 'http://127.0.0.1:9421/metrics'
+  - name: jolokia_exporter_local
+    url: 'http://127.0.0.1:9422/metrics'
+  - name: hp_raid_exporter_local
+    url: 'http://127.0.0.1:9423/metrics'
+  - name: influxdb_stats_exporter_local
+    url: 'http://127.0.0.1:9424/metrics'
+  - name: pachyderm_exporter_local
+    url: 'http://127.0.0.1:9425/metrics'
+  - name: vespa_engine_exporter_local
+    url: 'http://127.0.0.1:9426/metrics'
+  - name: ping_exporter_local
+    url: 'http://127.0.0.1:9427/metrics'
+  - name: ssh_exporter_local
+    url: 'http://127.0.0.1:9428/metrics'
+  - name: uptimerobot_exporter_local
+    url: 'http://127.0.0.1:9429/metrics'
+  - name: corerad_local
+    url: 'http://127.0.0.1:9430/metrics'
+  - name: hpfeeds_broker_exporter_local
+    url: 'http://127.0.0.1:9431/metrics'
+  - name: windows_perflib_exporter_local
+    url: 'http://127.0.0.1:9432/metrics'
+  - name: knot_exporter_local
+    url: 'http://127.0.0.1:9433/metrics'
+  - name: opensips_exporter_local
+    url: 'http://127.0.0.1:9434/metrics'
+  - name: ebpf_exporter_local
+    url: 'http://127.0.0.1:9435/metrics'
+  - name: mikrotik-exporter_local
+    url: 'http://127.0.0.1:9436/metrics'
+  - name: dell_emc_isilon_exporter_local
+    url: 'http://127.0.0.1:9437/metrics'
+  - name: dell_emc_ecs_exporter_local
+    url: 'http://127.0.0.1:9438/metrics'
+  - name: bitcoind_exporter_local
+    url: 'http://127.0.0.1:9439/metrics'
+  - name: ravendb_exporter_local
+    url: 'http://127.0.0.1:9440/metrics'
+  - name: nomad_exporter_local
+    url: 'http://127.0.0.1:9441/metrics'
+  - name: mcrouter_exporter_local
+    url: 'http://127.0.0.1:9442/metrics'
+  - name: foundationdb_exporter_local
+    url: 'http://127.0.0.1:9444/metrics'
+  - name: nvidia_gpu_exporter_local
+    url: 'http://127.0.0.1:9445/metrics'
+  - name: orange_livebox_dsl_modem_exporter_local
+    url: 'http://127.0.0.1:9446/metrics'
+  - name: resque_exporter_local
+    url: 'http://127.0.0.1:9447/metrics'
+  - name: eventstore_exporter_local
+    url: 'http://127.0.0.1:9448/metrics'
+  - name: omero_server_exporter_local
+    url: 'http://127.0.0.1:9449/metrics'
+  - name: habitat_exporter_local
+    url: 'http://127.0.0.1:9450/metrics'
+  - name: reindexer_exporter_local
+    url: 'http://127.0.0.1:9451/metrics'
+  - name: freebsd_jail_exporter_local
+    url: 'http://127.0.0.1:9452/metrics'
+  - name: midonet-kubernetes_local
+    url: 'http://127.0.0.1:9453/metrics'
+  - name: nvidia_smi_exporter_local
+    url: 'http://127.0.0.1:9454/metrics'
+  - name: iptables_exporter_local
+    url: 'http://127.0.0.1:9455/metrics'
+  - name: aws_lambda_exporter_local
+    url: 'http://127.0.0.1:9456/metrics'
+  - name: files_content_exporter_local
+    url: 'http://127.0.0.1:9457/metrics'
+  - name: rocket_chat_exporter_local
+    url: 'http://127.0.0.1:9458/metrics'
+  - name: yarn_exporter_local
+    url: 'http://127.0.0.1:9459/metrics'
+  - name: hana_exporter_local
+    url: 'http://127.0.0.1:9460/metrics'
+  - name: aws_lambda_read_adapter_local
+    url: 'http://127.0.0.1:9461/metrics'
+  - name: php_opcache_exporter_local
+    url: 'http://127.0.0.1:9462/metrics'
+  - name: virgin_media/liberty_global_hub3_exporter_local
+    url: 'http://127.0.0.1:9463/metrics'
+  - name: opencensus-nodejs_prometheus_exporter_local
+    url: 'http://127.0.0.1:9464/metrics'
+  - name: hetzner_cloud_k8s_cloud_controller_manager_local
+    url: 'http://127.0.0.1:9465/metrics'
+  - name: mqtt_push_gateway_local
+    url: 'http://127.0.0.1:9466/metrics'
+  - name: nginx-prometheus-shiny-exporter_local
+    url: 'http://127.0.0.1:9467/metrics'
+  - name: nasa-swpc-exporter_local
+    url: 'http://127.0.0.1:9468/metrics'
+  - name: script_exporter_local
+    url: 'http://127.0.0.1:9469/metrics'
+  - name: cachet_exporter_local
+    url: 'http://127.0.0.1:9470/metrics'
+  - name: lxc-exporter_local
+    url: 'http://127.0.0.1:9471/metrics'
+  - name: hetzner_cloud_csi_driver_controller_local
+    url: 'http://127.0.0.1:9472/metrics'
+  - name: stellar-core-exporter_local
+    url: 'http://127.0.0.1:9473/metrics'
+  - name: libvirtd_exporter_local
+    url: 'http://127.0.0.1:9474/metrics'
+  - name: wgipamd_local
+    url: 'http://127.0.0.1:9475/metrics'
+  - name: ovn_metrics_exporter_local
+    url: 'http://127.0.0.1:9476/metrics'
+  - name: csp_violation_report_exporter_local
+    url: 'http://127.0.0.1:9477/metrics'
+  - name: sentinel_exporter_local
+    url: 'http://127.0.0.1:9478/metrics'
+  - name: elasticbeat_exporter_local
+    url: 'http://127.0.0.1:9479/metrics'
+  - name: brigade_exporter_local
+    url: 'http://127.0.0.1:9480/metrics'
+  - name: drbd9_exporter_local
+    url: 'http://127.0.0.1:9481/metrics'
+  - name: vector_packet_process_vpp_exporter_local
+    url: 'http://127.0.0.1:9482/metrics'
+  - name: ibm_app_connect_enterprise_exporter_local
+    url: 'http://127.0.0.1:9483/metrics'
+  - name: kubedex-exporter_local
+    url: 'http://127.0.0.1:9484/metrics'
+  - name: emarsys_exporter_local
+    url: 'http://127.0.0.1:9485/metrics'
+  - name: domoticz_exporter_local
+    url: 'http://127.0.0.1:9486/metrics'
+  - name: docker_stats_exporter_local
+    url: 'http://127.0.0.1:9487/metrics'
+  - name: bmw_connected_drive_exporter_local
+    url: 'http://127.0.0.1:9488/metrics'
+  - name: tezos_node_metrics_exporter_local
+    url: 'http://127.0.0.1:9489/metrics'
+  - name: exporter_for_docker_libnetwork_plugin_for_ovn_local
+    url: 'http://127.0.0.1:9490/metrics'
+  - name: docker_container_stats_exporter_`docker_ps`_local
+    url: 'http://127.0.0.1:9491/metrics'
+  - name: azure_exporter_monitor_and_usage_local
+    url: 'http://127.0.0.1:9492/metrics'
+  - name: prosafe_exporter_local
+    url: 'http://127.0.0.1:9493/metrics'
+  - name: kamailio_exporter_local
+    url: 'http://127.0.0.1:9494/metrics'
+  - name: ingestor_exporter_local
+    url: 'http://127.0.0.1:9495/metrics'
+  - name: 389ds/ipa_exporter_local
+    url: 'http://127.0.0.1:9496/metrics'
+  - name: immudb_exporter_local
+    url: 'http://127.0.0.1:9497/metrics'
+  - name: tp-link_hs110_exporter_local
+    url: 'http://127.0.0.1:9498/metrics'
+  - name: smartthings_exporter_local
+    url: 'http://127.0.0.1:9499/metrics'
+  - name: cassandra_exporter_local
+    url: 'http://127.0.0.1:9500/metrics'
+  - name: hetznercloud_exporter_local
+    url: 'http://127.0.0.1:9501/metrics'
+  - name: hetzner_exporter_local
+    url: 'http://127.0.0.1:9502/metrics'
+  - name: scaleway_exporter_local
+    url: 'http://127.0.0.1:9503/metrics'
+  - name: github_exporter_local
+    url: 'http://127.0.0.1:9504/metrics'
+  - name: dockerhub_exporter_local
+    url: 'http://127.0.0.1:9505/metrics'
+  - name: jenkins_exporter_local
+    url: 'http://127.0.0.1:9506/metrics'
+  - name: owncloud_exporter_local
+    url: 'http://127.0.0.1:9507/metrics'
+  - name: ccache_exporter_local
+    url: 'http://127.0.0.1:9508/metrics'
+  - name: hetzner_storagebox_exporter_local
+    url: 'http://127.0.0.1:9509/metrics'
+  - name: dummy_exporter_local
+    url: 'http://127.0.0.1:9510/metrics'
+  - name: cloudera_exporter_local
+    url: 'http://127.0.0.1:9512/metrics'
+  - name: openconfig_streaming_telemetry_exporter_local
+    url: 'http://127.0.0.1:9513/metrics'
+  - name: app_stores_exporter_local
+    url: 'http://127.0.0.1:9514/metrics'
+  - name: swarm-exporter_local
+    url: 'http://127.0.0.1:9515/metrics'
+  - name: prometheus_speedtest_exporter_local
+    url: 'http://127.0.0.1:9516/metrics'
+  - name: matroschka_prober_local
+    url: 'http://127.0.0.1:9517/metrics'
+  - name: crypto_stock_exchanges_funds_exporter_local
+    url: 'http://127.0.0.1:9518/metrics'
+  - name: acurite_exporter_local
+    url: 'http://127.0.0.1:9519/metrics'
+  - name: swift_health_exporter_local
+    url: 'http://127.0.0.1:9520/metrics'
+  - name: ruuvi_exporter_local
+    url: 'http://127.0.0.1:9521/metrics'
+  - name: tftp_exporter_local
+    url: 'http://127.0.0.1:9522/metrics'
+  - name: 3cx_exporter_local
+    url: 'http://127.0.0.1:9523/metrics'
+  - name: loki_exporter_local
+    url: 'http://127.0.0.1:9524/metrics'
+  - name: alibaba_cloud_exporter_local
+    url: 'http://127.0.0.1:9525/metrics'
+  - name: kafka_lag_exporter_local
+    url: 'http://127.0.0.1:9526/metrics'
+  - name: netgear_cable_modem_exporter_local
+    url: 'http://127.0.0.1:9527/metrics'
+  - name: total_connect_comfort_exporter_local
+    url: 'http://127.0.0.1:9528/metrics'
+  - name: octoprint_exporter_local
+    url: 'http://127.0.0.1:9529/metrics'
+  - name: custom_prometheus_exporter_local
+    url: 'http://127.0.0.1:9530/metrics'
+  - name: jfrog_artifactory_exporter_local
+    url: 'http://127.0.0.1:9531/metrics'
+  - name: snyk_exporter_local
+    url: 'http://127.0.0.1:9532/metrics'
+  - name: network_exporter_for_cisco_api_local
+    url: 'http://127.0.0.1:9533/metrics'
+  - name: humio_exporter_local
+    url: 'http://127.0.0.1:9534/metrics'
+  - name: cron_exporter_local
+    url: 'http://127.0.0.1:9535/metrics'
+  - name: ipsec_exporter_local
+    url: 'http://127.0.0.1:9536/metrics'
+  - name: cri-o_local
+    url: 'http://127.0.0.1:9537/metrics'
+  - name: bull_queue_local
+    url: 'http://127.0.0.1:9538/metrics'
+  - name: modemmanager_exporter_local
+    url: 'http://127.0.0.1:9539/metrics'
+  - name: emq_exporter_local
+    url: 'http://127.0.0.1:9540/metrics'
+  - name: smartmon_exporter_local
+    url: 'http://127.0.0.1:9541/metrics'
+  - name: sakuracloud_exporter_local
+    url: 'http://127.0.0.1:9542/metrics'
+  - name: kube2iam_exporter_local
+    url: 'http://127.0.0.1:9543/metrics'
+  - name: pgio_exporter_local
+    url: 'http://127.0.0.1:9544/metrics'
+  - name: hp_ilo4_exporter_local
+    url: 'http://127.0.0.1:9545/metrics'
+  - name: pwrstat-exporter_local
+    url: 'http://127.0.0.1:9546/metrics'
+  - name: patroni_exporter_local
+    url: 'http://127.0.0.1:9547/metrics'
+  - name: trafficserver_exporter_local
+    url: 'http://127.0.0.1:9548/metrics'
+  - name: raspberry_exporter_local
+    url: 'http://127.0.0.1:9549/metrics'
+  - name: rtl_433_exporter_local
+    url: 'http://127.0.0.1:9550/metrics'
+  - name: hostapd_exporter_local
+    url: 'http://127.0.0.1:9551/metrics'
+  - name: alpine_apk_exporter_local
+    url: 'http://127.0.0.1:9552/metrics'
+  - name: aws_elastic_beanstalk_exporter_local
+    url: 'http://127.0.0.1:9552/metrics'
+  - name: apt_exporter_local
+    url: 'http://127.0.0.1:9553/metrics'
+  - name: acc_server_manager_exporter_local
+    url: 'http://127.0.0.1:9554/metrics'
+  - name: sona_exporter_local
+    url: 'http://127.0.0.1:9555/metrics'
+  - name: routinator_exporter_local
+    url: 'http://127.0.0.1:9556/metrics'
+  - name: mysql_count_exporter_local
+    url: 'http://127.0.0.1:9557/metrics'
+  - name: systemd_exporter_local
+    url: 'http://127.0.0.1:9558/metrics'
+  - name: ntp_exporter_local
+    url: 'http://127.0.0.1:9559/metrics'
+  - name: sql_queries_exporter_local
+    url: 'http://127.0.0.1:9560/metrics'
+  - name: qbittorrent_exporter_local
+    url: 'http://127.0.0.1:9561/metrics'
+  - name: ptv_xserver_exporter_local
+    url: 'http://127.0.0.1:9562/metrics'
+  - name: kibana_exporter_local
+    url: 'http://127.0.0.1:9563/metrics'
+  - name: purpleair_exporter_local
+    url: 'http://127.0.0.1:9564/metrics'
+  - name: bminer_exporter_local
+    url: 'http://127.0.0.1:9565/metrics'
+  - name: rabbitmq_cli_consumer_local
+    url: 'http://127.0.0.1:9566/metrics'
+  - name: alertsnitch_local
+    url: 'http://127.0.0.1:9567/metrics'
+  - name: dell_poweredge_ipmi_exporter_local
+    url: 'http://127.0.0.1:9568/metrics'
+  - name: hvpa_controller_local
+    url: 'http://127.0.0.1:9569/metrics'
+  - name: vpa_exporter_local
+    url: 'http://127.0.0.1:9570/metrics'
+  - name: helm_exporter_local
+    url: 'http://127.0.0.1:9571/metrics'
+  - name: ctld_exporter_local
+    url: 'http://127.0.0.1:9572/metrics'
+  - name: jkstatus_exporter_local
+    url: 'http://127.0.0.1:9573/metrics'
+  - name: opentracker_exporter_local
+    url: 'http://127.0.0.1:9574/metrics'
+  - name: poweradmin_server_monitor_exporter_local
+    url: 'http://127.0.0.1:9575/metrics'
+  - name: exabgp_exporter_local
+    url: 'http://127.0.0.1:9576/metrics'
+  - name: aria2_exporter_local
+    url: 'http://127.0.0.1:9578/metrics'
+  - name: iperf3_exporter_local
+    url: 'http://127.0.0.1:9579/metrics'
+  - name: azure_service_bus_exporter_local
+    url: 'http://127.0.0.1:9580/metrics'
+  - name: codenotary_vcn_exporter_local
+    url: 'http://127.0.0.1:9581/metrics'
+  - name: signatory_a_remote_operation_signer_for_tezos_local
+    url: 'http://127.0.0.1:9583/metrics'
+  - name: bunnycdn_exporter_local
+    url: 'http://127.0.0.1:9584/metrics'
+  - name: opvizor_performance_analyzer_process_exporter_local
+    url: 'http://127.0.0.1:9585/metrics'
+  - name: nfs-ganesha_exporter_local
+    url: 'http://127.0.0.1:9587/metrics'
+  - name: ltsv-tailer_exporter_local
+    url: 'http://127.0.0.1:9588/metrics'
+  - name: goflow_exporter_local
+    url: 'http://127.0.0.1:9589/metrics'
+  - name: flow_exporter_local
+    url: 'http://127.0.0.1:9590/metrics'
+  - name: srcds_exporter_local
+    url: 'http://127.0.0.1:9591/metrics'
+  - name: gcp_quota_exporter_local
+    url: 'http://127.0.0.1:9592/metrics'
+  - name: lighthouse_exporter_local
+    url: 'http://127.0.0.1:9593/metrics'
+  - name: plex_exporter_local
+    url: 'http://127.0.0.1:9594/metrics'
+  - name: netio_exporter_local
+    url: 'http://127.0.0.1:9595/metrics'
+  - name: azure_elastic_sql_exporter_local
+    url: 'http://127.0.0.1:9596/metrics'
+  - name: github_vulnerability_alerts_exporter_local
+    url: 'http://127.0.0.1:9597/metrics'
+  - name: pirograph_exporter_local
+    url: 'http://127.0.0.1:9599/metrics'
+  - name: circleci_exporter_local
+    url: 'http://127.0.0.1:9600/metrics'
+  - name: messagebird_exporter_local
+    url: 'http://127.0.0.1:9601/metrics'
+  - name: modbus_exporter_local
+    url: 'http://127.0.0.1:9602/metrics'
+  - name: xen_exporter_using_xenlight_local
+    url: 'http://127.0.0.1:9603/metrics'
+  - name: xmpp_blackbox_exporter_local
+    url: 'http://127.0.0.1:9604/metrics'
+  - name: fping-exporter_local
+    url: 'http://127.0.0.1:9605/metrics'
+  - name: ecr-exporter_local
+    url: 'http://127.0.0.1:9606/metrics'
+  - name: raspberry_pi_sense_hat_exporter_local
+    url: 'http://127.0.0.1:9607/metrics'
+  - name: ironic_prometheus_exporter_local
+    url: 'http://127.0.0.1:9608/metrics'
+  - name: netapp_exporter_local
+    url: 'http://127.0.0.1:9609/metrics'
+  - name: kubernetes_exporter_local
+    url: 'http://127.0.0.1:9610/metrics'
+  - name: speedport_exporter_local
+    url: 'http://127.0.0.1:9611/metrics'
+  - name: opflex-agent_exporter_local
+    url: 'http://127.0.0.1:9612/metrics'
+  - name: azure_health_exporter_local
+    url: 'http://127.0.0.1:9613/metrics'
+  - name: nut_upsc_exporter_local
+    url: 'http://127.0.0.1:9614/metrics'
+  - name: mellanox_mlx5_exporter_local
+    url: 'http://127.0.0.1:9615/metrics'
+  - name: mailgun_exporter_local
+    url: 'http://127.0.0.1:9616/metrics'
+  - name: pi-hole_exporter_local
+    url: 'http://127.0.0.1:9617/metrics'
+  - name: stellar-account-exporter_local
+    url: 'http://127.0.0.1:9618/metrics'
+  - name: stellar-horizon-exporter_local
+    url: 'http://127.0.0.1:9619/metrics'
+  - name: rundeck_exporter_local
+    url: 'http://127.0.0.1:9620/metrics'
+  - name: opennebula_exporter_local
+    url: 'http://127.0.0.1:9621/metrics'
+  - name: bmc_exporter_local
+    url: 'http://127.0.0.1:9622/metrics'
+  - name: tc4400_exporter_local
+    url: 'http://127.0.0.1:9623/metrics'
+  - name: pact_broker_exporter_local
+    url: 'http://127.0.0.1:9624/metrics'
+  - name: bareos_exporter_local
+    url: 'http://127.0.0.1:9625/metrics'
+  - name: hockeypuck_local
+    url: 'http://127.0.0.1:9626/metrics'
+  - name: artifactory_exporter_local
+    url: 'http://127.0.0.1:9627/metrics'
+  - name: solace_pubsub_plus_exporter_local
+    url: 'http://127.0.0.1:9628/metrics'
+  - name: prometheus_gitlab_notifier_local
+    url: 'http://127.0.0.1:9629/metrics'
+  - name: nftables_exporter_local
+    url: 'http://127.0.0.1:9630/metrics'
+  - name: a_op5_monitor_exporter_local
+    url: 'http://127.0.0.1:9631/metrics'
+  - name: opflex-server_exporter_local
+    url: 'http://127.0.0.1:9632/metrics'
+  - name: smartctl_exporter_local
+    url: 'http://127.0.0.1:9633/metrics'
+  - name: aerospike_ttl_exporter_local
+    url: 'http://127.0.0.1:9634/metrics'
+  - name: fail2ban_exporter_local
+    url: 'http://127.0.0.1:9635/metrics'
+  - name: exim4_exporter_local
+    url: 'http://127.0.0.1:9636/metrics'
+  - name: kubeversion_exporter_local
+    url: 'http://127.0.0.1:9637/metrics'
+  - name: a_icinga2_exporter_local
+    url: 'http://127.0.0.1:9638/metrics'
+  - name: scriptable_jmx_exporter_local
+    url: 'http://127.0.0.1:9639/metrics'
+  - name: logstash_output_exporter_local
+    url: 'http://127.0.0.1:9640/metrics'
+  - name: coturn_exporter_local
+    url: 'http://127.0.0.1:9641/metrics'
+  - name: bugsnag_exporter_local
+    url: 'http://127.0.0.1:9642/metrics'
+  - name: exporter_for_grouped_process_local
+    url: 'http://127.0.0.1:9644/metrics'
+  - name: burp_exporter_local
+    url: 'http://127.0.0.1:9645/metrics'
+  - name: locust_exporter_local
+    url: 'http://127.0.0.1:9646/metrics'
+  - name: docker_exporter_local
+    url: 'http://127.0.0.1:9647/metrics'
+  - name: ntpmon_exporter_local
+    url: 'http://127.0.0.1:9648/metrics'
+  - name: logstash_exporter_local
+    url: 'http://127.0.0.1:9649/metrics'
+  - name: keepalived_exporter_local
+    url: 'http://127.0.0.1:9650/metrics'
+  - name: storj_exporter_local
+    url: 'http://127.0.0.1:9651/metrics'
+  - name: praefect_exporter_local
+    url: 'http://127.0.0.1:9652/metrics'
+  - name: jira_issues_exporter_local
+    url: 'http://127.0.0.1:9653/metrics'
+  - name: ansible_galaxy_exporter_local
+    url: 'http://127.0.0.1:9654/metrics'
+  - name: kube-netc_exporter_local
+    url: 'http://127.0.0.1:9655/metrics'
+  - name: matrix_local
+    url: 'http://127.0.0.1:9656/metrics'
+  - name: krill_exporter_local
+    url: 'http://127.0.0.1:9657/metrics'
+  - name: sap_hana_sql_exporter_local
+    url: 'http://127.0.0.1:9658/metrics'
+  - name: kaiterra_laser_egg_exporter_local
+    url: 'http://127.0.0.1:9660/metrics'
+  - name: hashpipe_exporter_local
+    url: 'http://127.0.0.1:9661/metrics'
+  - name: pms5003_particulate_matter_sensor_exporter_local
+    url: 'http://127.0.0.1:9662/metrics'
+  - name: sap_nwrfc_exporter_local
+    url: 'http://127.0.0.1:9663/metrics'
+  - name: linux_ha_clusterlabs_exporter_local
+    url: 'http://127.0.0.1:9664/metrics'
+  - name: senderscore_exporter_local
+    url: 'http://127.0.0.1:9665/metrics'
+  - name: alertmanager_silences_exporter_local
+    url: 'http://127.0.0.1:9666/metrics'
+  - name: smtpd_exporter_local
+    url: 'http://127.0.0.1:9667/metrics'
+  - name: suses_sap_hana_exporter_local
+    url: 'http://127.0.0.1:9668/metrics'
+  - name: panopticon_native_metrics_local
+    url: 'http://127.0.0.1:9669/metrics'
+  - name: flare_native_metrics_local
+    url: 'http://127.0.0.1:9670/metrics'
+  - name: aws_ec2_spot_exporter_local
+    url: 'http://127.0.0.1:9671/metrics'
+  - name: aircontrol_co2_exporter_local
+    url: 'http://127.0.0.1:9672/metrics'
+  - name: co2_monitor_exporter_local
+    url: 'http://127.0.0.1:9673/metrics'
+  - name: google_analytics_exporter_local
+    url: 'http://127.0.0.1:9674/metrics'
+  - name: docker_swarm_exporter_local
+    url: 'http://127.0.0.1:9675/metrics'
+  - name: hetzner_traffic_exporter_local
+    url: 'http://127.0.0.1:9676/metrics'
+  - name: aws_ecs_exporter_local
+    url: 'http://127.0.0.1:9677/metrics'
+  - name: ircd_user_exporter_local
+    url: 'http://127.0.0.1:9678/metrics'
+  - name: aws_health_exporter_local
+    url: 'http://127.0.0.1:9679/metrics'
+  - name: suses_sap_host_exporter_local
+    url: 'http://127.0.0.1:9680/metrics'
+  - name: myfitnesspal_exporter_local
+    url: 'http://127.0.0.1:9681/metrics'
+  - name: powder_monkey_local
+    url: 'http://127.0.0.1:9682/metrics'
+  - name: infiniband_exporter_local
+    url: 'http://127.0.0.1:9683/metrics'
+  - name: kibana_standalone_exporter_local
+    url: 'http://127.0.0.1:9684/metrics'
+  - name: eideticom_local
+    url: 'http://127.0.0.1:9685/metrics'
+  - name: aws_ec2_exporter_local
+    url: 'http://127.0.0.1:9686/metrics'
+  - name: gitaly_blackbox_exporter_local
+    url: 'http://127.0.0.1:9687/metrics'
+  - name: lan_server_modbus_exporter_local
+    url: 'http://127.0.0.1:9689/metrics'
+  - name: tcp_longterm_connection_exporter_local
+    url: 'http://127.0.0.1:9690/metrics'
+  - name: celery/redis_exporter_local
+    url: 'http://127.0.0.1:9691/metrics'
+  - name: gcp_gce_exporter_local
+    url: 'http://127.0.0.1:9692/metrics'
+  - name: sigma_air_manager_exporter_local
+    url: 'http://127.0.0.1:9693/metrics'
+  - name: per-user_usage_exporter_for_cisco_xe_lnss_local
+    url: 'http://127.0.0.1:9694/metrics'
+  - name: cifs_exporter_local
+    url: 'http://127.0.0.1:9695/metrics'
+  - name: jitsi_videobridge_exporter_local
+    url: 'http://127.0.0.1:9696/metrics'
+  - name: tendermint_blockchain_exporter_local
+    url: 'http://127.0.0.1:9697/metrics'
+  - name: integrated_dell_remote_access_controller_idrac_exporter_local
+    url: 'http://127.0.0.1:9698/metrics'
+  - name: pyncette_exporter_local
+    url: 'http://127.0.0.1:9699/metrics'
+  - name: jitsi_meet_exporter_local
+    url: 'http://127.0.0.1:9700/metrics'
+  - name: workbook_exporter_local
+    url: 'http://127.0.0.1:9701/metrics'
+  - name: homeplug_plc_exporter_local
+    url: 'http://127.0.0.1:9702/metrics'
+  - name: vircadia_local
+    url: 'http://127.0.0.1:9703/metrics'
+  - name: linux_tc_exporter_local
+    url: 'http://127.0.0.1:9704/metrics'
+  - name: upc_connect_box_exporter_local
+    url: 'http://127.0.0.1:9705/metrics'
+  - name: postfix_exporter_local
+    url: 'http://127.0.0.1:9706/metrics'
+  - name: radarr_exporter_local
+    url: 'http://127.0.0.1:9707/metrics'
+  - name: sonarr_exporter_local
+    url: 'http://127.0.0.1:9708/metrics'
+  - name: hadoop_hdfs_fsimage_exporter_local
+    url: 'http://127.0.0.1:9709/metrics'
+  - name: nut-exporter_local
+    url: 'http://127.0.0.1:9710/metrics'
+  - name: cloudflare_flan_scan_report_exporter_local
+    url: 'http://127.0.0.1:9711/metrics'
+  - name: siemens_s7_plc_exporter_local
+    url: 'http://127.0.0.1:9712/metrics'
+  - name: glusterfs_exporter_local
+    url: 'http://127.0.0.1:9713/metrics'
+  - name: fritzbox_exporter_local
+    url: 'http://127.0.0.1:9714/metrics'
+  - name: twincat_ads_web_service_exporter_local
+    url: 'http://127.0.0.1:9715/metrics'
+  - name: signald_webhook_receiver_local
+    url: 'http://127.0.0.1:9716/metrics'
+  - name: tplink_easysmart_switch_exporter_local
+    url: 'http://127.0.0.1:9717/metrics'
+  - name: warp10_exporter_local
+    url: 'http://127.0.0.1:9718/metrics'
+  - name: pgpool-ii_exporter_local
+    url: 'http://127.0.0.1:9719/metrics'
+  - name: moodle_db_exporter_local
+    url: 'http://127.0.0.1:9720/metrics'
+  - name: gtp_exporter_local
+    url: 'http://127.0.0.1:9721/metrics'
+  - name: miele_exporter_local
+    url: 'http://127.0.0.1:9722/metrics'
+  - name: freeswitch_exporter_local
+    url: 'http://127.0.0.1:9724/metrics'
+  - name: sunnyboy_exporter_local
+    url: 'http://127.0.0.1:9725/metrics'
+  - name: python_rq_exporter_local
+    url: 'http://127.0.0.1:9726/metrics'
+  - name: ctdb_exporter_local
+    url: 'http://127.0.0.1:9727/metrics'
+  - name: nginx-rtmp_exporter_local
+    url: 'http://127.0.0.1:9728/metrics'
+  - name: libvirtd_exporter_local
+    url: 'http://127.0.0.1:9729/metrics'
+  - name: lynis_exporter_local
+    url: 'http://127.0.0.1:9730/metrics'
+  - name: nebula_mam_exporter_local
+    url: 'http://127.0.0.1:9731/metrics'
+  - name: nftables_exporter_local
+    url: 'http://127.0.0.1:9732/metrics'
+  - name: honeypot_exporter_local
+    url: 'http://127.0.0.1:9733/metrics'
+  - name: a10-networks_prometheus_exporter_local
+    url: 'http://127.0.0.1:9734/metrics'
+  - name: webweaver_local
+    url: 'http://127.0.0.1:9735/metrics'
+  - name: mongodb_query_exporter_local
+    url: 'http://127.0.0.1:9736/metrics'
+  - name: folding@home_exporter_local
+    url: 'http://127.0.0.1:9737/metrics'
+  - name: processor_counter_monitor_exporter_local
+    url: 'http://127.0.0.1:9738/metrics'
+  - name: kafka_consumer_lag_monitoring_local
+    url: 'http://127.0.0.1:9739/metrics'
+  - name: flightdeck_local
+    url: 'http://127.0.0.1:9740/metrics'
+  - name: ibm_spectrum_exporter_local
+    url: 'http://127.0.0.1:9741/metrics'
+  - name: transmission-exporter_local
+    url: 'http://127.0.0.1:9742/metrics'
+  - name: sma-exporter_local
+    url: 'http://127.0.0.1:9743/metrics'
+  - name: site24x7_exporter_local
+    url: 'http://127.0.0.1:9803/metrics'
+  - name: envoy_proxy_local
+    url: 'http://127.0.0.1:9901/metrics'
+  - name: nginx_vts_exporter_local
+    url: 'http://127.0.0.1:9913/metrics'
+  - name: login_exporter_local
+    url: 'http://127.0.0.1:9980/metrics'
+  - name: filestat_exporter_local
+    url: 'http://127.0.0.1:9943/metrics'
+  - name: sia_exporter_local
+    url: 'http://127.0.0.1:9983/metrics'
+  - name: couchdb_exporter_local
+    url: 'http://127.0.0.1:9984/metrics'
+  - name: netapp_solidfire_exporter_local
+    url: 'http://127.0.0.1:9987/metrics'
+  - name: wildfly_exporter_local
+    url: 'http://127.0.0.1:9990/metrics'
+  - name: prometheus-jdbc-exporter_local
+    url: 'http://127.0.0.1:5555/metrics'
+  - name: midonet_agent_local
+    url: 'http://127.0.0.1:7300/metrics'
+  - name: trickster_local
+    url: 'http://127.0.0.1:8082/metrics'
+  - name: fawkes_local
+    url: 'http://127.0.0.1:8088/metrics'
+  - name: prom2teams_local
+    url: 'http://127.0.0.1:8089/metrics'
+  - name: phabricator_webhook_for_alertmanager_local
+    url: 'http://127.0.0.1:8292/metrics'
+  - name: ha_proxy_v2_plus_local
     url: 'http://127.0.0.1:8404/metrics'
-  - name: rabbitmq_local
-    url: 'http://127.0.0.1:15692/metrics'
+  - name: rds_exporter_local
+    url: 'http://127.0.0.1:9042/metrics'
+  - name: telegram_bot_for_alertmanager_local
+    url: 'http://127.0.0.1:9087/metrics'
+  - name: jiralert_local
+    url: 'http://127.0.0.1:9097/metrics'
+  - name: storidge_exporter_local
+    url: 'http://127.0.0.1:16995/metrics'
+  - name: transmission_exporter_local
+    url: 'http://127.0.0.1:19091/metrics'
+  - name: fluent_plugin_for_prometheus_local
+    url: 'http://127.0.0.1:24231/metrics'
+  - name: proxysql_exporter_local
+    url: 'http://127.0.0.1:42004/metrics'
+  - name: pcp_exporter_local
+    url: 'http://127.0.0.1:44323/metrics'
+  - name: dcos_exporter_local
+    url: 'http://127.0.0.1:61091/metrics'

--- a/config/go.d/prometheus.conf
+++ b/config/go.d/prometheus.conf
@@ -178,7 +178,7 @@ jobs:
     url: 'http://127.0.0.1:9110/metrics'
   - name: expvar_exporter_local
     url: 'http://127.0.0.1:9111/metrics'
-  - name: promacct_pcap-based_network_traffic_accounting_local
+  - name: promacct_pcap-based_network_traffic_accounting_exporter_local
     url: 'http://127.0.0.1:9112/metrics'
   - name: nginx_exporter_local
     url: 'http://127.0.0.1:9113/metrics'
@@ -214,13 +214,13 @@ jobs:
     url: 'http://127.0.0.1:9128/metrics'
   - name: haproxy_log_exporter_local
     url: 'http://127.0.0.1:9129/metrics'
-  - name: unifi_poller_local
+  - name: unifi_poller_exporter_local
     url: 'http://127.0.0.1:9130/metrics'
   - name: varnish_exporter_local
     url: 'http://127.0.0.1:9131/metrics'
   - name: airflow_exporter_local
     url: 'http://127.0.0.1:9132/metrics'
-  - name: fritz!box_exporter_local
+  - name: fritz_box_exporter_local
     url: 'http://127.0.0.1:9133/metrics'
   - name: zfs_exporter_local
     url: 'http://127.0.0.1:9134/metrics'
@@ -258,11 +258,11 @@ jobs:
     url: 'http://127.0.0.1:9151/metrics'
   - name: command_runner_exporter_local
     url: 'http://127.0.0.1:9152/metrics'
-  - name: coredns_local
+  - name: coredns_exporter_local
     url: 'http://127.0.0.1:9153/metrics'
   - name: postfix_exporter_local
     url: 'http://127.0.0.1:9154/metrics'
-  - name: vsphere_graphite_local
+  - name: vsphere_graphite_exporter_local
     url: 'http://127.0.0.1:9155/metrics'
   - name: webdriver_exporter_local
     url: 'http://127.0.0.1:9156/metrics'
@@ -286,7 +286,7 @@ jobs:
     url: 'http://127.0.0.1:9166/metrics'
   - name: unbound_exporter_local
     url: 'http://127.0.0.1:9167/metrics'
-  - name: gitlab-monitor_local
+  - name: gitlab-monitor_exporter_local
     url: 'http://127.0.0.1:9168/metrics'
   - name: lustre_exporter_local
     url: 'http://127.0.0.1:9169/metrics'
@@ -328,7 +328,7 @@ jobs:
     url: 'http://127.0.0.1:9187/metrics'
   - name: crypto_exporter_local
     url: 'http://127.0.0.1:9188/metrics'
-  - name: hetzner_cloud_csi_driver_nodes_local
+  - name: hetzner_cloud_csi_driver_nodes_exporter_local
     url: 'http://127.0.0.1:9189/metrics'
   - name: bosh_exporter_local
     url: 'http://127.0.0.1:9190/metrics'
@@ -374,13 +374,13 @@ jobs:
     url: 'http://127.0.0.1:9213/metrics'
   - name: mqtt_blackbox_exporter_local
     url: 'http://127.0.0.1:9214/metrics'
-  - name: prometheus_graphite_bridge_local
+  - name: prometheus_graphite_bridge_exporter_local
     url: 'http://127.0.0.1:9215/metrics'
   - name: mongodb_exporter_local
     url: 'http://127.0.0.1:9216/metrics'
   - name: consul_agent_exporter_local
     url: 'http://127.0.0.1:9217/metrics'
-  - name: promql-guard_local
+  - name: promql-guard_exporter_local
     url: 'http://127.0.0.1:9218/metrics'
   - name: ssl_certificate_exporter_local
     url: 'http://127.0.0.1:9219/metrics'
@@ -396,13 +396,13 @@ jobs:
     url: 'http://127.0.0.1:9224/metrics'
   - name: mailexporter_local
     url: 'http://127.0.0.1:9225/metrics'
-  - name: allas_local
+  - name: allas_exporter_local
     url: 'http://127.0.0.1:9226/metrics'
   - name: proc_exporter_local
     url: 'http://127.0.0.1:9227/metrics'
   - name: flussonic_exporter_local
     url: 'http://127.0.0.1:9228/metrics'
-  - name: gitlab-workhorse_local
+  - name: gitlab-workhorse_exporter_local
     url: 'http://127.0.0.1:9229/metrics'
   - name: network_ups_tools_exporter_local
     url: 'http://127.0.0.1:9230/metrics'
@@ -420,7 +420,7 @@ jobs:
     url: 'http://127.0.0.1:9236/metrics'
   - name: sql_exporter_local
     url: 'http://127.0.0.1:9237/metrics'
-  - name: uwsgi_expoter_local
+  - name: uwsgi_expoter_exporter_local
     url: 'http://127.0.0.1:9238/metrics'
   - name: surfboard_exporter_local
     url: 'http://127.0.0.1:9239/metrics'
@@ -434,15 +434,15 @@ jobs:
     url: 'http://127.0.0.1:9243/metrics'
   - name: moby_container_exporter_local
     url: 'http://127.0.0.1:9244/metrics'
-  - name: naemon_/_nagios_exporter_local
+  - name: naemon_nagios_exporter_local
     url: 'http://127.0.0.1:9245/metrics'
-  - name: smartpi_local
+  - name: smartpi_exporter_local
     url: 'http://127.0.0.1:9246/metrics'
   - name: sphinx_exporter_local
     url: 'http://127.0.0.1:9247/metrics'
   - name: freebsd_gstat_exporter_local
     url: 'http://127.0.0.1:9248/metrics'
-  - name: apache_flink_metrics_reporter_local
+  - name: apache_flink_metrics_reporter_exporter_local
     url: 'http://127.0.0.1:9249/metrics'
   - name: opentsdb_exporter_local
     url: 'http://127.0.0.1:9250/metrics'
@@ -458,7 +458,7 @@ jobs:
     url: 'http://127.0.0.1:9255/metrics'
   - name: td-agent_exporter_local
     url: 'http://127.0.0.1:9256/metrics'
-  - name: s_m_a_r_t__exporter_local
+  - name: smart_exporter_local
     url: 'http://127.0.0.1:9257/metrics'
   - name: hello_sense_exporter_local
     url: 'http://127.0.0.1:9258/metrics'
@@ -480,7 +480,7 @@ jobs:
     url: 'http://127.0.0.1:9266/metrics'
   - name: nagios_livestatus_exporter_local
     url: 'http://127.0.0.1:9267/metrics'
-  - name: cratedb_remote_remote_read/write_adapter_local
+  - name: cratedb_remote_remote_read_write_adapter_exporter_local
     url: 'http://127.0.0.1:9268/metrics'
   - name: fluent-agent-lite_exporter_local
     url: 'http://127.0.0.1:9269/metrics'
@@ -510,17 +510,17 @@ jobs:
     url: 'http://127.0.0.1:9281/metrics'
   - name: freeswitch_exporter_local
     url: 'http://127.0.0.1:9282/metrics'
-  - name: ceph_ceph-mgr_prometheus_plugin_local
+  - name: ceph_ceph-mgr_prometheus_plugin_exporter_local
     url: 'http://127.0.0.1:9283/metrics'
-  - name: gobetween_local
+  - name: gobetween_exporter_local
     url: 'http://127.0.0.1:9284/metrics'
   - name: database_exporter_local
     url: 'http://127.0.0.1:9285/metrics'
   - name: vdo_compression_and_deduplication_exporter_local
     url: 'http://127.0.0.1:9286/metrics'
-  - name: ceph_iscsi_gateway_statistics_local
+  - name: ceph_iscsi_gateway_statistics_exporter_local
     url: 'http://127.0.0.1:9287/metrics'
-  - name: consrv_local
+  - name: consrv_exporter_local
     url: 'http://127.0.0.1:9288/metrics'
   - name: lovoos_ipmi_exporter_local
     url: 'http://127.0.0.1:9289/metrics'
@@ -532,7 +532,7 @@ jobs:
     url: 'http://127.0.0.1:9292/metrics'
   - name: connection_status_exporter_local
     url: 'http://127.0.0.1:9293/metrics'
-  - name: miflora_/_flower_care_exporter_local
+  - name: miflora_flower_care_exporter_local
     url: 'http://127.0.0.1:9294/metrics'
   - name: freifunk_exporter_local
     url: 'http://127.0.0.1:9295/metrics'
@@ -542,7 +542,7 @@ jobs:
     url: 'http://127.0.0.1:9297/metrics'
   - name: generic_exporter_local
     url: 'http://127.0.0.1:9298/metrics'
-  - name: exporter_aggregator_local
+  - name: exporter_aggregator_exporter_local
     url: 'http://127.0.0.1:9299/metrics'
   - name: squid_exporter_local
     url: 'http://127.0.0.1:9301/metrics'
@@ -586,7 +586,7 @@ jobs:
     url: 'http://127.0.0.1:9321/metrics'
   - name: haproxy_abuser_exporter_local
     url: 'http://127.0.0.1:9322/metrics'
-  - name: docker_prometheus_metrics_local
+  - name: docker_prometheus_metrics_exporter_local
     url: 'http://127.0.0.1:9323/metrics'
   - name: bird_routing_daemon_exporter_local
     url: 'http://127.0.0.1:9324/metrics'
@@ -602,7 +602,7 @@ jobs:
     url: 'http://127.0.0.1:9329/metrics'
   - name: openldap_metrics_exporter_local
     url: 'http://127.0.0.1:9330/metrics'
-  - name: influx-spout_prometheus_metrics_local
+  - name: influx-spout_prometheus_metrics_exporter_local
     url: 'http://127.0.0.1:9331/metrics'
   - name: network_exporter_local
     url: 'http://127.0.0.1:9332/metrics'
@@ -614,7 +614,7 @@ jobs:
     url: 'http://127.0.0.1:9335/metrics'
   - name: mediacom_internet_usage_exporter_local
     url: 'http://127.0.0.1:9336/metrics'
-  - name: mqttgateway_local
+  - name: mqttgateway_exporter_local
     url: 'http://127.0.0.1:9337/metrics'
   - name: aws_s3_exporter_local
     url: 'http://127.0.0.1:9339/metrics'
@@ -640,7 +640,7 @@ jobs:
     url: 'http://127.0.0.1:9349/metrics'
   - name: thousandeyes_exporter_local
     url: 'http://127.0.0.1:9350/metrics'
-  - name: wal-e/wal-g_exporter_local
+  - name: wal-e_wal-g_exporter_local
     url: 'http://127.0.0.1:9351/metrics'
   - name: nature_remo_exporter_local
     url: 'http://127.0.0.1:9352/metrics'
@@ -648,7 +648,7 @@ jobs:
     url: 'http://127.0.0.1:9353/metrics'
   - name: deluge_exporter_local
     url: 'http://127.0.0.1:9354/metrics'
-  - name: nightwatch_js_exporter_local
+  - name: nightwatchjs_exporter_local
     url: 'http://127.0.0.1:9355/metrics'
   - name: pacemaker_exporter_local
     url: 'http://127.0.0.1:9356/metrics'
@@ -656,7 +656,7 @@ jobs:
     url: 'http://127.0.0.1:9357/metrics'
   - name: performance_counters_exporter_local
     url: 'http://127.0.0.1:9358/metrics'
-  - name: sidekiq_prometheus_local
+  - name: sidekiq_prometheus_exporter_local
     url: 'http://127.0.0.1:9359/metrics'
   - name: powershell_exporter_local
     url: 'http://127.0.0.1:9360/metrics'
@@ -664,7 +664,7 @@ jobs:
     url: 'http://127.0.0.1:9361/metrics'
   - name: cisco_exporter_local
     url: 'http://127.0.0.1:9362/metrics'
-  - name: clickhouse_local
+  - name: clickhouse_exporter_local
     url: 'http://127.0.0.1:9363/metrics'
   - name: continent8_exporter_local
     url: 'http://127.0.0.1:9364/metrics'
@@ -676,21 +676,21 @@ jobs:
     url: 'http://127.0.0.1:9367/metrics'
   - name: ethereum_client_exporter_local
     url: 'http://127.0.0.1:9368/metrics'
-  - name: prometheus_pushprox_local
+  - name: prometheus_pushprox_exporter_local
     url: 'http://127.0.0.1:9369/metrics'
-  - name: u-bmc_local
+  - name: u-bmc_exporter_local
     url: 'http://127.0.0.1:9370/metrics'
   - name: conntrack-stats-exporter_local
     url: 'http://127.0.0.1:9371/metrics'
-  - name: appmetrics/prometheus_local
+  - name: appmetrics_prometheus_exporter_local
     url: 'http://127.0.0.1:9372/metrics'
-  - name: gcp_service_discovery_local
+  - name: gcp_service_discovery_exporter_local
     url: 'http://127.0.0.1:9373/metrics'
-  - name: smokeping_prober_local
+  - name: smokeping_prober_exporter_local
     url: 'http://127.0.0.1:9374/metrics'
   - name: particle_exporter_local
     url: 'http://127.0.0.1:9375/metrics'
-  - name: falco_local
+  - name: falco_exporter_local
     url: 'http://127.0.0.1:9376/metrics'
   - name: cisco_aci_exporter_local
     url: 'http://127.0.0.1:9377/metrics'
@@ -722,13 +722,13 @@ jobs:
     url: 'http://127.0.0.1:9389/metrics'
   - name: kannel_exporter_local
     url: 'http://127.0.0.1:9390/metrics'
-  - name: concourse_prometheus_metrics_local
+  - name: concourse_prometheus_metrics_exporter_local
     url: 'http://127.0.0.1:9391/metrics'
   - name: generic_command_line_output_exporter_local
     url: 'http://127.0.0.1:9392/metrics'
   - name: patroni_exporter_local
     url: 'http://127.0.0.1:9393/metrics'
-  - name: alertmanager_github_webhook_receiver_local
+  - name: alertmanager_github_webhook_receiver_exporter_local
     url: 'http://127.0.0.1:9393/metrics'
   - name: ruby_prometheus_exporter_local
     url: 'http://127.0.0.1:9394/metrics'
@@ -736,7 +736,7 @@ jobs:
     url: 'http://127.0.0.1:9395/metrics'
   - name: monerod_exporter_local
     url: 'http://127.0.0.1:9396/metrics'
-  - name: comap_local
+  - name: comap_exporter_local
     url: 'http://127.0.0.1:9397/metrics'
   - name: open_hardware_monitor_exporter_local
     url: 'http://127.0.0.1:9398/metrics'
@@ -772,7 +772,7 @@ jobs:
     url: 'http://127.0.0.1:9413/metrics'
   - name: homey_exporter_local
     url: 'http://127.0.0.1:9414/metrics'
-  - name: cloudwatch_read_adapter_local
+  - name: cloudwatch_read_adapter_exporter_local
     url: 'http://127.0.0.1:9415/metrics'
   - name: hp_ilo_metrics_exporter_local
     url: 'http://127.0.0.1:9416/metrics'
@@ -784,7 +784,7 @@ jobs:
     url: 'http://127.0.0.1:9419/metrics'
   - name: couchbase_exporter_local
     url: 'http://127.0.0.1:9420/metrics'
-  - name: apicast_local
+  - name: apicast_exporter_local
     url: 'http://127.0.0.1:9421/metrics'
   - name: jolokia_exporter_local
     url: 'http://127.0.0.1:9422/metrics'
@@ -802,7 +802,7 @@ jobs:
     url: 'http://127.0.0.1:9428/metrics'
   - name: uptimerobot_exporter_local
     url: 'http://127.0.0.1:9429/metrics'
-  - name: corerad_local
+  - name: corerad_exporter_local
     url: 'http://127.0.0.1:9430/metrics'
   - name: hpfeeds_broker_exporter_local
     url: 'http://127.0.0.1:9431/metrics'
@@ -838,7 +838,7 @@ jobs:
     url: 'http://127.0.0.1:9447/metrics'
   - name: eventstore_exporter_local
     url: 'http://127.0.0.1:9448/metrics'
-  - name: omero_server_exporter_local
+  - name: omeroserver_exporter_local
     url: 'http://127.0.0.1:9449/metrics'
   - name: habitat_exporter_local
     url: 'http://127.0.0.1:9450/metrics'
@@ -846,7 +846,7 @@ jobs:
     url: 'http://127.0.0.1:9451/metrics'
   - name: freebsd_jail_exporter_local
     url: 'http://127.0.0.1:9452/metrics'
-  - name: midonet-kubernetes_local
+  - name: midonet-kubernetes_exporter_local
     url: 'http://127.0.0.1:9453/metrics'
   - name: nvidia_smi_exporter_local
     url: 'http://127.0.0.1:9454/metrics'
@@ -856,23 +856,23 @@ jobs:
     url: 'http://127.0.0.1:9456/metrics'
   - name: files_content_exporter_local
     url: 'http://127.0.0.1:9457/metrics'
-  - name: rocket_chat_exporter_local
+  - name: rocketchat_exporter_local
     url: 'http://127.0.0.1:9458/metrics'
   - name: yarn_exporter_local
     url: 'http://127.0.0.1:9459/metrics'
   - name: hana_exporter_local
     url: 'http://127.0.0.1:9460/metrics'
-  - name: aws_lambda_read_adapter_local
+  - name: aws_lambda_read_adapter_exporter_local
     url: 'http://127.0.0.1:9461/metrics'
   - name: php_opcache_exporter_local
     url: 'http://127.0.0.1:9462/metrics'
-  - name: virgin_media/liberty_global_hub3_exporter_local
+  - name: virgin_media_liberty_global_hub3_exporter_local
     url: 'http://127.0.0.1:9463/metrics'
   - name: opencensus-nodejs_prometheus_exporter_local
     url: 'http://127.0.0.1:9464/metrics'
-  - name: hetzner_cloud_k8s_cloud_controller_manager_local
+  - name: hetzner_cloud_k8s_cloud_controller_manager_exporter_local
     url: 'http://127.0.0.1:9465/metrics'
-  - name: mqtt_push_gateway_local
+  - name: mqtt_push_gateway_exporter_local
     url: 'http://127.0.0.1:9466/metrics'
   - name: nginx-prometheus-shiny-exporter_local
     url: 'http://127.0.0.1:9467/metrics'
@@ -884,13 +884,13 @@ jobs:
     url: 'http://127.0.0.1:9470/metrics'
   - name: lxc-exporter_local
     url: 'http://127.0.0.1:9471/metrics'
-  - name: hetzner_cloud_csi_driver_controller_local
+  - name: hetzner_cloud_csi_driver_controller_exporter_local
     url: 'http://127.0.0.1:9472/metrics'
   - name: stellar-core-exporter_local
     url: 'http://127.0.0.1:9473/metrics'
   - name: libvirtd_exporter_local
     url: 'http://127.0.0.1:9474/metrics'
-  - name: wgipamd_local
+  - name: wgipamd_exporter_local
     url: 'http://127.0.0.1:9475/metrics'
   - name: ovn_metrics_exporter_local
     url: 'http://127.0.0.1:9476/metrics'
@@ -920,11 +920,11 @@ jobs:
     url: 'http://127.0.0.1:9488/metrics'
   - name: tezos_node_metrics_exporter_local
     url: 'http://127.0.0.1:9489/metrics'
-  - name: exporter_for_docker_libnetwork_plugin_for_ovn_local
+  - name: exporter_for_docker_libnetwork_plugin_for_ovn_exporter_local
     url: 'http://127.0.0.1:9490/metrics'
-  - name: docker_container_stats_exporter_`docker_ps`_local
+  - name: docker_container_stats_exporter_docker_ps_exporter_local
     url: 'http://127.0.0.1:9491/metrics'
-  - name: azure_exporter_monitor_and_usage_local
+  - name: azure_exporter_monitor_and_usage_exporter_local
     url: 'http://127.0.0.1:9492/metrics'
   - name: prosafe_exporter_local
     url: 'http://127.0.0.1:9493/metrics'
@@ -932,7 +932,7 @@ jobs:
     url: 'http://127.0.0.1:9494/metrics'
   - name: ingestor_exporter_local
     url: 'http://127.0.0.1:9495/metrics'
-  - name: 389ds/ipa_exporter_local
+  - name: 389ds_ipa_exporter_local
     url: 'http://127.0.0.1:9496/metrics'
   - name: immudb_exporter_local
     url: 'http://127.0.0.1:9497/metrics'
@@ -972,7 +972,7 @@ jobs:
     url: 'http://127.0.0.1:9515/metrics'
   - name: prometheus_speedtest_exporter_local
     url: 'http://127.0.0.1:9516/metrics'
-  - name: matroschka_prober_local
+  - name: matroschka_prober_exporter_local
     url: 'http://127.0.0.1:9517/metrics'
   - name: crypto_stock_exchanges_funds_exporter_local
     url: 'http://127.0.0.1:9518/metrics'
@@ -1004,7 +1004,7 @@ jobs:
     url: 'http://127.0.0.1:9531/metrics'
   - name: snyk_exporter_local
     url: 'http://127.0.0.1:9532/metrics'
-  - name: network_exporter_for_cisco_api_local
+  - name: network_exporter_for_cisco_api_exporter_local
     url: 'http://127.0.0.1:9533/metrics'
   - name: humio_exporter_local
     url: 'http://127.0.0.1:9534/metrics'
@@ -1012,9 +1012,9 @@ jobs:
     url: 'http://127.0.0.1:9535/metrics'
   - name: ipsec_exporter_local
     url: 'http://127.0.0.1:9536/metrics'
-  - name: cri-o_local
+  - name: cri-o_exporter_local
     url: 'http://127.0.0.1:9537/metrics'
-  - name: bull_queue_local
+  - name: bull_queue_exporter_local
     url: 'http://127.0.0.1:9538/metrics'
   - name: modemmanager_exporter_local
     url: 'http://127.0.0.1:9539/metrics'
@@ -1072,13 +1072,13 @@ jobs:
     url: 'http://127.0.0.1:9564/metrics'
   - name: bminer_exporter_local
     url: 'http://127.0.0.1:9565/metrics'
-  - name: rabbitmq_cli_consumer_local
+  - name: rabbitmq_cli_consumer_exporter_local
     url: 'http://127.0.0.1:9566/metrics'
-  - name: alertsnitch_local
+  - name: alertsnitch_exporter_local
     url: 'http://127.0.0.1:9567/metrics'
   - name: dell_poweredge_ipmi_exporter_local
     url: 'http://127.0.0.1:9568/metrics'
-  - name: hvpa_controller_local
+  - name: hvpa_controller_exporter_local
     url: 'http://127.0.0.1:9569/metrics'
   - name: vpa_exporter_local
     url: 'http://127.0.0.1:9570/metrics'
@@ -1102,7 +1102,7 @@ jobs:
     url: 'http://127.0.0.1:9580/metrics'
   - name: codenotary_vcn_exporter_local
     url: 'http://127.0.0.1:9581/metrics'
-  - name: signatory_a_remote_operation_signer_for_tezos_local
+  - name: signatory_a_remote_operation_signer_for_tezos_exporter_local
     url: 'http://127.0.0.1:9583/metrics'
   - name: bunnycdn_exporter_local
     url: 'http://127.0.0.1:9584/metrics'
@@ -1138,7 +1138,7 @@ jobs:
     url: 'http://127.0.0.1:9601/metrics'
   - name: modbus_exporter_local
     url: 'http://127.0.0.1:9602/metrics'
-  - name: xen_exporter_using_xenlight_local
+  - name: xen_exporter_using_xenlight_exporter_local
     url: 'http://127.0.0.1:9603/metrics'
   - name: xmpp_blackbox_exporter_local
     url: 'http://127.0.0.1:9604/metrics'
@@ -1184,13 +1184,13 @@ jobs:
     url: 'http://127.0.0.1:9624/metrics'
   - name: bareos_exporter_local
     url: 'http://127.0.0.1:9625/metrics'
-  - name: hockeypuck_local
+  - name: hockeypuck_exporter_local
     url: 'http://127.0.0.1:9626/metrics'
   - name: artifactory_exporter_local
     url: 'http://127.0.0.1:9627/metrics'
   - name: solace_pubsub_plus_exporter_local
     url: 'http://127.0.0.1:9628/metrics'
-  - name: prometheus_gitlab_notifier_local
+  - name: prometheus_gitlab_notifier_exporter_local
     url: 'http://127.0.0.1:9629/metrics'
   - name: nftables_exporter_local
     url: 'http://127.0.0.1:9630/metrics'
@@ -1218,7 +1218,7 @@ jobs:
     url: 'http://127.0.0.1:9641/metrics'
   - name: bugsnag_exporter_local
     url: 'http://127.0.0.1:9642/metrics'
-  - name: exporter_for_grouped_process_local
+  - name: exporter_for_grouped_process_exporter_local
     url: 'http://127.0.0.1:9644/metrics'
   - name: burp_exporter_local
     url: 'http://127.0.0.1:9645/metrics'
@@ -1242,7 +1242,7 @@ jobs:
     url: 'http://127.0.0.1:9654/metrics'
   - name: kube-netc_exporter_local
     url: 'http://127.0.0.1:9655/metrics'
-  - name: matrix_local
+  - name: matrix_exporter_local
     url: 'http://127.0.0.1:9656/metrics'
   - name: krill_exporter_local
     url: 'http://127.0.0.1:9657/metrics'
@@ -1266,9 +1266,9 @@ jobs:
     url: 'http://127.0.0.1:9667/metrics'
   - name: suses_sap_hana_exporter_local
     url: 'http://127.0.0.1:9668/metrics'
-  - name: panopticon_native_metrics_local
+  - name: panopticon_native_metrics_exporter_local
     url: 'http://127.0.0.1:9669/metrics'
-  - name: flare_native_metrics_local
+  - name: flare_native_metrics_exporter_local
     url: 'http://127.0.0.1:9670/metrics'
   - name: aws_ec2_spot_exporter_local
     url: 'http://127.0.0.1:9671/metrics'
@@ -1292,13 +1292,13 @@ jobs:
     url: 'http://127.0.0.1:9680/metrics'
   - name: myfitnesspal_exporter_local
     url: 'http://127.0.0.1:9681/metrics'
-  - name: powder_monkey_local
+  - name: powder_monkey_exporter_local
     url: 'http://127.0.0.1:9682/metrics'
   - name: infiniband_exporter_local
     url: 'http://127.0.0.1:9683/metrics'
   - name: kibana_standalone_exporter_local
     url: 'http://127.0.0.1:9684/metrics'
-  - name: eideticom_local
+  - name: eideticom_exporter_local
     url: 'http://127.0.0.1:9685/metrics'
   - name: aws_ec2_exporter_local
     url: 'http://127.0.0.1:9686/metrics'
@@ -1308,13 +1308,13 @@ jobs:
     url: 'http://127.0.0.1:9689/metrics'
   - name: tcp_longterm_connection_exporter_local
     url: 'http://127.0.0.1:9690/metrics'
-  - name: celery/redis_exporter_local
+  - name: celery_redis_exporter_local
     url: 'http://127.0.0.1:9691/metrics'
   - name: gcp_gce_exporter_local
     url: 'http://127.0.0.1:9692/metrics'
   - name: sigma_air_manager_exporter_local
     url: 'http://127.0.0.1:9693/metrics'
-  - name: per-user_usage_exporter_for_cisco_xe_lnss_local
+  - name: per-user_usage_exporter_for_cisco_xe_lnss_exporter_local
     url: 'http://127.0.0.1:9694/metrics'
   - name: cifs_exporter_local
     url: 'http://127.0.0.1:9695/metrics'
@@ -1332,7 +1332,7 @@ jobs:
     url: 'http://127.0.0.1:9701/metrics'
   - name: homeplug_plc_exporter_local
     url: 'http://127.0.0.1:9702/metrics'
-  - name: vircadia_local
+  - name: vircadia_exporter_local
     url: 'http://127.0.0.1:9703/metrics'
   - name: linux_tc_exporter_local
     url: 'http://127.0.0.1:9704/metrics'
@@ -1358,7 +1358,7 @@ jobs:
     url: 'http://127.0.0.1:9714/metrics'
   - name: twincat_ads_web_service_exporter_local
     url: 'http://127.0.0.1:9715/metrics'
-  - name: signald_webhook_receiver_local
+  - name: signald_webhook_receiver_exporter_local
     url: 'http://127.0.0.1:9716/metrics'
   - name: tplink_easysmart_switch_exporter_local
     url: 'http://127.0.0.1:9717/metrics'
@@ -1394,17 +1394,17 @@ jobs:
     url: 'http://127.0.0.1:9733/metrics'
   - name: a10-networks_prometheus_exporter_local
     url: 'http://127.0.0.1:9734/metrics'
-  - name: webweaver_local
+  - name: webweaver_exporter_local
     url: 'http://127.0.0.1:9735/metrics'
   - name: mongodb_query_exporter_local
     url: 'http://127.0.0.1:9736/metrics'
-  - name: folding@home_exporter_local
+  - name: foldinghome_exporter_local
     url: 'http://127.0.0.1:9737/metrics'
   - name: processor_counter_monitor_exporter_local
     url: 'http://127.0.0.1:9738/metrics'
-  - name: kafka_consumer_lag_monitoring_local
+  - name: kafka_consumer_lag_monitoring_exporter_local
     url: 'http://127.0.0.1:9739/metrics'
-  - name: flightdeck_local
+  - name: flightdeck_exporter_local
     url: 'http://127.0.0.1:9740/metrics'
   - name: ibm_spectrum_exporter_local
     url: 'http://127.0.0.1:9741/metrics'
@@ -1414,7 +1414,7 @@ jobs:
     url: 'http://127.0.0.1:9743/metrics'
   - name: site24x7_exporter_local
     url: 'http://127.0.0.1:9803/metrics'
-  - name: envoy_proxy_local
+  - name: envoy_proxy_exporter_local
     url: 'http://127.0.0.1:9901/metrics'
   - name: nginx_vts_exporter_local
     url: 'http://127.0.0.1:9913/metrics'
@@ -1432,29 +1432,29 @@ jobs:
     url: 'http://127.0.0.1:9990/metrics'
   - name: prometheus-jdbc-exporter_local
     url: 'http://127.0.0.1:5555/metrics'
-  - name: midonet_agent_local
+  - name: midonet_agent_exporter_local
     url: 'http://127.0.0.1:7300/metrics'
-  - name: trickster_local
+  - name: trickster_exporter_local
     url: 'http://127.0.0.1:8082/metrics'
-  - name: fawkes_local
+  - name: fawkes_exporter_local
     url: 'http://127.0.0.1:8088/metrics'
-  - name: prom2teams_local
+  - name: prom2teams_exporter_local
     url: 'http://127.0.0.1:8089/metrics'
-  - name: phabricator_webhook_for_alertmanager_local
+  - name: phabricator_webhook_for_alertmanager_exporter_local
     url: 'http://127.0.0.1:8292/metrics'
-  - name: ha_proxy_v2_plus_local
+  - name: ha_proxy_v2_plus_exporter_local
     url: 'http://127.0.0.1:8404/metrics'
   - name: rds_exporter_local
     url: 'http://127.0.0.1:9042/metrics'
-  - name: telegram_bot_for_alertmanager_local
+  - name: telegram_bot_for_alertmanager_exporter_local
     url: 'http://127.0.0.1:9087/metrics'
-  - name: jiralert_local
+  - name: jiralert_exporter_local
     url: 'http://127.0.0.1:9097/metrics'
   - name: storidge_exporter_local
     url: 'http://127.0.0.1:16995/metrics'
   - name: transmission_exporter_local
     url: 'http://127.0.0.1:19091/metrics'
-  - name: fluent_plugin_for_prometheus_local
+  - name: fluent_plugin_for_prometheus_exporter_local
     url: 'http://127.0.0.1:24231/metrics'
   - name: proxysql_exporter_local
     url: 'http://127.0.0.1:42004/metrics'

--- a/config/go.d/prometheus.conf
+++ b/config/go.d/prometheus.conf
@@ -155,7 +155,7 @@
 jobs:
   # https://github.com/prometheus/prometheus/wiki/Default-port-allocations
   - name: node_exporter_local
-      url: 'http://127.0.0.1:9100/metrics'
+    url: 'http://127.0.0.1:9100/metrics'
   - name: haproxy_exporter_local
     url: 'http://127.0.0.1:9101/metrics'
   - name: statsd_exporter_local
@@ -178,7 +178,7 @@ jobs:
     url: 'http://127.0.0.1:9110/metrics'
   - name: expvar_exporter_local
     url: 'http://127.0.0.1:9111/metrics'
-  - name: promacct_pcap-based_network_traffic_accounting_exporter_local
+  - name: promacct_pcap-based_network_traffic_accounting_local
     url: 'http://127.0.0.1:9112/metrics'
   - name: nginx_exporter_local
     url: 'http://127.0.0.1:9113/metrics'
@@ -214,7 +214,7 @@ jobs:
     url: 'http://127.0.0.1:9128/metrics'
   - name: haproxy_log_exporter_local
     url: 'http://127.0.0.1:9129/metrics'
-  - name: unifi_poller_exporter_local
+  - name: unifi_poller_local
     url: 'http://127.0.0.1:9130/metrics'
   - name: varnish_exporter_local
     url: 'http://127.0.0.1:9131/metrics'
@@ -258,11 +258,11 @@ jobs:
     url: 'http://127.0.0.1:9151/metrics'
   - name: command_runner_exporter_local
     url: 'http://127.0.0.1:9152/metrics'
-  - name: coredns_exporter_local
+  - name: coredns_local
     url: 'http://127.0.0.1:9153/metrics'
   - name: postfix_exporter_local
     url: 'http://127.0.0.1:9154/metrics'
-  - name: vsphere_graphite_exporter_local
+  - name: vsphere_graphite_local
     url: 'http://127.0.0.1:9155/metrics'
   - name: webdriver_exporter_local
     url: 'http://127.0.0.1:9156/metrics'
@@ -286,7 +286,7 @@ jobs:
     url: 'http://127.0.0.1:9166/metrics'
   - name: unbound_exporter_local
     url: 'http://127.0.0.1:9167/metrics'
-  - name: gitlab-monitor_exporter_local
+  - name: gitlab-monitor_local
     url: 'http://127.0.0.1:9168/metrics'
   - name: lustre_exporter_local
     url: 'http://127.0.0.1:9169/metrics'
@@ -328,7 +328,7 @@ jobs:
     url: 'http://127.0.0.1:9187/metrics'
   - name: crypto_exporter_local
     url: 'http://127.0.0.1:9188/metrics'
-  - name: hetzner_cloud_csi_driver_nodes_exporter_local
+  - name: hetzner_cloud_csi_driver_nodes_local
     url: 'http://127.0.0.1:9189/metrics'
   - name: bosh_exporter_local
     url: 'http://127.0.0.1:9190/metrics'
@@ -374,13 +374,13 @@ jobs:
     url: 'http://127.0.0.1:9213/metrics'
   - name: mqtt_blackbox_exporter_local
     url: 'http://127.0.0.1:9214/metrics'
-  - name: prometheus_graphite_bridge_exporter_local
+  - name: prometheus_graphite_bridge_local
     url: 'http://127.0.0.1:9215/metrics'
   - name: mongodb_exporter_local
     url: 'http://127.0.0.1:9216/metrics'
   - name: consul_agent_exporter_local
     url: 'http://127.0.0.1:9217/metrics'
-  - name: promql-guard_exporter_local
+  - name: promql-guard_local
     url: 'http://127.0.0.1:9218/metrics'
   - name: ssl_certificate_exporter_local
     url: 'http://127.0.0.1:9219/metrics'
@@ -396,13 +396,13 @@ jobs:
     url: 'http://127.0.0.1:9224/metrics'
   - name: mailexporter_local
     url: 'http://127.0.0.1:9225/metrics'
-  - name: allas_exporter_local
+  - name: allas_local
     url: 'http://127.0.0.1:9226/metrics'
   - name: proc_exporter_local
     url: 'http://127.0.0.1:9227/metrics'
   - name: flussonic_exporter_local
     url: 'http://127.0.0.1:9228/metrics'
-  - name: gitlab-workhorse_exporter_local
+  - name: gitlab-workhorse_local
     url: 'http://127.0.0.1:9229/metrics'
   - name: network_ups_tools_exporter_local
     url: 'http://127.0.0.1:9230/metrics'
@@ -420,7 +420,7 @@ jobs:
     url: 'http://127.0.0.1:9236/metrics'
   - name: sql_exporter_local
     url: 'http://127.0.0.1:9237/metrics'
-  - name: uwsgi_expoter_exporter_local
+  - name: uwsgi_expoter_local
     url: 'http://127.0.0.1:9238/metrics'
   - name: surfboard_exporter_local
     url: 'http://127.0.0.1:9239/metrics'
@@ -436,13 +436,13 @@ jobs:
     url: 'http://127.0.0.1:9244/metrics'
   - name: naemon_nagios_exporter_local
     url: 'http://127.0.0.1:9245/metrics'
-  - name: smartpi_exporter_local
+  - name: smartpi_local
     url: 'http://127.0.0.1:9246/metrics'
   - name: sphinx_exporter_local
     url: 'http://127.0.0.1:9247/metrics'
   - name: freebsd_gstat_exporter_local
     url: 'http://127.0.0.1:9248/metrics'
-  - name: apache_flink_metrics_reporter_exporter_local
+  - name: apache_flink_metrics_reporter_local
     url: 'http://127.0.0.1:9249/metrics'
   - name: opentsdb_exporter_local
     url: 'http://127.0.0.1:9250/metrics'
@@ -480,7 +480,7 @@ jobs:
     url: 'http://127.0.0.1:9266/metrics'
   - name: nagios_livestatus_exporter_local
     url: 'http://127.0.0.1:9267/metrics'
-  - name: cratedb_remote_remote_read_write_adapter_exporter_local
+  - name: cratedb_remote_remote_read_write_adapter_local
     url: 'http://127.0.0.1:9268/metrics'
   - name: fluent-agent-lite_exporter_local
     url: 'http://127.0.0.1:9269/metrics'
@@ -510,17 +510,17 @@ jobs:
     url: 'http://127.0.0.1:9281/metrics'
   - name: freeswitch_exporter_local
     url: 'http://127.0.0.1:9282/metrics'
-  - name: ceph_ceph-mgr_prometheus_plugin_exporter_local
+  - name: ceph_ceph-mgr_prometheus_plugin_local
     url: 'http://127.0.0.1:9283/metrics'
-  - name: gobetween_exporter_local
+  - name: gobetween_local
     url: 'http://127.0.0.1:9284/metrics'
   - name: database_exporter_local
     url: 'http://127.0.0.1:9285/metrics'
   - name: vdo_compression_and_deduplication_exporter_local
     url: 'http://127.0.0.1:9286/metrics'
-  - name: ceph_iscsi_gateway_statistics_exporter_local
+  - name: ceph_iscsi_gateway_statistics_local
     url: 'http://127.0.0.1:9287/metrics'
-  - name: consrv_exporter_local
+  - name: consrv_local
     url: 'http://127.0.0.1:9288/metrics'
   - name: lovoos_ipmi_exporter_local
     url: 'http://127.0.0.1:9289/metrics'
@@ -542,7 +542,7 @@ jobs:
     url: 'http://127.0.0.1:9297/metrics'
   - name: generic_exporter_local
     url: 'http://127.0.0.1:9298/metrics'
-  - name: exporter_aggregator_exporter_local
+  - name: exporter_aggregator_local
     url: 'http://127.0.0.1:9299/metrics'
   - name: squid_exporter_local
     url: 'http://127.0.0.1:9301/metrics'
@@ -586,7 +586,7 @@ jobs:
     url: 'http://127.0.0.1:9321/metrics'
   - name: haproxy_abuser_exporter_local
     url: 'http://127.0.0.1:9322/metrics'
-  - name: docker_prometheus_metrics_exporter_local
+  - name: docker_prometheus_metrics_local
     url: 'http://127.0.0.1:9323/metrics'
   - name: bird_routing_daemon_exporter_local
     url: 'http://127.0.0.1:9324/metrics'
@@ -602,7 +602,7 @@ jobs:
     url: 'http://127.0.0.1:9329/metrics'
   - name: openldap_metrics_exporter_local
     url: 'http://127.0.0.1:9330/metrics'
-  - name: influx-spout_prometheus_metrics_exporter_local
+  - name: influx-spout_prometheus_metrics_local
     url: 'http://127.0.0.1:9331/metrics'
   - name: network_exporter_local
     url: 'http://127.0.0.1:9332/metrics'
@@ -614,7 +614,7 @@ jobs:
     url: 'http://127.0.0.1:9335/metrics'
   - name: mediacom_internet_usage_exporter_local
     url: 'http://127.0.0.1:9336/metrics'
-  - name: mqttgateway_exporter_local
+  - name: mqttgateway_local
     url: 'http://127.0.0.1:9337/metrics'
   - name: aws_s3_exporter_local
     url: 'http://127.0.0.1:9339/metrics'
@@ -656,7 +656,7 @@ jobs:
     url: 'http://127.0.0.1:9357/metrics'
   - name: performance_counters_exporter_local
     url: 'http://127.0.0.1:9358/metrics'
-  - name: sidekiq_prometheus_exporter_local
+  - name: sidekiq_prometheus_local
     url: 'http://127.0.0.1:9359/metrics'
   - name: powershell_exporter_local
     url: 'http://127.0.0.1:9360/metrics'
@@ -664,7 +664,7 @@ jobs:
     url: 'http://127.0.0.1:9361/metrics'
   - name: cisco_exporter_local
     url: 'http://127.0.0.1:9362/metrics'
-  - name: clickhouse_exporter_local
+  - name: clickhouse_local
     url: 'http://127.0.0.1:9363/metrics'
   - name: continent8_exporter_local
     url: 'http://127.0.0.1:9364/metrics'
@@ -676,21 +676,21 @@ jobs:
     url: 'http://127.0.0.1:9367/metrics'
   - name: ethereum_client_exporter_local
     url: 'http://127.0.0.1:9368/metrics'
-  - name: prometheus_pushprox_exporter_local
+  - name: prometheus_pushprox_local
     url: 'http://127.0.0.1:9369/metrics'
-  - name: u-bmc_exporter_local
+  - name: u-bmc_local
     url: 'http://127.0.0.1:9370/metrics'
   - name: conntrack-stats-exporter_local
     url: 'http://127.0.0.1:9371/metrics'
-  - name: appmetrics_prometheus_exporter_local
+  - name: appmetrics_prometheus_local
     url: 'http://127.0.0.1:9372/metrics'
-  - name: gcp_service_discovery_exporter_local
+  - name: gcp_service_discovery_local
     url: 'http://127.0.0.1:9373/metrics'
-  - name: smokeping_prober_exporter_local
+  - name: smokeping_prober_local
     url: 'http://127.0.0.1:9374/metrics'
   - name: particle_exporter_local
     url: 'http://127.0.0.1:9375/metrics'
-  - name: falco_exporter_local
+  - name: falco_local
     url: 'http://127.0.0.1:9376/metrics'
   - name: cisco_aci_exporter_local
     url: 'http://127.0.0.1:9377/metrics'
@@ -722,13 +722,13 @@ jobs:
     url: 'http://127.0.0.1:9389/metrics'
   - name: kannel_exporter_local
     url: 'http://127.0.0.1:9390/metrics'
-  - name: concourse_prometheus_metrics_exporter_local
+  - name: concourse_prometheus_metrics_local
     url: 'http://127.0.0.1:9391/metrics'
   - name: generic_command_line_output_exporter_local
     url: 'http://127.0.0.1:9392/metrics'
   - name: patroni_exporter_local
     url: 'http://127.0.0.1:9393/metrics'
-  - name: alertmanager_github_webhook_receiver_exporter_local
+  - name: alertmanager_github_webhook_receiver_local
     url: 'http://127.0.0.1:9393/metrics'
   - name: ruby_prometheus_exporter_local
     url: 'http://127.0.0.1:9394/metrics'
@@ -736,7 +736,7 @@ jobs:
     url: 'http://127.0.0.1:9395/metrics'
   - name: monerod_exporter_local
     url: 'http://127.0.0.1:9396/metrics'
-  - name: comap_exporter_local
+  - name: comap_local
     url: 'http://127.0.0.1:9397/metrics'
   - name: open_hardware_monitor_exporter_local
     url: 'http://127.0.0.1:9398/metrics'
@@ -772,7 +772,7 @@ jobs:
     url: 'http://127.0.0.1:9413/metrics'
   - name: homey_exporter_local
     url: 'http://127.0.0.1:9414/metrics'
-  - name: cloudwatch_read_adapter_exporter_local
+  - name: cloudwatch_read_adapter_local
     url: 'http://127.0.0.1:9415/metrics'
   - name: hp_ilo_metrics_exporter_local
     url: 'http://127.0.0.1:9416/metrics'
@@ -784,7 +784,7 @@ jobs:
     url: 'http://127.0.0.1:9419/metrics'
   - name: couchbase_exporter_local
     url: 'http://127.0.0.1:9420/metrics'
-  - name: apicast_exporter_local
+  - name: apicast_local
     url: 'http://127.0.0.1:9421/metrics'
   - name: jolokia_exporter_local
     url: 'http://127.0.0.1:9422/metrics'
@@ -802,7 +802,7 @@ jobs:
     url: 'http://127.0.0.1:9428/metrics'
   - name: uptimerobot_exporter_local
     url: 'http://127.0.0.1:9429/metrics'
-  - name: corerad_exporter_local
+  - name: corerad_local
     url: 'http://127.0.0.1:9430/metrics'
   - name: hpfeeds_broker_exporter_local
     url: 'http://127.0.0.1:9431/metrics'
@@ -846,7 +846,7 @@ jobs:
     url: 'http://127.0.0.1:9451/metrics'
   - name: freebsd_jail_exporter_local
     url: 'http://127.0.0.1:9452/metrics'
-  - name: midonet-kubernetes_exporter_local
+  - name: midonet-kubernetes_local
     url: 'http://127.0.0.1:9453/metrics'
   - name: nvidia_smi_exporter_local
     url: 'http://127.0.0.1:9454/metrics'
@@ -862,7 +862,7 @@ jobs:
     url: 'http://127.0.0.1:9459/metrics'
   - name: hana_exporter_local
     url: 'http://127.0.0.1:9460/metrics'
-  - name: aws_lambda_read_adapter_exporter_local
+  - name: aws_lambda_read_adapter_local
     url: 'http://127.0.0.1:9461/metrics'
   - name: php_opcache_exporter_local
     url: 'http://127.0.0.1:9462/metrics'
@@ -870,9 +870,9 @@ jobs:
     url: 'http://127.0.0.1:9463/metrics'
   - name: opencensus-nodejs_prometheus_exporter_local
     url: 'http://127.0.0.1:9464/metrics'
-  - name: hetzner_cloud_k8s_cloud_controller_manager_exporter_local
+  - name: hetzner_cloud_k8s_cloud_controller_manager_local
     url: 'http://127.0.0.1:9465/metrics'
-  - name: mqtt_push_gateway_exporter_local
+  - name: mqtt_push_gateway_local
     url: 'http://127.0.0.1:9466/metrics'
   - name: nginx-prometheus-shiny-exporter_local
     url: 'http://127.0.0.1:9467/metrics'
@@ -884,13 +884,13 @@ jobs:
     url: 'http://127.0.0.1:9470/metrics'
   - name: lxc-exporter_local
     url: 'http://127.0.0.1:9471/metrics'
-  - name: hetzner_cloud_csi_driver_controller_exporter_local
+  - name: hetzner_cloud_csi_driver_controller_local
     url: 'http://127.0.0.1:9472/metrics'
   - name: stellar-core-exporter_local
     url: 'http://127.0.0.1:9473/metrics'
   - name: libvirtd_exporter_local
     url: 'http://127.0.0.1:9474/metrics'
-  - name: wgipamd_exporter_local
+  - name: wgipamd_local
     url: 'http://127.0.0.1:9475/metrics'
   - name: ovn_metrics_exporter_local
     url: 'http://127.0.0.1:9476/metrics'
@@ -920,11 +920,11 @@ jobs:
     url: 'http://127.0.0.1:9488/metrics'
   - name: tezos_node_metrics_exporter_local
     url: 'http://127.0.0.1:9489/metrics'
-  - name: exporter_for_docker_libnetwork_plugin_for_ovn_exporter_local
+  - name: exporter_for_docker_libnetwork_plugin_for_ovn_local
     url: 'http://127.0.0.1:9490/metrics'
-  - name: docker_container_stats_exporter_docker_ps_exporter_local
+  - name: docker_container_stats_exporter_docker_ps_local
     url: 'http://127.0.0.1:9491/metrics'
-  - name: azure_exporter_monitor_and_usage_exporter_local
+  - name: azure_exporter_monitor_and_usage_local
     url: 'http://127.0.0.1:9492/metrics'
   - name: prosafe_exporter_local
     url: 'http://127.0.0.1:9493/metrics'
@@ -972,7 +972,7 @@ jobs:
     url: 'http://127.0.0.1:9515/metrics'
   - name: prometheus_speedtest_exporter_local
     url: 'http://127.0.0.1:9516/metrics'
-  - name: matroschka_prober_exporter_local
+  - name: matroschka_prober_local
     url: 'http://127.0.0.1:9517/metrics'
   - name: crypto_stock_exchanges_funds_exporter_local
     url: 'http://127.0.0.1:9518/metrics'
@@ -1004,7 +1004,7 @@ jobs:
     url: 'http://127.0.0.1:9531/metrics'
   - name: snyk_exporter_local
     url: 'http://127.0.0.1:9532/metrics'
-  - name: network_exporter_for_cisco_api_exporter_local
+  - name: network_exporter_for_cisco_api_local
     url: 'http://127.0.0.1:9533/metrics'
   - name: humio_exporter_local
     url: 'http://127.0.0.1:9534/metrics'
@@ -1012,9 +1012,9 @@ jobs:
     url: 'http://127.0.0.1:9535/metrics'
   - name: ipsec_exporter_local
     url: 'http://127.0.0.1:9536/metrics'
-  - name: cri-o_exporter_local
+  - name: cri-o_local
     url: 'http://127.0.0.1:9537/metrics'
-  - name: bull_queue_exporter_local
+  - name: bull_queue_local
     url: 'http://127.0.0.1:9538/metrics'
   - name: modemmanager_exporter_local
     url: 'http://127.0.0.1:9539/metrics'
@@ -1072,13 +1072,13 @@ jobs:
     url: 'http://127.0.0.1:9564/metrics'
   - name: bminer_exporter_local
     url: 'http://127.0.0.1:9565/metrics'
-  - name: rabbitmq_cli_consumer_exporter_local
+  - name: rabbitmq_cli_consumer_local
     url: 'http://127.0.0.1:9566/metrics'
-  - name: alertsnitch_exporter_local
+  - name: alertsnitch_local
     url: 'http://127.0.0.1:9567/metrics'
   - name: dell_poweredge_ipmi_exporter_local
     url: 'http://127.0.0.1:9568/metrics'
-  - name: hvpa_controller_exporter_local
+  - name: hvpa_controller_local
     url: 'http://127.0.0.1:9569/metrics'
   - name: vpa_exporter_local
     url: 'http://127.0.0.1:9570/metrics'
@@ -1102,7 +1102,7 @@ jobs:
     url: 'http://127.0.0.1:9580/metrics'
   - name: codenotary_vcn_exporter_local
     url: 'http://127.0.0.1:9581/metrics'
-  - name: signatory_a_remote_operation_signer_for_tezos_exporter_local
+  - name: signatory_a_remote_operation_signer_for_tezos_local
     url: 'http://127.0.0.1:9583/metrics'
   - name: bunnycdn_exporter_local
     url: 'http://127.0.0.1:9584/metrics'
@@ -1138,7 +1138,7 @@ jobs:
     url: 'http://127.0.0.1:9601/metrics'
   - name: modbus_exporter_local
     url: 'http://127.0.0.1:9602/metrics'
-  - name: xen_exporter_using_xenlight_exporter_local
+  - name: xen_exporter_using_xenlight_local
     url: 'http://127.0.0.1:9603/metrics'
   - name: xmpp_blackbox_exporter_local
     url: 'http://127.0.0.1:9604/metrics'
@@ -1184,13 +1184,13 @@ jobs:
     url: 'http://127.0.0.1:9624/metrics'
   - name: bareos_exporter_local
     url: 'http://127.0.0.1:9625/metrics'
-  - name: hockeypuck_exporter_local
+  - name: hockeypuck_local
     url: 'http://127.0.0.1:9626/metrics'
   - name: artifactory_exporter_local
     url: 'http://127.0.0.1:9627/metrics'
   - name: solace_pubsub_plus_exporter_local
     url: 'http://127.0.0.1:9628/metrics'
-  - name: prometheus_gitlab_notifier_exporter_local
+  - name: prometheus_gitlab_notifier_local
     url: 'http://127.0.0.1:9629/metrics'
   - name: nftables_exporter_local
     url: 'http://127.0.0.1:9630/metrics'
@@ -1218,7 +1218,7 @@ jobs:
     url: 'http://127.0.0.1:9641/metrics'
   - name: bugsnag_exporter_local
     url: 'http://127.0.0.1:9642/metrics'
-  - name: exporter_for_grouped_process_exporter_local
+  - name: exporter_for_grouped_process_local
     url: 'http://127.0.0.1:9644/metrics'
   - name: burp_exporter_local
     url: 'http://127.0.0.1:9645/metrics'
@@ -1242,7 +1242,7 @@ jobs:
     url: 'http://127.0.0.1:9654/metrics'
   - name: kube-netc_exporter_local
     url: 'http://127.0.0.1:9655/metrics'
-  - name: matrix_exporter_local
+  - name: matrix_local
     url: 'http://127.0.0.1:9656/metrics'
   - name: krill_exporter_local
     url: 'http://127.0.0.1:9657/metrics'
@@ -1266,9 +1266,9 @@ jobs:
     url: 'http://127.0.0.1:9667/metrics'
   - name: suses_sap_hana_exporter_local
     url: 'http://127.0.0.1:9668/metrics'
-  - name: panopticon_native_metrics_exporter_local
+  - name: panopticon_native_metrics_local
     url: 'http://127.0.0.1:9669/metrics'
-  - name: flare_native_metrics_exporter_local
+  - name: flare_native_metrics_local
     url: 'http://127.0.0.1:9670/metrics'
   - name: aws_ec2_spot_exporter_local
     url: 'http://127.0.0.1:9671/metrics'
@@ -1292,13 +1292,13 @@ jobs:
     url: 'http://127.0.0.1:9680/metrics'
   - name: myfitnesspal_exporter_local
     url: 'http://127.0.0.1:9681/metrics'
-  - name: powder_monkey_exporter_local
+  - name: powder_monkey_local
     url: 'http://127.0.0.1:9682/metrics'
   - name: infiniband_exporter_local
     url: 'http://127.0.0.1:9683/metrics'
   - name: kibana_standalone_exporter_local
     url: 'http://127.0.0.1:9684/metrics'
-  - name: eideticom_exporter_local
+  - name: eideticom_local
     url: 'http://127.0.0.1:9685/metrics'
   - name: aws_ec2_exporter_local
     url: 'http://127.0.0.1:9686/metrics'
@@ -1314,7 +1314,7 @@ jobs:
     url: 'http://127.0.0.1:9692/metrics'
   - name: sigma_air_manager_exporter_local
     url: 'http://127.0.0.1:9693/metrics'
-  - name: per-user_usage_exporter_for_cisco_xe_lnss_exporter_local
+  - name: per-user_usage_exporter_for_cisco_xe_lnss_local
     url: 'http://127.0.0.1:9694/metrics'
   - name: cifs_exporter_local
     url: 'http://127.0.0.1:9695/metrics'
@@ -1332,7 +1332,7 @@ jobs:
     url: 'http://127.0.0.1:9701/metrics'
   - name: homeplug_plc_exporter_local
     url: 'http://127.0.0.1:9702/metrics'
-  - name: vircadia_exporter_local
+  - name: vircadia_local
     url: 'http://127.0.0.1:9703/metrics'
   - name: linux_tc_exporter_local
     url: 'http://127.0.0.1:9704/metrics'
@@ -1358,7 +1358,7 @@ jobs:
     url: 'http://127.0.0.1:9714/metrics'
   - name: twincat_ads_web_service_exporter_local
     url: 'http://127.0.0.1:9715/metrics'
-  - name: signald_webhook_receiver_exporter_local
+  - name: signald_webhook_receiver_local
     url: 'http://127.0.0.1:9716/metrics'
   - name: tplink_easysmart_switch_exporter_local
     url: 'http://127.0.0.1:9717/metrics'
@@ -1394,17 +1394,17 @@ jobs:
     url: 'http://127.0.0.1:9733/metrics'
   - name: a10-networks_prometheus_exporter_local
     url: 'http://127.0.0.1:9734/metrics'
-  - name: webweaver_exporter_local
+  - name: webweaver_local
     url: 'http://127.0.0.1:9735/metrics'
   - name: mongodb_query_exporter_local
     url: 'http://127.0.0.1:9736/metrics'
-  - name: foldinghome_exporter_local
+  - name: folding_home_exporter_local
     url: 'http://127.0.0.1:9737/metrics'
   - name: processor_counter_monitor_exporter_local
     url: 'http://127.0.0.1:9738/metrics'
-  - name: kafka_consumer_lag_monitoring_exporter_local
+  - name: kafka_consumer_lag_monitoring_local
     url: 'http://127.0.0.1:9739/metrics'
-  - name: flightdeck_exporter_local
+  - name: flightdeck_local
     url: 'http://127.0.0.1:9740/metrics'
   - name: ibm_spectrum_exporter_local
     url: 'http://127.0.0.1:9741/metrics'
@@ -1414,7 +1414,7 @@ jobs:
     url: 'http://127.0.0.1:9743/metrics'
   - name: site24x7_exporter_local
     url: 'http://127.0.0.1:9803/metrics'
-  - name: envoy_proxy_exporter_local
+  - name: envoy_proxy_local
     url: 'http://127.0.0.1:9901/metrics'
   - name: nginx_vts_exporter_local
     url: 'http://127.0.0.1:9913/metrics'
@@ -1432,29 +1432,29 @@ jobs:
     url: 'http://127.0.0.1:9990/metrics'
   - name: prometheus-jdbc-exporter_local
     url: 'http://127.0.0.1:5555/metrics'
-  - name: midonet_agent_exporter_local
+  - name: midonet_agent_local
     url: 'http://127.0.0.1:7300/metrics'
-  - name: trickster_exporter_local
+  - name: trickster_local
     url: 'http://127.0.0.1:8082/metrics'
-  - name: fawkes_exporter_local
+  - name: fawkes_local
     url: 'http://127.0.0.1:8088/metrics'
-  - name: prom2teams_exporter_local
+  - name: prom2teams_local
     url: 'http://127.0.0.1:8089/metrics'
-  - name: phabricator_webhook_for_alertmanager_exporter_local
+  - name: phabricator_webhook_for_alertmanager_local
     url: 'http://127.0.0.1:8292/metrics'
-  - name: ha_proxy_v2_plus_exporter_local
+  - name: ha_proxy_v2_plus_local
     url: 'http://127.0.0.1:8404/metrics'
   - name: rds_exporter_local
     url: 'http://127.0.0.1:9042/metrics'
-  - name: telegram_bot_for_alertmanager_exporter_local
+  - name: telegram_bot_for_alertmanager_local
     url: 'http://127.0.0.1:9087/metrics'
-  - name: jiralert_exporter_local
+  - name: jiralert_local
     url: 'http://127.0.0.1:9097/metrics'
   - name: storidge_exporter_local
     url: 'http://127.0.0.1:16995/metrics'
   - name: transmission_exporter_local
     url: 'http://127.0.0.1:19091/metrics'
-  - name: fluent_plugin_for_prometheus_exporter_local
+  - name: fluent_plugin_for_prometheus_local
     url: 'http://127.0.0.1:24231/metrics'
   - name: proxysql_exporter_local
     url: 'http://127.0.0.1:42004/metrics'


### PR DESCRIPTION
These are jobs from the https://github.com/prometheus/prometheus/wiki/Default-port-allocations

Some exporters like (netdata, telegraf were excluded).