### PR TITLE
add dnsmasq dns forwarder collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you have time and willing to help, there are a lof of ways to contribute:
 
 ## Available modules
 
-| Name                                                                                      | Monitors                   |
+| Name                                                                                              | Monitors                        |
 | :------------------------------------------------------------------------------------------------ | :------------------------------ |
 | [activemq](https://github.com/netdata/go.d.plugin/tree/master/modules/activemq)                   | `ActiveMQ`                      |
 | [apache](https://github.com/netdata/go.d.plugin/tree/master/modules/apache)                       | `Apache`                        |
@@ -33,7 +33,8 @@ If you have time and willing to help, there are a lof of ways to contribute:
 | [consul](https://github.com/netdata/go.d.plugin/tree/master/modules/consul)                       | `Consul`                        |
 | [coredns](https://github.com/netdata/go.d.plugin/tree/master/modules/coredns)                     | `CoreDNS`                       |
 | [couchdb](https://github.com/netdata/go.d.plugin/tree/master/modules/couchdb)                     | `CouchDB`                       |
-| [dnsmasq_dhcp](https://github.com/netdata/go.d.plugin/tree/master/modules/dnsmasq_dhcp)           | `Dnsmasq`                       |
+| [dnsmasq](https://github.com/netdata/go.d.plugin/tree/master/modules/dnsmasq)                     | `Dnsmasq DNS Forwarder`         |
+| [dnsmasq_dhcp](https://github.com/netdata/go.d.plugin/tree/master/modules/dnsmasq_dhcp)           | `Dnsmasq DHCP`                  |
 | [dns_query](https://github.com/netdata/go.d.plugin/tree/master/modules/dnsquery)                  | `DNS Query RTT`                 |
 | [docker_engine](https://github.com/netdata/go.d.plugin/tree/master/modules/docker_engine)         | `Docker Engine`                 |
 | [dockerhub](https://github.com/netdata/go.d.plugin/tree/master/modules/dockerhub)                 | `Docker Hub`                    |

--- a/config/go.d/dnsmasq.conf
+++ b/config/go.d/dnsmasq.conf
@@ -61,10 +61,10 @@
 #    Syntax:
 #      address: 127.0.0.1:53
 #
-#  - network
+#  - protocol
 #    DNS query transport protocol. Valid options: udp, tcp, tcp-tls.
 #    Syntax:
-#      network: udp
+#      protocol: udp
 #
 #  - timeout
 #    DNS query timeout (dial, write and read) in seconds.
@@ -74,7 +74,7 @@
 #
 # [ JOB defaults ]:
 #  address: 127.0.0.1:53
-#  network: udp
+#  protocol: udp
 #  timeout: 1
 #
 #
@@ -92,9 +92,9 @@
 # [ JOBS ]
 jobs:
   - name: local
-    network: udp
-    addresss: '127.0.0.1:53'
+    protocol: udp
+    address: '127.0.0.1:53'
 
 #  - name: remote
-#    network: udp
-#    addresss: '203.0.113.0:53'
+#    protocol: udp
+#    address: '203.0.113.0:53'

--- a/config/go.d/dnsmasq.conf
+++ b/config/go.d/dnsmasq.conf
@@ -1,0 +1,100 @@
+# netdata go.d.plugin configuration for dnsmasq
+#
+# This file is in YAML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - GLOBAL
+#  - JOBS
+#
+#
+# [ GLOBAL ]
+# These variables set the defaults for all JOBs, however each JOB may define its own, overriding the defaults.
+#
+# The GLOBAL section format:
+# param1: value1
+# param2: value2
+#
+# Currently supported global parameters:
+#  - update_every
+#    Data collection frequency in seconds. Default: 1.
+#
+#  - autodetection_retry
+#    Re-check interval in seconds. Attempts to start the job are made once every interval.
+#    Zero means not to schedule re-check. Default: 0.
+#
+#  - priority
+#    Priority is the relative priority of the charts as rendered on the web page,
+#    lower numbers make the charts appear before the ones with higher numbers. Default: 70000.
+#
+#
+# [ JOBS ]
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# IMPORTANT:
+#  - Parameter 'name' is mandatory.
+#  - Jobs with the same name are mutually exclusive. Only one of them will be allowed running at any time.
+#
+# This allows autodetection to try several alternatives and pick the one that works.
+# Any number of jobs is supported.
+#
+# The JOBS section format:
+#
+# jobs:
+#   - name: job1
+#     param1: value1
+#     param2: value2
+#
+#   - name: job2
+#     param1: value1
+#     param2: value2
+#
+#   - name: job2
+#     param1: value1
+#
+#
+# [ List of JOB specific parameters ]:
+#  - address
+#    Server's address. Format is 'ip_address:port'.
+#    Syntax:
+#      address: 127.0.0.1:53
+#
+#  - network
+#    DNS query transport protocol. Valid options: udp, tcp, tcp-tls.
+#    Syntax:
+#      network: udp
+#
+#  - timeout
+#    DNS query timeout (dial, write and read) in seconds.
+#    Syntax:
+#      timeout: 1
+#
+#
+# [ JOB defaults ]:
+#  address: 127.0.0.1:53
+#  network: udp
+#  timeout: 1
+#
+#
+# [ JOB mandatory parameters ]:
+#  - name
+#  - address
+#
+# ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
+# [ GLOBAL ]
+# update_every: 1
+# autodetection_retry: 0
+# priority: 70000
+#
+#
+# [ JOBS ]
+jobs:
+  - name: local
+    network: udp
+    addresss: '127.0.0.1:53'
+
+#  - name: remote
+#    network: udp
+#    addresss: '203.0.113.0:53'

--- a/modules/dnsmasq/README.md
+++ b/modules/dnsmasq/README.md
@@ -1,0 +1,80 @@
+<!--
+title: "Dnsmasq DNS Forwarder"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/dnsmasq/README.md
+sidebar_label: "Dnsmasq DNS Forwarder"
+-->
+
+# Dnsmasq DNS Forwarder
+
+[`Dnsmasq`](http://www.thekelleys.org.uk/dnsmasq/doc.html) is a lightweight, easy to configure DNS forwarder,
+designed to provide DNS (and optionally DHCP and TFTP) services to a small-scale network.
+
+This module monitors one or more `Dnsmasq DNS Forwarder` instances, depending on your configuration.
+
+It collects DNS cache statistics by [reading the response for the following query](https://manpages.debian.org/stretch/dnsmasq-base/dnsmasq.8.en.html#NOTES):
+
+```cmd
+;; opcode: QUERY, status: NOERROR, id: 37862
+;; flags: rd; QUERY: 7, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0
+
+;; QUESTION SECTION:
+;cachesize.bind.   CH	 TXT
+;insertions.bind.  CH	 TXT
+;evictions.bind.   CH	 TXT
+;hits.bind.        CH	 TXT
+;misses.bind.      CH	 TXT
+;auth.bind.        CH	 TXT
+;servers.bind.     CH	 TXT
+```
+
+## Charts
+
+-   Queries forwarded to the upstream servers in `queries/s`
+-   Cache entries in `entries`
+-   Cache operations in `operations/s`
+-   Cache performance in `events/s`
+
+## Configuration
+
+Edit the `go.d/dnsmasq.conf` configuration file using `edit-config` from the Netdata [config
+directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+
+```bash
+cd /etc/netdata # Replace this path with your Netdata config directory
+sudo ./edit-config go.d/dnsmasq.conf
+```
+
+Needs only `address`, here is an example with two jobs:
+
+```yaml
+jobs:
+  - name: local
+    address: '127.0.0.1:53'
+
+  - name: remote
+    address: '203.0.113.0:53'
+```
+
+For all available options, see the `dnsmasq` collector's [configuration
+file](https://github.com/netdata/go.d.plugin/blob/master/config/go.d/dnsmasq.conf).
+
+
+## Troubleshooting
+
+To troubleshoot issues with the `dnsmasq` collector, run the `go.d.plugin` with the debug option enabled.
+The output should give you clues as to why the collector isn't working.
+
+First, navigate to your plugins directory, usually at `/usr/libexec/netdata/plugins.d/`. If that's not the case on your
+system, open `netdata.conf` and look for the setting `plugins directory`. Once you're in the plugin's directory, switch
+to the `netdata` user.
+
+```bash
+cd /usr/libexec/netdata/plugins.d/
+sudo -u netdata -s
+```
+
+You can now run the `go.d.plugin` orchestrator to debug the collector:
+
+```bash
+./go.d.plugin -d -m dnsmasq
+```

--- a/modules/dnsmasq/README.md
+++ b/modules/dnsmasq/README.md
@@ -11,7 +11,7 @@ designed to provide DNS (and optionally DHCP and TFTP) services to a small-scale
 
 This module monitors one or more `Dnsmasq DNS Forwarder` instances, depending on your configuration.
 
-It collects DNS cache statistics by [reading the response for the following query](https://manpages.debian.org/stretch/dnsmasq-base/dnsmasq.8.en.html#NOTES):
+It collects DNS cache statistics by [reading the response on the following query](https://manpages.debian.org/stretch/dnsmasq-base/dnsmasq.8.en.html#NOTES):
 
 ```cmd
 ;; opcode: QUERY, status: NOERROR, id: 37862

--- a/modules/dnsmasq/charts.go
+++ b/modules/dnsmasq/charts.go
@@ -1,0 +1,51 @@
+package dnsmasq
+
+import "github.com/netdata/go.d.plugin/agent/module"
+
+var cacheCharts = module.Charts{
+	{
+		ID:    "servers_queries",
+		Title: "Queries forwarded to the upstream servers",
+		Units: "queries/s",
+		Fam:   "servers",
+		Ctx:   "dnsmasq.servers_queries",
+		Dims: module.Dims{
+			{ID: "queries", Name: "success", Algo: module.Incremental},
+			{ID: "failed_queries", Name: "failed", Algo: module.Incremental},
+		},
+	},
+	{
+		ID:    "cache_entries",
+		Title: "Cache entries",
+		Units: "entries",
+		Fam:   "cache",
+		Ctx:   "dnsmasq.cache_entries",
+		Type:  module.Area,
+		Dims: module.Dims{
+			{ID: "cachesize", Name: "max"},
+			{ID: "cache_entries", Name: "current"},
+		},
+	},
+	{
+		ID:    "cache_operations",
+		Title: "Cache operations",
+		Units: "operations/s",
+		Fam:   "cache",
+		Ctx:   "dnsmasq.cache_operations",
+		Dims: module.Dims{
+			{ID: "insertions", Algo: module.Incremental},
+			{ID: "evictions", Algo: module.Incremental},
+		},
+	},
+	{
+		ID:    "cache_performance",
+		Title: "Cache performance",
+		Units: "events/s",
+		Fam:   "cache",
+		Ctx:   "dnsmasq.cache_performance",
+		Dims: module.Dims{
+			{ID: "hits", Algo: module.Incremental},
+			{ID: "misses", Algo: module.Incremental},
+		},
+	},
+}

--- a/modules/dnsmasq/collect.go
+++ b/modules/dnsmasq/collect.go
@@ -1,0 +1,139 @@
+package dnsmasq
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+func (d *Dnsmasq) collect() (map[string]int64, error) {
+	r, err := d.queryCacheStatistics()
+	if err != nil {
+		return nil, err
+	}
+
+	ms := make(map[string]int64)
+	err = d.collectResponse(ms, r)
+	if err != nil {
+		return nil, err
+	}
+
+	calcCacheEntries(ms)
+	return ms, nil
+}
+
+func calcCacheEntries(ms map[string]int64) {
+	if !has(ms, "insertions", "evictions") {
+		return
+	}
+	ms["cache_entries"] = ms["insertions"] - ms["evictions"]
+}
+
+func (d *Dnsmasq) collectResponse(ms map[string]int64, resp *dns.Msg) error {
+	/*
+		;; flags: qr aa rd ra; QUERY: 7, ANSWER: 7, AUTHORITY: 0, ADDITIONAL: 0
+
+		;; QUESTION SECTION:
+		;cachesize.bind.	CH	 TXT
+		;insertions.bind.	CH	 TXT
+		;evictions.bind.	CH	 TXT
+		;hits.bind.			CH	 TXT
+		;misses.bind.		CH	 TXT
+		;auth.bind.			CH	 TXT
+		;servers.bind.		CH	 TXT
+
+		;; ANSWER SECTION:
+		cachesize.bind.		0	CH	TXT	"150"
+		insertions.bind.	0	CH	TXT	"1"
+		evictions.bind.		0	CH	TXT	"0"
+		hits.bind.			0	CH	TXT	"176"
+		misses.bind.		0	CH	TXT	"4"
+		auth.bind.			0	CH	TXT	"0"
+		servers.bind.		0	CH	TXT	"10.0.0.1#53 0 0" "1.1.1.1#53 4 3" "1.0.0.1#53 3 0"
+	*/
+	for _, a := range resp.Answer {
+		txt, ok := a.(*dns.TXT)
+		if !ok {
+			continue
+		}
+
+		idx := strings.IndexByte(txt.Hdr.Name, '.')
+		if idx == -1 {
+			continue
+		}
+
+		switch name := txt.Hdr.Name[:idx]; name {
+		case "servers":
+			for _, entry := range txt.Txt {
+				parts := strings.Fields(entry)
+				if len(parts) != 3 {
+					return fmt.Errorf("parse %s (%s): unexpected format", txt.Hdr.Name, entry)
+				}
+				queries, err := strconv.ParseFloat(parts[1], 64)
+				if err != nil {
+					return fmt.Errorf("parse '%s' (%s): %v", txt.Hdr.Name, entry, err)
+				}
+				failedQueries, err := strconv.ParseFloat(parts[2], 64)
+				if err != nil {
+					return fmt.Errorf("parse '%s' (%s): %v", txt.Hdr.Name, entry, err)
+				}
+
+				ms["queries"] += int64(queries)
+				ms["failed_queries"] += int64(failedQueries)
+			}
+		case "cachesize", "insertions", "evictions", "hits", "misses", "auth":
+			if len(txt.Txt) != 1 {
+				return fmt.Errorf("parse '%s' (%v): unexpected format", txt.Hdr.Name, txt.Txt)
+			}
+			v, err := strconv.ParseFloat(txt.Txt[0], 64)
+			if err != nil {
+				return fmt.Errorf("parse '%s' (%s): %v", txt.Hdr.Name, txt.Txt[0], err)
+			}
+
+			ms[name] = int64(v)
+		}
+	}
+	return nil
+}
+
+func (d *Dnsmasq) queryCacheStatistics() (*dns.Msg, error) {
+	msg := &dns.Msg{
+		MsgHdr: dns.MsgHdr{
+			Id:               dns.Id(),
+			RecursionDesired: true,
+		},
+		Question: []dns.Question{
+			{Name: "cachesize.bind.", Qtype: dns.TypeTXT, Qclass: dns.ClassCHAOS},
+			{Name: "insertions.bind.", Qtype: dns.TypeTXT, Qclass: dns.ClassCHAOS},
+			{Name: "evictions.bind.", Qtype: dns.TypeTXT, Qclass: dns.ClassCHAOS},
+			{Name: "hits.bind.", Qtype: dns.TypeTXT, Qclass: dns.ClassCHAOS},
+			{Name: "misses.bind.", Qtype: dns.TypeTXT, Qclass: dns.ClassCHAOS},
+			{Name: "auth.bind.", Qtype: dns.TypeTXT, Qclass: dns.ClassCHAOS},
+			{Name: "servers.bind.", Qtype: dns.TypeTXT, Qclass: dns.ClassCHAOS},
+		},
+	}
+
+	r, _, err := d.dnsClient.Exchange(msg, d.Address)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		return nil, fmt.Errorf("'%s' returned an empty response", d.Address)
+	}
+	if r.Rcode != dns.RcodeSuccess {
+		s := dns.RcodeToString[r.Rcode]
+		return nil, fmt.Errorf("'%s' returned '%s' (%d) response code", d.Address, s, r.Rcode)
+	}
+	return r, nil
+}
+
+func has(m map[string]int64, key string, keys ...string) bool {
+	switch _, ok := m[key]; len(keys) {
+	case 0:
+		return ok
+	default:
+		return ok && has(m, keys[0], keys[1:]...)
+	}
+}

--- a/modules/dnsmasq/dev.md
+++ b/modules/dnsmasq/dev.md
@@ -1,0 +1,24 @@
+#### Setup Dnsmasq
+
+Just run the docker command ([image page](https://hub.docker.com/r/andyshinn/dnsmasq)):
+
+```cmd
+docker run \
+	--name dnsmasq \
+	-d \
+	-p 53:53/udp \
+	--cap-add=NET_ADMIN \
+	andyshinn/dnsmasq
+```
+
+#### Gather metrics.
+
+See [cache statistics section](https://manpages.debian.org/stretch/dnsmasq-base/dnsmasq.8.en.html#NOTES).
+
+The cache statistics are also available in the DNS as answers to 
+queries of class CHAOS and type TXT in domain bind.
+The domain names are `cachesize.bind`, `insertions.bind`, `evictions.bind`,
+`misses.bind`, `hits.bind`, `auth.bind` and `servers.bind`. An example command to query this,
+using the dig utility would be:
+
+> dig +short chaos txt cachesize.bind

--- a/modules/dnsmasq/dnsmasq.go
+++ b/modules/dnsmasq/dnsmasq.go
@@ -1,0 +1,101 @@
+package dnsmasq
+
+import (
+	"time"
+
+	"github.com/netdata/go.d.plugin/agent/module"
+	"github.com/netdata/go.d.plugin/pkg/web"
+
+	"github.com/miekg/dns"
+)
+
+func init() {
+	module.Register("dnsmasq", module.Creator{
+		Create: func() module.Module { return New() },
+	})
+}
+
+func New() *Dnsmasq {
+	return &Dnsmasq{
+		Config: Config{
+			Network: "udp",
+			Address: "127.0.0.1:53",
+			Timeout: web.Duration{Duration: time.Second},
+		},
+
+		newDNSClient: func(network string, timeout time.Duration) dnsClient {
+			return &dns.Client{
+				Net:     network,
+				Timeout: timeout,
+			}
+		},
+	}
+}
+
+type Config struct {
+	Network string       `yaml:"network"`
+	Address string       `yaml:"address"`
+	Timeout web.Duration `yaml:"timeout"`
+}
+
+type (
+	Dnsmasq struct {
+		module.Base
+		Config `yaml:",inline"`
+
+		newDNSClient func(network string, timeout time.Duration) dnsClient
+		dnsClient    dnsClient
+
+		charts *module.Charts
+	}
+
+	dnsClient interface {
+		Exchange(msg *dns.Msg, address string) (resp *dns.Msg, rtt time.Duration, err error)
+	}
+)
+
+func (d *Dnsmasq) Init() bool {
+	err := d.validateConfig()
+	if err != nil {
+		d.Errorf("config validation: %v", err)
+		return false
+	}
+
+	client, err := d.initDNSClient()
+	if err != nil {
+		d.Errorf("init DNS client: %v", err)
+		return false
+	}
+	d.dnsClient = client
+
+	charts, err := d.initCharts()
+	if err != nil {
+		d.Errorf("init charts: %v", err)
+		return false
+	}
+	d.charts = charts
+
+	return true
+}
+
+func (d *Dnsmasq) Check() bool {
+	return len(d.Collect()) > 0
+}
+
+func (d *Dnsmasq) Charts() *module.Charts {
+	return d.charts
+}
+
+func (d *Dnsmasq) Collect() map[string]int64 {
+	ms, err := d.collect()
+	if err != nil {
+		d.Error(err)
+	}
+
+	if len(ms) == 0 {
+		return nil
+	}
+	return ms
+}
+
+func (Dnsmasq) Cleanup() {}

--- a/modules/dnsmasq/dnsmasq.go
+++ b/modules/dnsmasq/dnsmasq.go
@@ -18,9 +18,9 @@ func init() {
 func New() *Dnsmasq {
 	return &Dnsmasq{
 		Config: Config{
-			Network: "udp",
-			Address: "127.0.0.1:53",
-			Timeout: web.Duration{Duration: time.Second},
+			Protocol: "udp",
+			Address:  "127.0.0.1:53",
+			Timeout:  web.Duration{Duration: time.Second},
 		},
 
 		newDNSClient: func(network string, timeout time.Duration) dnsClient {
@@ -33,9 +33,9 @@ func New() *Dnsmasq {
 }
 
 type Config struct {
-	Network string       `yaml:"network"`
-	Address string       `yaml:"address"`
-	Timeout web.Duration `yaml:"timeout"`
+	Protocol string       `yaml:"protocol"`
+	Address  string       `yaml:"address"`
+	Timeout  web.Duration `yaml:"timeout"`
 }
 
 type (

--- a/modules/dnsmasq/dnsmasq_test.go
+++ b/modules/dnsmasq/dnsmasq_test.go
@@ -26,22 +26,22 @@ func TestDnsmasq_Init(t *testing.T) {
 		"fails on unset 'address'": {
 			wantFail: true,
 			config: Config{
-				Network: "udp",
-				Address: "",
+				Protocol: "udp",
+				Address:  "",
 			},
 		},
-		"fails on unset 'network'": {
+		"fails on unset 'protocol'": {
 			wantFail: true,
 			config: Config{
-				Network: "",
-				Address: "127.0.0.1:53",
+				Protocol: "",
+				Address:  "127.0.0.1:53",
 			},
 		},
-		"fails on invalid 'network'": {
+		"fails on invalid 'protocol'": {
 			wantFail: true,
 			config: Config{
-				Network: "http",
-				Address: "127.0.0.1:53",
+				Protocol: "http",
+				Address:  "127.0.0.1:53",
 			},
 		},
 	}

--- a/modules/dnsmasq/dnsmasq_test.go
+++ b/modules/dnsmasq/dnsmasq_test.go
@@ -1,0 +1,238 @@
+package dnsmasq
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	assert.IsType(t, (*Dnsmasq)(nil), New())
+}
+
+func TestDnsmasq_Init(t *testing.T) {
+	tests := map[string]struct {
+		config   Config
+		wantFail bool
+	}{
+		"success on default config": {
+			config: New().Config,
+		},
+		"fails on unset 'address'": {
+			wantFail: true,
+			config: Config{
+				Network: "udp",
+				Address: "",
+			},
+		},
+		"fails on unset 'network'": {
+			wantFail: true,
+			config: Config{
+				Network: "",
+				Address: "127.0.0.1:53",
+			},
+		},
+		"fails on invalid 'network'": {
+			wantFail: true,
+			config: Config{
+				Network: "http",
+				Address: "127.0.0.1:53",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ns := New()
+			ns.Config = test.config
+
+			if test.wantFail {
+				assert.False(t, ns.Init())
+			} else {
+				assert.True(t, ns.Init())
+			}
+		})
+	}
+}
+
+func TestDnsmasq_Check(t *testing.T) {
+	tests := map[string]struct {
+		prepare  func() *Dnsmasq
+		wantFail bool
+	}{
+		"success on valid response": {
+			prepare: prepareOKDnsmasq,
+		},
+		"fails on error on cache stats query": {
+			wantFail: true,
+			prepare:  prepareErrorOnExchangeDnsmasq,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			dnsmasq := test.prepare()
+			require.True(t, dnsmasq.Init())
+
+			if test.wantFail {
+				assert.False(t, dnsmasq.Check())
+			} else {
+				assert.True(t, dnsmasq.Check())
+			}
+		})
+	}
+}
+
+func TestDnsmasq_Charts(t *testing.T) {
+	dnsmasq := New()
+	require.True(t, dnsmasq.Init())
+	assert.NotNil(t, dnsmasq.Charts())
+}
+
+func TestDnsmasq_Cleanup(t *testing.T) {
+	assert.NotPanics(t, New().Cleanup)
+}
+
+func TestDnsmasq_Collect(t *testing.T) {
+	tests := map[string]struct {
+		prepare       func() *Dnsmasq
+		wantCollected map[string]int64
+	}{
+		"success on valid response": {
+			prepare: prepareOKDnsmasq,
+			wantCollected: map[string]int64{
+				"auth":           5,
+				"cache_entries":  5,
+				"cachesize":      999,
+				"evictions":      5,
+				"failed_queries": 9,
+				"hits":           100,
+				"insertions":     10,
+				"misses":         50,
+				"queries":        17,
+			},
+		},
+		"fails on error on cache stats query": {
+			prepare: prepareErrorOnExchangeDnsmasq,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			dnsmasq := test.prepare()
+			require.True(t, dnsmasq.Init())
+
+			collected := dnsmasq.Collect()
+
+			assert.Equal(t, test.wantCollected, collected)
+			if len(test.wantCollected) > 0 {
+				ensureCollectedHasAllChartsDimsVarsIDs(t, dnsmasq, collected)
+			}
+		})
+	}
+}
+
+func ensureCollectedHasAllChartsDimsVarsIDs(t *testing.T, dnsmasq *Dnsmasq, collected map[string]int64) {
+	for _, chart := range *dnsmasq.Charts() {
+		if chart.Obsolete {
+			continue
+		}
+		for _, dim := range chart.Dims {
+			_, ok := collected[dim.ID]
+			assert.Truef(t, ok, "chart '%s' dim '%s': no dim in collected", dim.ID, chart.ID)
+		}
+		for _, v := range chart.Vars {
+			_, ok := collected[v.ID]
+			assert.Truef(t, ok, "chart '%s' dim '%s': no dim in collected", v.ID, chart.ID)
+		}
+	}
+}
+
+func prepareOKDnsmasq() *Dnsmasq {
+	dnsmasq := New()
+	dnsmasq.newDNSClient = func(network string, timeout time.Duration) dnsClient {
+		return &mockDNSClient{}
+	}
+	return dnsmasq
+}
+
+func prepareErrorOnExchangeDnsmasq() *Dnsmasq {
+	dnsmasq := New()
+	dnsmasq.newDNSClient = func(network string, timeout time.Duration) dnsClient {
+		return &mockDNSClient{
+			errOnExchange: true,
+		}
+	}
+	return dnsmasq
+}
+
+type mockDNSClient struct {
+	errOnExchange bool
+}
+
+func (m mockDNSClient) Exchange(msg *dns.Msg, address string) (*dns.Msg, time.Duration, error) {
+	if m.errOnExchange {
+		return nil, 0, errors.New("'Exchange' error")
+	}
+
+	var answers []dns.RR
+	for _, q := range msg.Question {
+		a, err := prepareDNSAnswer(q)
+		if err != nil {
+			return nil, 0, err
+		}
+		answers = append(answers, a)
+	}
+
+	resp := &dns.Msg{
+		MsgHdr: dns.MsgHdr{
+			Rcode: dns.RcodeSuccess,
+		},
+		Answer: answers,
+	}
+	return resp, 0, nil
+}
+
+func prepareDNSAnswer(q dns.Question) (dns.RR, error) {
+	if want, got := dns.TypeToString[dns.TypeTXT], dns.TypeToString[q.Qtype]; want != got {
+		return nil, fmt.Errorf("unexpected Qtype, want=%s, got=%s", want, got)
+	}
+	if want, got := dns.ClassToString[dns.ClassCHAOS], dns.ClassToString[q.Qclass]; want != got {
+		return nil, fmt.Errorf("unexpected Qclass, want=%s, got=%s", want, got)
+	}
+
+	var txt []string
+	switch q.Name {
+	case "cachesize.bind.":
+		txt = []string{"999"}
+	case "insertions.bind.":
+		txt = []string{"10"}
+	case "evictions.bind.":
+		txt = []string{"5"}
+	case "hits.bind.":
+		txt = []string{"100"}
+	case "misses.bind.":
+		txt = []string{"50"}
+	case "auth.bind.":
+		txt = []string{"5"}
+	case "servers.bind.":
+		txt = []string{"10.0.0.1#53 10 5", "1.1.1.1#53 4 3", "1.0.0.1#53 3 1"}
+	default:
+		return nil, fmt.Errorf("unexpected question Name: %s", q.Name)
+	}
+
+	rr := &dns.TXT{
+		Hdr: dns.RR_Header{
+			Name:   q.Name,
+			Rrtype: dns.TypeTXT,
+			Class:  dns.ClassCHAOS,
+		},
+		Txt: txt,
+	}
+	return rr, nil
+}

--- a/modules/dnsmasq/init.go
+++ b/modules/dnsmasq/init.go
@@ -1,0 +1,41 @@
+package dnsmasq
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/netdata/go.d.plugin/agent/module"
+)
+
+func (d Dnsmasq) validateConfig() error {
+	if d.Address == "" {
+		return errors.New("'address' parameter not set")
+	}
+	if !isNetworkValid(d.Network) {
+		return fmt.Errorf("'network' (%s) is not valid, expected one of %v", d.Network, validNetworks)
+	}
+	return nil
+}
+
+func (d Dnsmasq) initDNSClient() (dnsClient, error) {
+	return d.newDNSClient(d.Network, d.Timeout.Duration), nil
+}
+
+func (d Dnsmasq) initCharts() (*module.Charts, error) {
+	return cacheCharts.Copy(), nil
+}
+
+func isNetworkValid(network string) bool {
+	for _, v := range validNetworks {
+		if network == v {
+			return true
+		}
+	}
+	return false
+}
+
+var validNetworks = []string{
+	"udp",
+	"tcp",
+	"tcp-tls",
+}

--- a/modules/dnsmasq/init.go
+++ b/modules/dnsmasq/init.go
@@ -11,30 +11,30 @@ func (d Dnsmasq) validateConfig() error {
 	if d.Address == "" {
 		return errors.New("'address' parameter not set")
 	}
-	if !isNetworkValid(d.Network) {
-		return fmt.Errorf("'network' (%s) is not valid, expected one of %v", d.Network, validNetworks)
+	if !isProtocolValid(d.Protocol) {
+		return fmt.Errorf("'protocol' (%s) is not valid, expected one of %v", d.Protocol, validProtocols)
 	}
 	return nil
 }
 
 func (d Dnsmasq) initDNSClient() (dnsClient, error) {
-	return d.newDNSClient(d.Network, d.Timeout.Duration), nil
+	return d.newDNSClient(d.Protocol, d.Timeout.Duration), nil
 }
 
 func (d Dnsmasq) initCharts() (*module.Charts, error) {
 	return cacheCharts.Copy(), nil
 }
 
-func isNetworkValid(network string) bool {
-	for _, v := range validNetworks {
-		if network == v {
+func isProtocolValid(protocol string) bool {
+	for _, v := range validProtocols {
+		if protocol == v {
 			return true
 		}
 	}
 	return false
 }
 
-var validNetworks = []string{
+var validProtocols = []string{
 	"udp",
 	"tcp",
 	"tcp-tls",

--- a/modules/init.go
+++ b/modules/init.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/netdata/go.d.plugin/modules/consul"
 	_ "github.com/netdata/go.d.plugin/modules/coredns"
 	_ "github.com/netdata/go.d.plugin/modules/couchdb"
+	_ "github.com/netdata/go.d.plugin/modules/dnsmasq"
 	_ "github.com/netdata/go.d.plugin/modules/dnsmasq_dhcp"
 	_ "github.com/netdata/go.d.plugin/modules/dnsquery"
 	_ "github.com/netdata/go.d.plugin/modules/docker_engine"


### PR DESCRIPTION
https://manpages.debian.org/stretch/dnsmasq-base/dnsmasq.8.en.html#NOTES

> The cache statistics are also available in the DNS as answers to queries of class CHAOS and type TXT in domain bind. The domain names are cachesize.bind, insertions.bind, evictions.bind, misses.bind, hits.bind, auth.bind and servers.bind. An example command to query this, using the dig utility would be