### PR TITLE
Change configure doc to reflect new standard leftovers

### DIFF
--- a/modules/elasticsearch/README.md
+++ b/modules/elasticsearch/README.md
@@ -100,8 +100,8 @@ Enabled by default.
 
 ## Configuration
 
-Edit the `go.d/elasticsearch.conf` configuration file using `edit-config` from the Agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `go.d/elasticsearch.conf` configuration file using `edit-config` from the Netdata [config
+directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/example/README.md
+++ b/modules/example/README.md
@@ -15,20 +15,20 @@ Number of charts, dimensions and chart type is configurable.
 
 ## Configuration
 
+Edit the `go.d/example.conf` configuration file using `edit-config` from the Netdata [config
+directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+
+```bash
+cd /etc/netdata # Replace this path with your Netdata config directory
+sudo ./edit-config go.d/example.conf
+```
+
 Disabled by default. Should be explicitly enabled in [go.d.conf](https://github.com/netdata/go.d.plugin/blob/master/config/go.d.conf).
 
 ```yaml
 # go.d.conf
 modules:
   example: yes
-```
-
-Edit the `go.d/example.conf` configuration file using `edit-config` from the Agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
-
-```bash
-cd /etc/netdata # Replace this path with your Netdata config directory
-sudo ./edit-config go.d/example.conf
 ```
 
 Here is an example configuration with several jobs:

--- a/modules/filecheck/README.md
+++ b/modules/filecheck/README.md
@@ -56,8 +56,8 @@ Files and directories have their own set of charts.
 
 ## Configuration
 
-Edit the `go.d/filecheck.conf` configuration file using `edit-config` from the Agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `go.d/filecheck.conf` configuration file using `edit-config` from the Netdata [config
+directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/isc_dhcpd/README.md
+++ b/modules/isc_dhcpd/README.md
@@ -23,8 +23,8 @@ the DHCP client lease database (`dhcpd.leases`).
 
 ## Configuration
 
-Edit the `go.d/isc_dhcpd.conf` configuration file using `edit-config` from the Agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `go.d/isc_dhcpd.conf` configuration file using `edit-config` from the Netdata [config
+directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -116,8 +116,8 @@ If [User Statistics](https://mariadb.com/kb/en/user-statistics/) metrics are ava
 
 ## Configuration
 
-Edit the `go.d/mysql.conf` configuration file using `edit-config` from your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `go.d/mysql.conf` configuration file using `edit-config` from the Netdata [config
+directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/prometheus/README.md
+++ b/modules/prometheus/README.md
@@ -26,8 +26,8 @@ For example, scraping [`node_exporter`](https://github.com/prometheus/node_expor
 
 ## Configuration
 
-Edit the `go.d/prometheus.conf` configuration file using `edit-config` from the Agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `go.d/prometheus.conf` configuration file using `edit-config` from the Netdata [config
+directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/systemdunits/README.md
+++ b/modules/systemdunits/README.md
@@ -47,8 +47,8 @@ It produces the following charts:
 
 ## Configuration
 
-Edit the `go.d/systemdunits.conf` configuration file using `edit-config` from the Agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `go.d/systemdunits.conf` configuration file using `edit-config` from the Netdata [config
+directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory


### PR DESCRIPTION
from #493

- before

```cmd
0 go.d.plugin (master)$ grep "step-by-step/step-04" -R *
modules/isc_dhcpd/README.md:directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
modules/systemdunits/README.md:directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
modules/example/README.md:directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
modules/filecheck/README.md:directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
modules/mysql/README.md:directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
modules/prometheus/README.md:directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
modules/elasticsearch/README.md:directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
```

- after
```cmd
0 go.d.plugin (docs_new_standard_leftovers)$ grep "step-by-step/step-04" -R *
1 go.d.plugin (docs_new_standard_leftovers)$
```