### PR TITLE
log plugin version and current user name/uid on start

### DIFF
--- a/cmd/godplugin/main.go
+++ b/cmd/godplugin/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/user"
 	"path"
 	"strings"
 
@@ -106,6 +107,11 @@ func main() {
 		RunModule:         opts.Module,
 		MinUpdateEvery:    opts.UpdateEvery,
 	})
+
+	a.Debugf("plugin: name=%s, version=%s", a.Name, version)
+	if u, err := user.Current(); err == nil {
+		a.Debugf("current user: name=%s, uid=%s", u.Username, u.Uid)
+	}
 
 	a.Run()
 }


### PR DESCRIPTION
This helps in debugging problems when users show their debug log

```cmd
0 go.d.plugin (log_version_and_user *)$ bin/godplugin -d -m example
[ DEBUG ] main[main] main.go:111 plugin: name=go.d, version=v0.25.0-20-gffe61a9-dirty
[ DEBUG ] main[main] main.go:113 current user: name=ilyam, uid=501
...
```