### PR TITLE
agent/job/build: log number of jobs in a config group

### DIFF
--- a/agent/job/build/build.go
+++ b/agent/job/build/build.go
@@ -150,6 +150,8 @@ func (m *Manager) processGroup(ctx context.Context, group *confgroup.Group) {
 		return
 	}
 	added, removed := m.grpCache.put(group)
+	m.Debugf("received config group ('%s'): %d jobs (added: %d, removed: %d)",
+		group.Source, len(group.Configs), len(added), len(removed))
 
 	select {
 	case <-ctx.Done():

--- a/agent/job/discovery/file/read.go
+++ b/agent/job/discovery/file/read.go
@@ -66,8 +66,6 @@ func (r Reader) groups() (groups []*confgroup.Group) {
 			if group == nil {
 				group = &confgroup.Group{Source: path}
 			}
-
-			r.Debugf("file '%s' contains %d job(s)", path, len(group.Configs))
 			groups = append(groups, group)
 		}
 	}


### PR DESCRIPTION
seems better place to log number of jobs then in https://github.com/netdata/go.d.plugin/pull/474