### PR TITLE
vernemq: fix `netsplit` chart dims algorithm

### DIFF
--- a/modules/vernemq/charts.go
+++ b/modules/vernemq/charts.go
@@ -440,8 +440,8 @@ var (
 		Ctx:   "vernemq.netsplits",
 		Type:  module.Stacked,
 		Dims: Dims{
-			{ID: metricNetSplitResolved, Name: "resolved"},
-			{ID: metricNetSplitDetected, Name: "detected"},
+			{ID: metricNetSplitResolved, Name: "resolved", Algo: module.Incremental},
+			{ID: metricNetSplitDetected, Name: "detected", Algo: module.Incremental},
 		},
 	}
 )


### PR DESCRIPTION
[Is counter type](https://github.com/vernemq/vernemq/blob/95ad92497ac61b221a0db217793872daa6a6fb20/apps/vmq_server/src/vmq_metrics.erl#L1016-L1017).