### PR TITLE
systemdunits: use appropriate ListUnits function depends on systemd version

### DIFF
--- a/modules/systemdunits/charts.go
+++ b/modules/systemdunits/charts.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package systemdunits
 
 import (

--- a/modules/systemdunits/charts.go
+++ b/modules/systemdunits/charts.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package systemdunits
 
 import (

--- a/modules/systemdunits/client.go
+++ b/modules/systemdunits/client.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package systemdunits
 
 import (
@@ -13,6 +11,8 @@ type systemdClient interface {
 }
 type systemdConnection interface {
 	Close()
+	GetManagerProperty(string) (string, error)
+	ListUnitsContext(ctx context.Context) ([]dbus.UnitStatus, error)
 	ListUnitsByPatternsContext(ctx context.Context, states []string, patterns []string) ([]dbus.UnitStatus, error)
 }
 

--- a/modules/systemdunits/client.go
+++ b/modules/systemdunits/client.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package systemdunits
 
 import (

--- a/modules/systemdunits/collect.go
+++ b/modules/systemdunits/collect.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package systemdunits
 
 import (
@@ -29,6 +31,7 @@ func (s *SystemdUnits) collect() (map[string]int64, error) {
 
 	var units []dbus.UnitStatus
 	if s.systemdVersion >= 230 {
+		// https://github.com/systemd/systemd/pull/3142
 		units, err = s.getLoadedUnitsByPatterns(conn)
 	} else {
 		units, err = s.getLoadedUnits(conn)
@@ -81,6 +84,7 @@ var reVersion = regexp.MustCompile(`[0-9][0-9][0-9]`)
 const versionProperty = "Version"
 
 func (s *SystemdUnits) getSystemdVersion(conn systemdConnection) (int, error) {
+	s.Debugf("calling function 'GetManagerProperty'")
 	version, err := conn.GetManagerProperty(versionProperty)
 	if err != nil {
 		return 0, fmt.Errorf("error on getting '%s' manager property: %v", versionProperty, err)
@@ -105,6 +109,7 @@ func (s *SystemdUnits) getLoadedUnits(conn systemdConnection) ([]dbus.UnitStatus
 	ctx, cancel := context.WithTimeout(context.Background(), s.Timeout.Duration)
 	defer cancel()
 
+	s.Debugf("calling function 'ListUnits'")
 	units, err := conn.ListUnitsContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error on ListUnits: %v", err)
@@ -125,6 +130,7 @@ func (s *SystemdUnits) getLoadedUnitsByPatterns(conn systemdConnection) ([]dbus.
 	ctx, cancel := context.WithTimeout(context.Background(), s.Timeout.Duration)
 	defer cancel()
 
+	s.Debugf("calling function 'ListUnitsByPatterns'")
 	units, err := conn.ListUnitsByPatternsContext(
 		ctx,
 		[]string{"active", "activating", "failed", "inactive", "deactivating"},

--- a/modules/systemdunits/collect.go
+++ b/modules/systemdunits/collect.go
@@ -78,21 +78,22 @@ func (s *SystemdUnits) closeConnection() {
 
 var reVersion = regexp.MustCompile(`[0-9][0-9][0-9]`)
 
+const versionProperty = "Version"
+
 func (s *SystemdUnits) getSystemdVersion(conn systemdConnection) (int, error) {
-	const prop = "Version"
-	versionProperty, err := conn.GetManagerProperty(prop)
+	version, err := conn.GetManagerProperty(versionProperty)
 	if err != nil {
-		return 0, fmt.Errorf("error on getting '%s' manager property: %v", prop, err)
+		return 0, fmt.Errorf("error on getting '%s' manager property: %v", versionProperty, err)
 	}
 
-	s.Debugf("systemd version: %s", versionProperty)
+	s.Debugf("systemd version: %s", version)
 
-	version := reVersion.FindString(versionProperty)
-	if version == "" {
-		return 0, fmt.Errorf("couldn't parse systemd version string '%s'", versionProperty)
+	major := reVersion.FindString(version)
+	if major == "" {
+		return 0, fmt.Errorf("couldn't parse systemd version string '%s'", version)
 	}
 
-	ver, err := strconv.Atoi(version)
+	ver, err := strconv.Atoi(major)
 	if err != nil {
 		return 0, fmt.Errorf("couldn't parse systemd version string '%s': %v", versionProperty, err)
 	}

--- a/modules/systemdunits/collect.go
+++ b/modules/systemdunits/collect.go
@@ -1,10 +1,9 @@
-// +build linux
-
 package systemdunits
 
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -14,8 +13,28 @@ import (
 )
 
 func (s *SystemdUnits) collect() (map[string]int64, error) {
-	units, err := s.getLoadedUnits()
+	conn, err := s.getConnection()
 	if err != nil {
+		return nil, err
+	}
+
+	if s.systemdVersion == 0 {
+		ver, err := s.getSystemdVersion(conn)
+		if err != nil {
+			s.closeConnection()
+			return nil, err
+		}
+		s.systemdVersion = ver
+	}
+
+	var units []dbus.UnitStatus
+	if s.systemdVersion >= 230 {
+		units, err = s.getLoadedUnitsByPatterns(conn)
+	} else {
+		units, err = s.getLoadedUnits(conn)
+	}
+	if err != nil {
+		s.closeConnection()
 		return nil, err
 	}
 
@@ -23,20 +42,23 @@ func (s *SystemdUnits) collect() (map[string]int64, error) {
 		return nil, nil
 	}
 
-	mx := make(map[string]int64)
+	collected := make(map[string]int64)
+	s.collectUnitsStates(collected, units)
+	return collected, nil
+}
+
+func (s *SystemdUnits) collectUnitsStates(collected map[string]int64, units []dbus.UnitStatus) {
 	for _, unit := range units {
 		name := cleanUnitName(unit.Name)
-
 		if !s.collectedUnits[name] {
 			s.collectedUnits[name] = true
 			s.addUnitToCharts(name)
 		}
-		mx[name] = convertUnitState(unit.ActiveState)
+		collected[name] = convertUnitState(unit.ActiveState)
 	}
-	return mx, nil
 }
 
-func (s *SystemdUnits) getLoadedUnits() ([]dbus.UnitStatus, error) {
+func (s *SystemdUnits) getConnection() (systemdConnection, error) {
 	if s.conn == nil {
 		conn, err := s.client.connect()
 		if err != nil {
@@ -44,19 +66,71 @@ func (s *SystemdUnits) getLoadedUnits() ([]dbus.UnitStatus, error) {
 		}
 		s.conn = conn
 	}
+	return s.conn, nil
+}
 
+func (s *SystemdUnits) closeConnection() {
+	if s.conn != nil {
+		s.conn.Close()
+		s.conn = nil
+	}
+}
+
+var reVersion = regexp.MustCompile(`[0-9][0-9][0-9]`)
+
+func (s *SystemdUnits) getSystemdVersion(conn systemdConnection) (int, error) {
+	const prop = "Version"
+	versionProperty, err := conn.GetManagerProperty(prop)
+	if err != nil {
+		return 0, fmt.Errorf("error on getting '%s' manager property: %v", prop, err)
+	}
+
+	s.Debugf("systemd version: %s", versionProperty)
+
+	version := reVersion.FindString(versionProperty)
+	if version == "" {
+		return 0, fmt.Errorf("couldn't parse systemd version string '%s'", versionProperty)
+	}
+
+	ver, err := strconv.Atoi(version)
+	if err != nil {
+		return 0, fmt.Errorf("couldn't parse systemd version string '%s': %v", versionProperty, err)
+	}
+
+	return ver, nil
+}
+
+func (s *SystemdUnits) getLoadedUnits(conn systemdConnection) ([]dbus.UnitStatus, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), s.Timeout.Duration)
 	defer cancel()
 
-	units, err := s.conn.ListUnitsByPatternsContext(
+	units, err := conn.ListUnitsContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error on ListUnits: %v", err)
+	}
+
+	loaded := units[:0]
+	for _, unit := range units {
+		if unit.LoadState == "loaded" && s.sr.MatchString(unit.Name) {
+			loaded = append(loaded, unit)
+		}
+	}
+
+	s.Debugf("got total/loaded %d/%d units", len(units), len(loaded))
+	return loaded, nil
+}
+
+func (s *SystemdUnits) getLoadedUnitsByPatterns(conn systemdConnection) ([]dbus.UnitStatus, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), s.Timeout.Duration)
+	defer cancel()
+
+	units, err := conn.ListUnitsByPatternsContext(
 		ctx,
 		[]string{"active", "activating", "failed", "inactive", "deactivating"},
 		s.Include,
 	)
 	if err != nil {
-		s.conn.Close()
-		s.conn = nil
-		return nil, fmt.Errorf("error on listing units: %v", err)
+		return nil, fmt.Errorf("error on ListUnitsByPatterns: %v", err)
 	}
 
 	loaded := units[:0]
@@ -65,6 +139,7 @@ func (s *SystemdUnits) getLoadedUnits() ([]dbus.UnitStatus, error) {
 			loaded = append(loaded, unit)
 		}
 	}
+
 	s.Debugf("got total/loaded %d/%d units", len(units), len(loaded))
 	return loaded, nil
 }
@@ -75,6 +150,7 @@ func (s *SystemdUnits) addUnitToCharts(name string) {
 		s.Warningf("add dimension (unit '%s'): can't extract unit type", name)
 		return
 	}
+
 	id := fmt.Sprintf("%s_unit_state", typ)
 	chart := s.Charts().Get(id)
 	if chart == nil {

--- a/modules/systemdunits/init.go
+++ b/modules/systemdunits/init.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package systemdunits
 
 import (

--- a/modules/systemdunits/init.go
+++ b/modules/systemdunits/init.go
@@ -1,6 +1,7 @@
 package systemdunits
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/netdata/go.d.plugin/agent/module"
@@ -8,6 +9,9 @@ import (
 )
 
 func (s SystemdUnits) validateConfig() error {
+	if len(s.Include) == 0 {
+		return errors.New("'include' option not set")
+	}
 	return nil
 }
 

--- a/modules/systemdunits/init.go
+++ b/modules/systemdunits/init.go
@@ -1,0 +1,25 @@
+package systemdunits
+
+import (
+	"strings"
+
+	"github.com/netdata/go.d.plugin/agent/module"
+	"github.com/netdata/go.d.plugin/pkg/matcher"
+)
+
+func (s SystemdUnits) validateConfig() error {
+	return nil
+}
+
+func (s SystemdUnits) initSelector() (matcher.Matcher, error) {
+	if len(s.Include) == 0 {
+		return matcher.TRUE(), nil
+	}
+
+	expr := strings.Join(s.Include, " ")
+	return matcher.NewSimplePatternsMatcher(expr)
+}
+
+func (s SystemdUnits) initCharts() (*module.Charts, error) {
+	return charts.Copy(), nil
+}

--- a/modules/systemdunits/systemdunits.go
+++ b/modules/systemdunits/systemdunits.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package systemdunits
 
 import (

--- a/modules/systemdunits/systemdunits.go
+++ b/modules/systemdunits/systemdunits.go
@@ -1,11 +1,10 @@
-// +build linux
-
 package systemdunits
 
 import (
 	"time"
 
 	"github.com/netdata/go.d.plugin/agent/module"
+	"github.com/netdata/go.d.plugin/pkg/matcher"
 	"github.com/netdata/go.d.plugin/pkg/web"
 )
 
@@ -30,7 +29,6 @@ func New() *SystemdUnits {
 
 		client:         newSystemdDBusClient(),
 		collectedUnits: make(map[string]bool),
-		charts:         charts.Copy(),
 	}
 }
 
@@ -39,24 +37,41 @@ type Config struct {
 	Timeout web.Duration `yaml:"timeout"`
 }
 
-type (
-	SystemdUnits struct {
-		module.Base
-		Config `yaml:",inline"`
+type SystemdUnits struct {
+	module.Base
+	Config `yaml:",inline"`
 
-		client systemdClient
-		conn   systemdConnection
+	client systemdClient
+	conn   systemdConnection
 
-		collectedUnits map[string]bool
-		charts         *module.Charts
-	}
-)
+	systemdVersion int
+	collectedUnits map[string]bool
+	sr             matcher.Matcher
+
+	charts *module.Charts
+}
 
 func (s *SystemdUnits) Init() bool {
-	if len(s.Include) == 0 {
-		s.Error("'include' option not set")
+	err := s.validateConfig()
+	if err != nil {
+		s.Errorf("config validation: %v", err)
 		return false
 	}
+
+	sr, err := s.initSelector()
+	if err != nil {
+		s.Errorf("init selector: %v", err)
+		return false
+	}
+	s.sr = sr
+
+	cs, err := s.initCharts()
+	if err != nil {
+		s.Errorf("init charts: %v", err)
+		return false
+	}
+	s.charts = cs
+
 	s.Debugf("unit names patterns: %v", s.Include)
 	s.Debugf("timeout: %s", s.Timeout)
 	return true
@@ -71,20 +86,17 @@ func (s *SystemdUnits) Charts() *module.Charts {
 }
 
 func (s *SystemdUnits) Collect() map[string]int64 {
-	mx, err := s.collect()
+	ms, err := s.collect()
 	if err != nil {
 		s.Error(err)
 	}
 
-	if len(mx) == 0 {
+	if len(ms) == 0 {
 		return nil
 	}
-	return mx
+	return ms
 }
 
 func (s *SystemdUnits) Cleanup() {
-	if s.conn != nil {
-		s.conn.Close()
-		s.conn = nil
-	}
+	s.closeConnection()
 }

--- a/modules/systemdunits/systemdunits_test.go
+++ b/modules/systemdunits/systemdunits_test.go
@@ -199,7 +199,7 @@ func TestSystemdUnits_Collect(t *testing.T) {
 				"var-lib-nfs-rpc_pipefs.mount":             2,
 			},
 		},
-		"success on systemd version 230- on collecting all unit types": {
+		"success on systemd v230- on collecting all unit types": {
 			prepare: func() *SystemdUnits {
 				systemd := New()
 				systemd.Include = []string{"*"}
@@ -442,7 +442,7 @@ func (m mockConn) ListUnitsContext(_ context.Context) ([]dbus.UnitStatus, error)
 	if m.version >= 230 {
 		return nil, errors.New("'ListUnits' unsupported function error")
 	}
-	return m.units, nil
+	return append([]dbus.UnitStatus{}, m.units...), nil
 }
 
 func (m mockConn) ListUnitsByPatternsContext(_ context.Context, _ []string, ps []string) ([]dbus.UnitStatus, error) {

--- a/modules/systemdunits/systemdunits_test.go
+++ b/modules/systemdunits/systemdunits_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package systemdunits
 
 import (

--- a/modules/systemdunits/systemdunits_test.go
+++ b/modules/systemdunits/systemdunits_test.go
@@ -3,6 +3,7 @@ package systemdunits
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -22,19 +23,17 @@ func TestSystemdUnits_Init(t *testing.T) {
 		config   Config
 		wantFail bool
 	}{
-		"default": {
+		"success on default config": {
 			config: New().Config,
 		},
-		"'include' option set": {
+		"success when 'include' option set": {
 			config: Config{
 				Include: []string{"*"},
 			},
 		},
-		"'include' option not set": {
+		"fails when 'include' option not set": {
 			wantFail: true,
-			config: Config{
-				Include: []string{},
-			},
+			config:   Config{Include: []string{}},
 		},
 	}
 
@@ -57,36 +56,52 @@ func TestSystemdUnits_Check(t *testing.T) {
 		prepare  func() *SystemdUnits
 		wantFail bool
 	}{
-		"successful collection": {
+		"success on systemd v230+": {
 			prepare: func() *SystemdUnits {
 				systemd := New()
 				systemd.Include = []string{"*"}
-				systemd.client = prepareOKClient()
+				systemd.client = prepareOKClient(230)
 				return systemd
 			},
 		},
-		"filter all units": {
+		"success on systemd v230-": {
+			prepare: func() *SystemdUnits {
+				systemd := New()
+				systemd.Include = []string{"*"}
+				systemd.client = prepareOKClient(220)
+				return systemd
+			},
+		},
+		"fails when all unites are filtered": {
 			wantFail: true,
 			prepare: func() *SystemdUnits {
 				systemd := New()
 				systemd.Include = []string{"*.not_exists"}
-				systemd.client = prepareOKClient()
+				systemd.client = prepareOKClient(230)
 				return systemd
 			},
 		},
-		"error on connect": {
+		"fails on error on connect": {
 			wantFail: true,
 			prepare: func() *SystemdUnits {
 				systemd := New()
-				systemd.client = prepareErrOnConnectClient()
+				systemd.client = prepareClientErrOnConnect()
 				return systemd
 			},
 		},
-		"error on list units": {
+		"fails on error on get manager property": {
 			wantFail: true,
 			prepare: func() *SystemdUnits {
 				systemd := New()
-				systemd.client = prepareErrOnListUnitsClient()
+				systemd.client = prepareClientErrOnGetManagerProperty()
+				return systemd
+			},
+		},
+		"fails on error on list units": {
+			wantFail: true,
+			prepare: func() *SystemdUnits {
+				systemd := New()
+				systemd.client = prepareClientErrOnListUnits()
 				return systemd
 			},
 		},
@@ -107,14 +122,15 @@ func TestSystemdUnits_Check(t *testing.T) {
 }
 
 func TestSystemdUnits_Charts(t *testing.T) {
-	assert.NotNil(t, New().Charts())
-
+	systemd := New()
+	require.True(t, systemd.Init())
+	assert.NotNil(t, systemd.Charts())
 }
 
 func TestSystemdUnits_Cleanup(t *testing.T) {
 	systemd := New()
 	systemd.Include = []string{"*"}
-	client := prepareOKClient()
+	client := prepareOKClient(230)
 	systemd.client = client
 
 	require.True(t, systemd.Init())
@@ -132,11 +148,11 @@ func TestSystemdUnits_Collect(t *testing.T) {
 		prepare       func() *SystemdUnits
 		wantCollected map[string]int64
 	}{
-		"collect all unit types": {
+		"success on systemd v230+ on collecting all unit type": {
 			prepare: func() *SystemdUnits {
 				systemd := New()
 				systemd.Include = []string{"*"}
-				systemd.client = prepareOKClient()
+				systemd.client = prepareOKClient(230)
 				return systemd
 			},
 			wantCollected: map[string]int64{
@@ -183,11 +199,62 @@ func TestSystemdUnits_Collect(t *testing.T) {
 				"var-lib-nfs-rpc_pipefs.mount":             2,
 			},
 		},
-		"collect only 'service' unit type": {
+		"success on systemd version 230- on collecting all unit types": {
+			prepare: func() *SystemdUnits {
+				systemd := New()
+				systemd.Include = []string{"*"}
+				systemd.client = prepareOKClient(220)
+				return systemd
+			},
+			wantCollected: map[string]int64{
+				"dbus.socket":                              1,
+				"dev-disk-by-uuid-DE44-CEE0.device":        1,
+				"dev-nvme0n1.device":                       1,
+				"docker.socket":                            1,
+				"getty-pre.target":                         2,
+				"init.scope":                               1,
+				"logrotate.timer":                          1,
+				"lvm2-lvmetad.socket":                      1,
+				"lvm2-lvmpolld.socket":                     1,
+				"man-db.timer":                             1,
+				"org.cups.cupsd.path":                      1,
+				"pamac-cleancache.timer":                   1,
+				"pamac-mirrorlist.timer":                   1,
+				"proc-sys-fs-binfmt_misc.automount":        1,
+				"remote-fs-pre.target":                     2,
+				"rpc_pipefs.target":                        2,
+				"run-user-1000-gvfs.mount":                 1,
+				"run-user-1000.mount":                      1,
+				"session-1.scope":                          1,
+				"session-2.scope":                          1,
+				"session-3.scope":                          1,
+				"session-6.scope":                          1,
+				"shadow.timer":                             1,
+				"sound.target":                             1,
+				"sys-devices-virtual-net-loopback1.device": 1,
+				"sys-module-fuse.device":                   1,
+				"sysinit.target":                           1,
+				"system-getty.slice":                       1,
+				"system-netctl.slice":                      1,
+				"system-systemd-fsck.slice":                1,
+				"system.slice":                             1,
+				"systemd-ask-password-console.path":        1,
+				"systemd-ask-password-wall.path":           1,
+				"systemd-ask-password-wall.service":        2,
+				"systemd-fsck-root.service":                2,
+				"systemd-udevd-kernel.socket":              1,
+				"tmp.mount":                                1,
+				"user-runtime-dir@1000.service":            1,
+				"user.slice":                               1,
+				"user@1000.service":                        1,
+				"var-lib-nfs-rpc_pipefs.mount":             2,
+			},
+		},
+		"success on systemd v230+ on collecting only 'service' unit type": {
 			prepare: func() *SystemdUnits {
 				systemd := New()
 				systemd.Include = []string{"*.service"}
-				systemd.client = prepareOKClient()
+				systemd.client = prepareOKClient(230)
 				return systemd
 			},
 			wantCollected: map[string]int64{
@@ -197,27 +264,49 @@ func TestSystemdUnits_Collect(t *testing.T) {
 				"user@1000.service":                 1,
 			},
 		},
-		"filter all units": {
+		"success on systemd v230- on collecting only 'service' unit type": {
+			prepare: func() *SystemdUnits {
+				systemd := New()
+				systemd.Include = []string{"*.service"}
+				systemd.client = prepareOKClient(220)
+				return systemd
+			},
+			wantCollected: map[string]int64{
+				"systemd-ask-password-wall.service": 2,
+				"systemd-fsck-root.service":         2,
+				"user-runtime-dir@1000.service":     1,
+				"user@1000.service":                 1,
+			},
+		},
+		"fails when all unites are filtered": {
 			prepare: func() *SystemdUnits {
 				systemd := New()
 				systemd.Include = []string{"*.not_exists"}
-				systemd.client = prepareOKClient()
+				systemd.client = prepareOKClient(230)
 				return systemd
 			},
 			wantCollected: nil,
 		},
-		"error on connect": {
+		"fails on error on connect": {
 			prepare: func() *SystemdUnits {
 				systemd := New()
-				systemd.client = prepareErrOnConnectClient()
+				systemd.client = prepareClientErrOnConnect()
 				return systemd
 			},
 			wantCollected: nil,
 		},
-		"error on list units": {
+		"fails on error on get manager property": {
 			prepare: func() *SystemdUnits {
 				systemd := New()
-				systemd.client = prepareErrOnListUnitsClient()
+				systemd.client = prepareClientErrOnGetManagerProperty()
+				return systemd
+			},
+			wantCollected: nil,
+		},
+		"fails on error on list units": {
+			prepare: func() *SystemdUnits {
+				systemd := New()
+				systemd.client = prepareClientErrOnListUnits()
 				return systemd
 			},
 			wantCollected: nil,
@@ -236,7 +325,9 @@ func TestSystemdUnits_Collect(t *testing.T) {
 			}
 
 			assert.Equal(t, test.wantCollected, collected)
-			ensureCollectedHasAllChartsDimsVarsIDs(t, systemd, collected)
+			if len(test.wantCollected) > 0 {
+				ensureCollectedHasAllChartsDimsVarsIDs(t, systemd, collected)
+			}
 		})
 	}
 }
@@ -244,7 +335,7 @@ func TestSystemdUnits_Collect(t *testing.T) {
 func TestSystemdUnits_connectionReuse(t *testing.T) {
 	systemd := New()
 	systemd.Include = []string{"*"}
-	client := prepareOKClient()
+	client := prepareOKClient(230)
 	systemd.client = client
 	require.True(t, systemd.Init())
 
@@ -273,24 +364,37 @@ func ensureCollectedHasAllChartsDimsVarsIDs(t *testing.T, sd *SystemdUnits, coll
 	}
 }
 
-func prepareOKClient() *mockClient {
+func prepareOKClient(ver int) *mockClient {
 	return &mockClient{
 		conn: &mockConn{
-			units: mockSystemdUnits,
+			version: ver,
+			units:   mockSystemdUnits,
 		},
 	}
 }
 
-func prepareErrOnConnectClient() *mockClient {
+func prepareClientErrOnConnect() *mockClient {
 	return &mockClient{
 		errOnConnect: true,
 	}
 }
 
-func prepareErrOnListUnitsClient() *mockClient {
+func prepareClientErrOnGetManagerProperty() *mockClient {
 	return &mockClient{
 		conn: &mockConn{
+			version:                 230,
+			errOnGetManagerProperty: true,
+			units:                   mockSystemdUnits,
+		},
+	}
+}
+
+func prepareClientErrOnListUnits() *mockClient {
+	return &mockClient{
+		conn: &mockConn{
+			version:        230,
 			errOnListUnits: true,
+			units:          mockSystemdUnits,
 		},
 	}
 }
@@ -310,18 +414,43 @@ func (m *mockClient) connect() (systemdConnection, error) {
 }
 
 type mockConn struct {
-	units          []dbus.UnitStatus
-	errOnListUnits bool
-	closeCalled    bool
+	version                 int
+	units                   []dbus.UnitStatus
+	errOnGetManagerProperty bool
+	errOnListUnits          bool
+	closeCalled             bool
 }
 
 func (m *mockConn) Close() {
 	m.closeCalled = true
 }
 
+func (m mockConn) GetManagerProperty(prop string) (string, error) {
+	if m.errOnGetManagerProperty {
+		return "", errors.New("'GetManagerProperty' call error")
+	}
+	if prop != versionProperty {
+		return "", fmt.Errorf("'GetManagerProperty' unkown property: %s", prop)
+	}
+	return fmt.Sprintf("%d.6-1-manjaro", m.version), nil
+}
+
+func (m mockConn) ListUnitsContext(_ context.Context) ([]dbus.UnitStatus, error) {
+	if m.errOnListUnits {
+		return nil, errors.New("'ListUnits' call error")
+	}
+	if m.version >= 230 {
+		return nil, errors.New("'ListUnits' unsupported function error")
+	}
+	return m.units, nil
+}
+
 func (m mockConn) ListUnitsByPatternsContext(_ context.Context, _ []string, ps []string) ([]dbus.UnitStatus, error) {
 	if m.errOnListUnits {
-		return nil, errors.New("mock 'ListUnitsByPatterns' error")
+		return nil, errors.New("'ListUnitsByPatterns' call error")
+	}
+	if m.version < 230 {
+		return nil, errors.New("'ListUnitsByPatterns' unsupported function error")
 	}
 
 	matches := func(name string) bool {

--- a/modules/systemdunits/systemdunits_test.go
+++ b/modules/systemdunits/systemdunits_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package systemdunits
 
 import (


### PR DESCRIPTION
Fixes: #499

Fix is to use `ListUnits` if systemd version < 230 and filter units on our side, if systemd version 230+ nothing changed - we keep using `ListUnitsByPatterns`.

---

@thiagoftsm could you test it on old Centos?

```cmd
git clone https://github.com/ilyam8/go.d.plugin --branch=systemdunits_listunits_comp_fix godsystemd
cd godsystemd
hack/go-build.sh
bin/godplugin -d -m systemdunits
```