### PR TITLE
agent: exit 0 on SIGPIPE

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -189,13 +189,7 @@ func (a *Agent) signalHandling() {
 
 	sig := <-ch
 	a.Infof("received %s signal (%d). Terminating...", sig, sig)
-
-	switch sig {
-	case syscall.SIGPIPE:
-		os.Exit(1)
-	default:
-		os.Exit(0)
-	}
+	os.Exit(0)
 }
 
 func (a *Agent) keepAlive() {


### PR DESCRIPTION
Netdata daemon doesnt restart plugin if its exit code is not 0 (even if it has been sending data for a while).

I did some tests on k8s and somehow/sometimes `go.d.plugin` got SIGPIPE on some nodes after fresh install, netdata was running tho. I think we need to exit 0 and allow netdata to restart the plugin.