### PR TITLE
build: remove darwin/386

### DIFF
--- a/hack/go-build.sh
+++ b/hack/go-build.sh
@@ -3,7 +3,6 @@
 set -e
 
 PLATFORMS=(
-  darwin/386
   darwin/amd64
   freebsd/386
   freebsd/amd64


### PR DESCRIPTION
> Go 1.15 drops support for 32-bit binaries on macOS, iOS, iPadOS, watchOS, and tvOS (the darwin/386 and darwin/arm ports)

https://golang.org/doc/go1.15#darwin