### PR TITLE
Added JSON log parser

### DIFF
--- a/config/go.d/web_log.conf
+++ b/config/go.d/web_log.conf
@@ -218,6 +218,6 @@ jobs:
     log_type: json
       json_config:
         mapping:
-          status: respCode
-          http_user_agent: reqClient
-          request_time: upsRespTime
+          response_status: status
+          server_name: host
+          response_time: request_time

--- a/config/go.d/web_log.conf
+++ b/config/go.d/web_log.conf
@@ -137,6 +137,14 @@
 #        label1: field1
 #        label2: field2
 #
+#  - json_config
+#    JSON log type specific parameters.
+#    Syntax:
+#    json_config:
+#      mapping:              # Label field mapping, json-log-label: weblog-label
+#        label1: field1
+#        label2: field2
+#
 #  - regexp_config
 #    RegExp log type specific parameters.
 #    Pattern syntax: https://golang.org/pkg/regexp/syntax/.
@@ -203,3 +211,13 @@ jobs:
 
   - name: gunicorn
     path: /var/log/gunicorn/gunicorn-access.log
+
+# custom JSON log
+  - name: custom_json_log
+    path: /var/log/access.log.json
+    log_type: json
+      json_config:
+        mapping:
+          status: respCode
+          http_user_agent: reqClient
+          request_time: upsRespTime

--- a/config/go.d/web_log.conf
+++ b/config/go.d/web_log.conf
@@ -179,45 +179,35 @@
 #
 # [ JOBS ]
 jobs:
-# NGINX
-# debian, arch
+  # NGINX
+  # debian, arch
   - name: nginx
     path: /var/log/nginx/access.log
 
-# gentoo
+  # gentoo
   - name: nginx
     path: /var/log/nginx/localhost.access_log
 
-# APACHE
-# debian
+  # APACHE
+  # debian
   - name: apache
     path: /var/log/apache2/access.log
 
-# gentoo
+  # gentoo
   - name: apache
     path: /var/log/apache2/access_log
 
-# arch
+  # arch
   - name: apache
     path: /var/log/httpd/access_log
 
-# debian
+  # debian
   - name: apache_vhosts
     path: /var/log/apache2/other_vhosts_access.log
 
-# GUNICORN
+  # GUNICORN
   - name: gunicorn
     path: /var/log/gunicorn/access.log
 
   - name: gunicorn
     path: /var/log/gunicorn/gunicorn-access.log
-
-# custom JSON log
-  - name: custom_json_log
-    path: /var/log/access.log.json
-    log_type: json
-      json_config:
-        mapping:
-          response_status: status
-          server_name: host
-          response_time: request_time

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/stretchr/testify v1.6.0
 	github.com/tomasen/fcgi_client v0.0.0-20180423082037-2bb3d819fd19
+	github.com/valyala/fastjson v1.5.4
 	github.com/vmware/govmomi v0.22.2
 	golang.org/x/net v0.0.0-20191027093000-83d349e8ac1a // indirect; needed for freebsd/arm64
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/tomasen/fcgi_client v0.0.0-20180423082037-2bb3d819fd19 h1:ZCmSnT6CLGhfoQ2lPEhL4nsJstKDCw1F1RfN8/smTCU=
 github.com/tomasen/fcgi_client v0.0.0-20180423082037-2bb3d819fd19/go.mod h1:SXTY+QvI+KTTKXQdg0zZ7nx0u94QWh8ZAwBQYsW9cqk=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fastjson v1.5.4 h1:r8gpiVwdzDU09NrlN38OyL5dUFpdwGQR5RQEBqY+hLg=
+github.com/valyala/fastjson v1.5.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/vmware/govmomi v0.22.2 h1:hmLv4f+RMTTseqtJRijjOWzwELiaLMIoHv2D6H3bF4I=
 github.com/vmware/govmomi v0.22.2/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=

--- a/modules/weblog/README.md
+++ b/modules/weblog/README.md
@@ -50,13 +50,15 @@ For every URL pattern:
 
 ## Log Parsers
 
-Weblog supports 3 different log parsers:
+Weblog supports 4 different log parsers:
 
--   CSV
--   [LTSV](http://ltsv.org/)
--   RegExp
+-   `CSV`
+-   [`JSON`](https://www.json.org/json-en.html)
+-   [`LTSV`](http://ltsv.org/)
+-   `RegExp`
 
-Try to avoid using RegExp because it's much slower than the other two parsers. RegExp should be used only if LTSV and CSV parsers dont work for you.
+Try to avoid using `RegExp` because it's much slower than the other parsers.
+Prefer to use `LTSV` and `CSV` parses whenever is possible.
 
 There is an example job for every log parser.
 
@@ -70,6 +72,14 @@ jobs:
       fields_per_record: -1
       delimiter: ' '
       trim_leading_space: no
+
+  - name: json_parser_example
+    path: /path/to/file.log
+    log_type: json
+    json_config:
+      mapping:
+        label1: field1
+        label2: field2
 
   - name: ltsv_parser_example
     path: /path/to/file.log
@@ -90,12 +100,12 @@ jobs:
 
 ## Log Parser Auto-Detection
 
-If `log_type` parameter is set to `auto` (which is default), weblog will try to auto-detect appropriate log parser and log format
+If `log_type` parameter set to `auto` (which is default), weblog will try to auto-detect appropriate log parser and log format
 using the last line of the log file.
 
-To auto-detect parser type the module checks if the line is in LTSV format first. If it is not the case it assumes that the format is CSV.
+To auto-detect parser type the module checks if the line is in `LTSV` format first. If it is not the case it assumes that the format is `CSV`.
 
-To auto-detect CSV format weblog uses list of predefined csv formats. It tries to parse the line using each of them in the following order:
+To auto-detect `CSV` format weblog uses list of predefined csv formats. It tries to parse the line using each of them in the following order:
 
 ```sh
 $host:$server_port $remote_addr - - [$time_local] "$request" $status $body_bytes_sent - - $request_length $request_time $upstream_response_time
@@ -110,8 +120,8 @@ $host:$server_port $remote_addr - - [$time_local] "$request" $status $body_bytes
                    $remote_addr - - [$time_local] "$request" $status $body_bytes_sent
 ```
 
-The first one that matches will be used later. If you use default Apache/NGINX log format auto-detect will do for you.
-If it doesnt work you need [to set format manually](#custom-log-format).
+The first one matches is used later. If you use default Apache/NGINX log format auto-detect will do for you.
+If it doesn't work you need [to set format manually](#custom-log-format).
 
 ## Known Fields
 
@@ -159,12 +169,11 @@ Notes:
 
 Custom log format is easy. Use [known fields](#known-fields) to construct your log format.
 
--   If using CSV parser
+-   If using `CSV` parser
 
-Since weblog understands 
- and Apache variables all you need is to copy your log format and... that is it!
+Since weblog understands NGINX and Apache variables all you need is to copy your log format and... that is it!
 If there is a field that is not known by the weblog it's not a problem. It will skip it during parsing.
-But we suggest to replace all unknown fields with `-` for optimization purposes.
+We suggest replace all unknown fields with `-` for optimization purposes.
 
 Let's take as an example some non default format.
 
@@ -183,7 +192,7 @@ is optional but recommended.
 
 Special case:
 
-`%t` and `$time_local` represent time in [Common Log Format](https://www.w3.org/Daemon/User/Config/Logging.html#common-logfile-format).
+Both `%t` and `$time_local` fields represent time in [Common Log Format](https://www.w3.org/Daemon/User/Config/Logging.html#common-logfile-format).
 It is a special case because it's in fact 2 fields after csv parse (ex.: `[22/Mar/2009:09:30:31 +0100]`).
 Weblog understands it and you don't need to replace it with `-` (if we want to do it we need to make it `- -`).
 
@@ -202,11 +211,15 @@ jobs:
       format: '- - $remote_addr - - [$time_local] "$request" $status $body_bytes_sent'
 ```
 
--   If using LTSV parser
+-   If using `JSON` parser
 
-Provide fields mapping if needed. Dont use `$` and `%` prefixes for mapped field names. They are only needed in CSV format.
+Provide fields [mapping](#known-fields) if needed. Don't use `$` and `%` prefixes for mapped field names. They are only needed in `CSV` format.
 
--   If using RegExp parser
+-   If using `LTSV` parser
+
+Provide fields [mapping](#known-fields) if needed. Don't use `$` and `%` prefixes for mapped field names. They are only needed in `CSV` format.
+
+-   If using `RegExp` parser
 
 Use pattern with subexpressions names. These names should be known by weblog.
 

--- a/modules/weblog/parser.go
+++ b/modules/weblog/parser.go
@@ -83,6 +83,8 @@ func (w *WebLog) newParser(record []byte) (logs.Parser, error) {
 		w.Debugf("config: %+v", w.Parser.LogType)
 	case logs.TypeRegExp:
 		w.Debugf("config: %+v", w.Parser.RegExp)
+	case logs.TypeJSON:
+		w.Debugf("config: %+v", w.Parser.JSON)
 	}
 	return logs.NewParser(w.Parser, w.file)
 }

--- a/modules/weblog/parser.go
+++ b/modules/weblog/parser.go
@@ -66,6 +66,7 @@ const (
 
 var (
 	reLTSV = regexp.MustCompile(`^[a-zA-Z0-9]+:[^\t]*(\t[a-zA-Z0-9]+:[^\t]*)*$`)
+	reJSON = regexp.MustCompile(`^[[:space:]]*{.*}[[:space:]]*$`)
 )
 
 func (w *WebLog) newParser(record []byte) (logs.Parser, error) {
@@ -94,6 +95,10 @@ func (w *WebLog) guessParser(record []byte) (logs.Parser, error) {
 	if reLTSV.Match(record) {
 		w.Debug("log type is LTSV")
 		return logs.NewLTSVParser(w.Parser.LTSV, w.file)
+	}
+	if reJSON.Match(record) {
+		w.Debug("log type is JSON")
+		return logs.NewJSONParser(w.Parser.JSON, w.file)
 	}
 	w.Debug("log type is CSV")
 	return w.guessCSVParser(record)

--- a/modules/weblog/parser_test.go
+++ b/modules/weblog/parser_test.go
@@ -42,6 +42,18 @@ func TestWebLog_guessParser(t *testing.T) {
 			},
 		},
 		{
+			name:           "guessed json",
+			wantParserType: logs.TypeJSON,
+			inputs: []string{
+				`{}`,
+				` {}`,
+				` {} `,
+				`{"host": "example.com"}`,
+				`{"host": "example.com","time": "2020-08-04T20:23:27+03:00", "upstream_response_time": "0.776", "remote_addr": "1.2.3.4"}`,
+				` {"host": "example.com","time": "2020-08-04T20:23:27+03:00", "upstream_response_time": "0.776", "remote_addr": "1.2.3.4"}	`,
+			},
+		},
+		{
 			name:    "unknown",
 			wantErr: true,
 			inputs: []string{
@@ -71,6 +83,8 @@ func TestWebLog_guessParser(t *testing.T) {
 						assert.IsType(t, (*logs.LTSVParser)(nil), p)
 					case logs.TypeCSV:
 						require.IsType(t, (*logs.CSVParser)(nil), p)
+					case logs.TypeJSON:
+						require.IsType(t, (*logs.JSONParser)(nil), p)
 					}
 				}
 			})

--- a/modules/weblog/weblog.go
+++ b/modules/weblog/weblog.go
@@ -28,6 +28,7 @@ func New() *WebLog {
 			ValueDelimiter: ':',
 		},
 		RegExp: logs.RegExpConfig{},
+		JSON:   logs.JSONConfig{},
 	}
 	return &WebLog{
 		Config: Config{

--- a/pkg/logs/json.go
+++ b/pkg/logs/json.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"unsafe"
 
 	"github.com/valyala/fastjson"
 )
@@ -57,7 +56,7 @@ func (p *JSONParser) Parse(row []byte, line LogLine) error {
 			return
 		}
 
-		name := *(*string)(unsafe.Pointer(&key))
+		name := string(key)
 		if mapped, ok := p.mapping[name]; ok {
 			name = mapped
 		}

--- a/pkg/logs/json.go
+++ b/pkg/logs/json.go
@@ -61,7 +61,7 @@ func (p *JSONParser) Parse(row []byte, line LogLine) error {
 }
 
 func (p *JSONParser) mapField(field string) string {
-	if newLogLineField,exist := p.mapping[field]; exist == true {
+	if newLogLineField,exist := p.mapping[field]; exist {
 		return newLogLineField
 	}
 	return field

--- a/pkg/logs/json.go
+++ b/pkg/logs/json.go
@@ -12,7 +12,7 @@ type JSONConfig struct {
 }
 
 type JSONParser struct {
-	reader *bufio.Reader
+	reader  *bufio.Reader
 	mapping map[string]string
 }
 
@@ -23,8 +23,8 @@ func NewJSONParser(config JSONConfig, in io.Reader) (*JSONParser, error) {
 	}
 
 	parser := &JSONParser{
-		reader:		bufio.NewReader(in),
-		mapping:	fieldMap,
+		reader:  bufio.NewReader(in),
+		mapping: fieldMap,
 	}
 
 	return parser, nil
@@ -48,11 +48,11 @@ func (p *JSONParser) Parse(row []byte, line LogLine) error {
 	}
 
 	/* Now map the fields */
-	for logField,logValue := range parsedLine {
+	for logField, logValue := range parsedLine {
 		/* Convert logValue to string */
 		stringValue := fmt.Sprintf("%v", logValue)
 
-		if err := line.Assign( p.mapField(logField), stringValue ); err != nil {
+		if err := line.Assign(p.mapField(logField), stringValue); err != nil {
 			return err
 		}
 	}
@@ -61,7 +61,7 @@ func (p *JSONParser) Parse(row []byte, line LogLine) error {
 }
 
 func (p *JSONParser) mapField(field string) string {
-	if newLogLineField,exist := p.mapping[field]; exist {
+	if newLogLineField, exist := p.mapping[field]; exist {
 		return newLogLineField
 	}
 	return field

--- a/pkg/logs/json.go
+++ b/pkg/logs/json.go
@@ -63,15 +63,15 @@ func (p *JSONParser) Parse(row []byte, line LogLine) error {
 		}
 
 		p.buf = p.buf[:0]
-		p.buf = v.MarshalTo(p.buf)
-		if len(p.buf) == 0 {
+		if p.buf = v.MarshalTo(p.buf); len(p.buf) == 0 {
 			return
 		}
 
-		if v.Type() == fastjson.TypeString {
+		switch v.Type() {
+		case fastjson.TypeString:
 			// trim "
 			err = line.Assign(name, string(p.buf[1:len(p.buf)-1]))
-		} else {
+		default:
 			err = line.Assign(name, string(p.buf))
 		}
 	})

--- a/pkg/logs/json.go
+++ b/pkg/logs/json.go
@@ -1,0 +1,72 @@
+package logs
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+type JSONConfig struct {
+	Mapping map[string]string `yaml:"mapping"`
+}
+
+type JSONParser struct {
+	reader *bufio.Reader
+	mapping map[string]string
+}
+
+func NewJSONParser(config JSONConfig, in io.Reader) (*JSONParser, error) {
+	fieldMap := config.Mapping
+	if fieldMap == nil {
+		fieldMap = make(map[string]string)
+	}
+
+	parser := &JSONParser{
+		reader:		bufio.NewReader(in),
+		mapping:	fieldMap,
+	}
+
+	return parser, nil
+}
+
+func (p *JSONParser) ReadLine(line LogLine) error {
+	row, err := p.reader.ReadSlice('\n')
+
+	if err != nil && len(row) == 0 {
+		return err
+	}
+
+	return p.Parse(row, line)
+}
+
+func (p *JSONParser) Parse(row []byte, line LogLine) error {
+	var parsedLine map[string]interface{}
+
+	if err := json.Unmarshal(row, &parsedLine); err != nil {
+		return err
+	}
+
+	/* Now map the fields */
+	for logField,logValue := range parsedLine {
+		/* Convert logValue to string */
+		stringValue := fmt.Sprintf("%v", logValue)
+
+		if err := line.Assign( p.mapField(logField), stringValue ); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *JSONParser) mapField(field string) string {
+	if newLogLineField,exist := p.mapping[field]; exist == true {
+		return newLogLineField
+	}
+	return field
+}
+
+func (p *JSONParser) Info() string {
+	return fmt.Sprintf("json: %q", p.mapping)
+}

--- a/pkg/logs/json_test.go
+++ b/pkg/logs/json_test.go
@@ -15,8 +15,8 @@ var testJSONConfig = JSONConfig{
 func TestNewJSONParser(t *testing.T) {
 	tests := []struct {
 		name    string
-		wantErr bool
 		config  JSONConfig
+		wantErr bool
 	}{
 		{
 			name:    "empty config",
@@ -48,9 +48,9 @@ func TestNewJSONParser(t *testing.T) {
 func TestJSONParser_ReadLine(t *testing.T) {
 	tests := []struct {
 		name    string
-		wantErr bool
 		config  JSONConfig
 		data    string
+		wantErr bool
 	}{
 		{
 			name:    "no error",
@@ -59,7 +59,8 @@ func TestJSONParser_ReadLine(t *testing.T) {
 			data:    `{ "host": "example.com" }`,
 		},
 		{
-			name: "splits on newline", config: JSONConfig{},
+			name:    "splits on newline",
+			config:  JSONConfig{},
 			wantErr: false,
 			data:    "{\"host\": \"example.com\"}\n{\"host\": \"acme.org\"}",
 		},
@@ -139,51 +140,6 @@ func TestJSONParser_Parse(t *testing.T) {
 				assert.NoError(t, parseErr)
 			}
 
-		})
-	}
-}
-
-func TestJSONParser_mapField(t *testing.T) {
-	tests := []struct {
-		name     string
-		field    string
-		expected string
-		fieldMap map[string]string
-	}{
-		{
-			name:     "defaults",
-			field:    "x",
-			expected: "x",
-			fieldMap: map[string]string{},
-		},
-		{
-			name:     "mapping-non-existing",
-			field:    "x",
-			expected: "x",
-			fieldMap: map[string]string{"y": "z"},
-		},
-		{
-			name:     "mapping-existing",
-			field:    "x",
-			expected: "z",
-			fieldMap: map[string]string{"x": "z"},
-		},
-		{
-			name:     "mapping-identity",
-			field:    "x",
-			expected: "x",
-			fieldMap: map[string]string{"x": "x"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p, err := NewJSONParser(JSONConfig{Mapping: tt.fieldMap}, nil)
-			assert.NoError(t, err)
-
-			actual := p.mapField(tt.field)
-
-			assert.Equal(t, tt.expected, actual)
 		})
 	}
 }

--- a/pkg/logs/json_test.go
+++ b/pkg/logs/json_test.go
@@ -59,7 +59,7 @@ func TestJSONParser_ReadLine(t *testing.T) {
 			data:    `{ "host": "example.com" }`,
 		},
 		{
-			name:    "splits on newline", config: JSONConfig{},
+			name: "splits on newline", config: JSONConfig{},
 			wantErr: false,
 			data:    "{\"host\": \"example.com\"}\n{\"host\": \"acme.org\"}",
 		},

--- a/pkg/logs/json_test.go
+++ b/pkg/logs/json_test.go
@@ -1,10 +1,11 @@
 package logs
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var testJSONConfig = JSONConfig{
@@ -17,8 +18,16 @@ func TestNewJSONParser(t *testing.T) {
 		wantErr bool
 		config  JSONConfig
 	}{
-		{name: "empty config", config: JSONConfig{}, wantErr: false},
-		{name: "empty config", config: testJSONConfig, wantErr: false},
+		{
+			name:    "empty config",
+			config:  JSONConfig{},
+			wantErr: false,
+		},
+		{
+			name:    "empty config",
+			config:  testJSONConfig,
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -43,10 +52,29 @@ func TestJSONParser_ReadLine(t *testing.T) {
 		config  JSONConfig
 		data    string
 	}{
-		{name: "no error", config: JSONConfig{}, wantErr: false, data: `{ "host": "example.com" }`},
-		{name: "splits on newline", config: JSONConfig{}, wantErr: false, data: "{\"host\": \"example.com\"}\n{\"host\": \"acme.org\"}"},
-		{name: "error on malformed JSON", config: JSONConfig{}, wantErr: true, data: `{ "host"": unquoted_string}`},
-		{name: "error on no data", config: JSONConfig{}, wantErr: true, data: ``},
+		{
+			name:    "no error",
+			config:  JSONConfig{},
+			wantErr: false,
+			data:    `{ "host": "example.com" }`,
+		},
+		{
+			name:    "splits on newline", config: JSONConfig{},
+			wantErr: false,
+			data:    "{\"host\": \"example.com\"}\n{\"host\": \"acme.org\"}",
+		},
+		{
+			name:    "error on malformed JSON",
+			config:  JSONConfig{},
+			wantErr: true,
+			data:    `{ "host"": unquoted_string}`,
+		},
+		{
+			name:    "error on no data",
+			config:  JSONConfig{},
+			wantErr: true,
+			data:    ``,
+		},
 	}
 
 	for _, tt := range tests {
@@ -75,10 +103,26 @@ func TestJSONParser_Parse(t *testing.T) {
 		fieldMap     map[string]string
 		wantParseErr bool
 	}{
-		{name: "malformed JSON", row: `{`, wantParseErr: true},
-		{name: "malformed JSON #2", row: `{ host: "example.com" }`, wantParseErr: true},
-		{name: "empty string", row: "", wantParseErr: true},
-		{name: "no field mapping", row: `{ "host": "example.com", "remote_addr": "127.0.0.1", "request_time": 0.05 }`, wantParseErr: false},
+		{
+			name:         "malformed JSON",
+			row:          `{`,
+			wantParseErr: true,
+		},
+		{
+			name:         "malformed JSON #2",
+			row:          `{ host: "example.com" }`,
+			wantParseErr: true,
+		},
+		{
+			name:         "empty string",
+			row:          "",
+			wantParseErr: true,
+		},
+		{
+			name:         "no field mapping",
+			row:          `{ "host": "example.com", "remote_addr": "127.0.0.1", "request_time": 0.05 }`,
+			wantParseErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -106,10 +150,30 @@ func TestJSONParser_mapField(t *testing.T) {
 		expected string
 		fieldMap map[string]string
 	}{
-		{name: "defaults", field: "x", expected: "x", fieldMap: map[string]string{}},
-		{name: "mapping-non-existing", field: "x", expected: "x", fieldMap: map[string]string{"y": "z"}},
-		{name: "mapping-existing", field: "x", expected: "z", fieldMap: map[string]string{"x": "z"}},
-		{name: "mapping-identity", field: "x", expected: "x", fieldMap: map[string]string{"x": "x"}},
+		{
+			name:     "defaults",
+			field:    "x",
+			expected: "x",
+			fieldMap: map[string]string{},
+		},
+		{
+			name:     "mapping-non-existing",
+			field:    "x",
+			expected: "x",
+			fieldMap: map[string]string{"y": "z"},
+		},
+		{
+			name:     "mapping-existing",
+			field:    "x",
+			expected: "z",
+			fieldMap: map[string]string{"x": "z"},
+		},
+		{
+			name:     "mapping-identity",
+			field:    "x",
+			expected: "x",
+			fieldMap: map[string]string{"x": "x"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/logs/json_test.go
+++ b/pkg/logs/json_test.go
@@ -24,7 +24,7 @@ func TestNewJSONParser(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "empty config",
+			name:    "basic config",
 			config:  testJSONConfig,
 			wantErr: false,
 		},

--- a/pkg/logs/json_test.go
+++ b/pkg/logs/json_test.go
@@ -13,12 +13,12 @@ var testJSONConfig = JSONConfig{
 
 func TestNewJSONParser(t *testing.T) {
 	tests := []struct {
-		name	string
-		wantErr	bool
-		config JSONConfig
+		name    string
+		wantErr bool
+		config  JSONConfig
 	}{
-		{ name: "empty config", config: JSONConfig{}, wantErr: false},
-		{ name: "empty config", config: testJSONConfig, wantErr: false},
+		{name: "empty config", config: JSONConfig{}, wantErr: false},
+		{name: "empty config", config: testJSONConfig, wantErr: false},
 	}
 
 	for _, tt := range tests {
@@ -43,10 +43,10 @@ func TestJSONParser_ReadLine(t *testing.T) {
 		config  JSONConfig
 		data    string
 	}{
-		{ name: "no error", config: JSONConfig{}, wantErr: false, data: `{ "host": "example.com" }` },
-		{ name: "splits on newline", config: JSONConfig{}, wantErr: false, data: "{\"host\": \"example.com\"}\n{\"host\": \"acme.org\"}"},
-		{ name: "error on malformed JSON", config: JSONConfig{}, wantErr: true, data: `{ "host"": unquoted_string}`},
-		{ name: "error on no data", config: JSONConfig{}, wantErr: true, data: ``},
+		{name: "no error", config: JSONConfig{}, wantErr: false, data: `{ "host": "example.com" }`},
+		{name: "splits on newline", config: JSONConfig{}, wantErr: false, data: "{\"host\": \"example.com\"}\n{\"host\": \"acme.org\"}"},
+		{name: "error on malformed JSON", config: JSONConfig{}, wantErr: true, data: `{ "host"": unquoted_string}`},
+		{name: "error on no data", config: JSONConfig{}, wantErr: true, data: ``},
 	}
 
 	for _, tt := range tests {
@@ -54,10 +54,10 @@ func TestJSONParser_ReadLine(t *testing.T) {
 			var line logLine
 			in := strings.NewReader(tt.data)
 			p, err := NewJSONParser(tt.config, in)
-			require.NoError(t, err);
-			require.NotNil(t, p);
+			require.NoError(t, err)
+			require.NotNil(t, p)
 
-			err = p.ReadLine(&line);
+			err = p.ReadLine(&line)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -70,10 +70,10 @@ func TestJSONParser_ReadLine(t *testing.T) {
 
 func TestJSONParser_Parse(t *testing.T) {
 	tests := []struct {
-		name	string
-		row		string
-		fieldMap map[string]string
-		wantParseErr	bool
+		name         string
+		row          string
+		fieldMap     map[string]string
+		wantParseErr bool
 	}{
 		{name: "malformed JSON", row: `{`, wantParseErr: true},
 		{name: "malformed JSON #2", row: `{ host: "example.com" }`, wantParseErr: true},
@@ -84,7 +84,7 @@ func TestJSONParser_Parse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var line logLine
-			p, err := NewJSONParser(JSONConfig{ Mapping: tt.fieldMap}, nil)
+			p, err := NewJSONParser(JSONConfig{Mapping: tt.fieldMap}, nil)
 			assert.NoError(t, err)
 
 			parseErr := p.Parse([]byte(tt.row), line)
@@ -106,15 +106,15 @@ func TestJSONParser_mapField(t *testing.T) {
 		expected string
 		fieldMap map[string]string
 	}{
-		{name: "defaults", field: "x", expected: "x", fieldMap: map[string]string {} },
-		{name: "mapping-non-existing", field: "x", expected: "x", fieldMap: map[string]string { "y": "z"} },
-		{name: "mapping-existing", field: "x", expected: "z", fieldMap: map[string]string { "x": "z"} },
-		{name: "mapping-identity", field: "x", expected: "x", fieldMap: map[string]string {"x": "x"} },
+		{name: "defaults", field: "x", expected: "x", fieldMap: map[string]string{}},
+		{name: "mapping-non-existing", field: "x", expected: "x", fieldMap: map[string]string{"y": "z"}},
+		{name: "mapping-existing", field: "x", expected: "z", fieldMap: map[string]string{"x": "z"}},
+		{name: "mapping-identity", field: "x", expected: "x", fieldMap: map[string]string{"x": "x"}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := NewJSONParser(JSONConfig{ Mapping: tt.fieldMap}, nil)
+			p, err := NewJSONParser(JSONConfig{Mapping: tt.fieldMap}, nil)
 			assert.NoError(t, err)
 
 			actual := p.mapField(tt.field)

--- a/pkg/logs/json_test.go
+++ b/pkg/logs/json_test.go
@@ -1,0 +1,125 @@
+package logs
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+var testJSONConfig = JSONConfig{
+	Mapping: map[string]string{"from_field_1": "to_field_1"},
+}
+
+func TestNewJSONParser(t *testing.T) {
+	tests := []struct {
+		name	string
+		wantErr	bool
+		config JSONConfig
+	}{
+		{ name: "empty config", config: JSONConfig{}, wantErr: false},
+		{ name: "empty config", config: testJSONConfig, wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewJSONParser(tt.config, nil)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, p)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, p)
+			}
+		})
+	}
+}
+
+func TestJSONParser_ReadLine(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+		config  JSONConfig
+		data    string
+	}{
+		{ name: "no error", config: JSONConfig{}, wantErr: false, data: `{ "host": "example.com" }` },
+		{ name: "splits on newline", config: JSONConfig{}, wantErr: false, data: "{\"host\": \"example.com\"}\n{\"host\": \"acme.org\"}"},
+		{ name: "error on malformed JSON", config: JSONConfig{}, wantErr: true, data: `{ "host"": unquoted_string}`},
+		{ name: "error on no data", config: JSONConfig{}, wantErr: true, data: ``},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var line logLine
+			in := strings.NewReader(tt.data)
+			p, err := NewJSONParser(tt.config, in)
+			require.NoError(t, err);
+			require.NotNil(t, p);
+
+			err = p.ReadLine(&line);
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestJSONParser_Parse(t *testing.T) {
+	tests := []struct {
+		name	string
+		row		string
+		fieldMap map[string]string
+		wantParseErr	bool
+	}{
+		{name: "malformed JSON", row: `{`, wantParseErr: true},
+		{name: "malformed JSON #2", row: `{ host: "example.com" }`, wantParseErr: true},
+		{name: "empty string", row: "", wantParseErr: true},
+		{name: "no field mapping", row: `{ "host": "example.com", "remote_addr": "127.0.0.1", "request_time": 0.05 }`, wantParseErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var line logLine
+			p, err := NewJSONParser(JSONConfig{ Mapping: tt.fieldMap}, nil)
+			assert.NoError(t, err)
+
+			parseErr := p.Parse([]byte(tt.row), line)
+
+			if tt.wantParseErr {
+				assert.Error(t, parseErr)
+			} else {
+				assert.NoError(t, parseErr)
+			}
+
+		})
+	}
+}
+
+func TestJSONParser_mapField(t *testing.T) {
+	tests := []struct {
+		name     string
+		field    string
+		expected string
+		fieldMap map[string]string
+	}{
+		{name: "defaults", field: "x", expected: "x", fieldMap: map[string]string {} },
+		{name: "mapping-non-existing", field: "x", expected: "x", fieldMap: map[string]string { "y": "z"} },
+		{name: "mapping-existing", field: "x", expected: "z", fieldMap: map[string]string { "x": "z"} },
+		{name: "mapping-identity", field: "x", expected: "x", fieldMap: map[string]string {"x": "x"} },
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewJSONParser(JSONConfig{ Mapping: tt.fieldMap}, nil)
+			assert.NoError(t, err)
+
+			actual := p.mapField(tt.field)
+
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/pkg/logs/parser.go
+++ b/pkg/logs/parser.go
@@ -33,6 +33,7 @@ const (
 	TypeCSV    = "csv"
 	TypeLTSV   = "ltsv"
 	TypeRegExp = "regexp"
+	TypeJSON   = "json"
 )
 
 type ParserConfig struct {
@@ -40,6 +41,7 @@ type ParserConfig struct {
 	CSV     CSVConfig    `yaml:"csv_config"`
 	LTSV    LTSVConfig   `yaml:"ltsv_config"`
 	RegExp  RegExpConfig `yaml:"regexp_config"`
+	JSON    JSONConfig   `yaml:"json_config"`
 }
 
 func NewParser(config ParserConfig, in io.Reader) (Parser, error) {
@@ -50,6 +52,8 @@ func NewParser(config ParserConfig, in io.Reader) (Parser, error) {
 		return NewLTSVParser(config.LTSV, in)
 	case TypeRegExp:
 		return NewRegExpParser(config.RegExp, in)
+	case TypeJSON:
+		return NewJSONParser(config.JSON, in)
 	default:
 		return nil, fmt.Errorf("invalid type: %q", config.LogType)
 	}

--- a/pkg/logs/regexp_test.go
+++ b/pkg/logs/regexp_test.go
@@ -107,12 +107,23 @@ func TestRegExpParser_Info(t *testing.T) {
 	assert.NotZero(t, p.Info())
 }
 
-type logLine struct{}
+type logLine struct {
+	assigned map[string]string
+}
 
-func (l logLine) Assign(name, val string) error {
+func newLogLine() *logLine {
+	return &logLine{
+		assigned: make(map[string]string),
+	}
+}
+
+func (l *logLine) Assign(name, val string) error {
 	switch name {
 	case "$ERR", "ERR":
 		return errors.New("assign error")
+	}
+	if l.assigned != nil {
+		l.assigned[name] = val
 	}
 	return nil
 }


### PR DESCRIPTION
This is a JSON log parser. It reads JSON files and maps fields according to the `json_config->mapping` configuration. The parser expects each line to contain single JSON entry.

If this PR is accepted, I'll push small weblog PR that makes use of JSON parser.

# Why

JSON logs are more verbose than CSV-ish files, but JSON has some clear advantages:
- it's much easier to parse and query JSON files from command line(for example using `jq`) for quick troubleshooting,
- it's easier to import them into other tools/services for further processing,
- data types might be preserved.

Some tools provide option to generate JSON logs, e.g. nginx.

# How

`json.Unmarshall()` is being used to decode JSON files. All values read by `json.Unmarshall()` are converted back to strings before they're passed to `LogLine`.

# Todo, future optimization

- ~~JSON file autodetection~~ (done, #1e673b8480050f17943437f8b3becfd08d86b9e5),
- if needed, JSON parsing might be optimized as LogLine accepts only strings and `json.Unmarshall()` type conversion is unnecessary. 