### PR TITLE
agent/job/state: proprely handle jobs with same module/name

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -154,10 +154,10 @@ func (a *Agent) run(ctx context.Context) {
 	if !isTerminal && a.StateFile != "" {
 		saver = state.NewManager(a.StateFile)
 		builder.CurState = saver
-		if st, err := state.Load(a.StateFile); err != nil {
+		if store, err := state.Load(a.StateFile); err != nil {
 			a.Warningf("couldn't load state file: %v", err)
 		} else {
-			builder.PrevState = st
+			builder.PrevState = store
 		}
 	}
 

--- a/agent/job/state/state_test.go
+++ b/agent/job/state/state_test.go
@@ -1,6 +1,13 @@
 package state
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+
+	"github.com/netdata/go.d.plugin/agent/job/confgroup"
+
+	"github.com/stretchr/testify/assert"
+)
 
 // TODO: tech debt
 func TestNewManager(t *testing.T) {
@@ -30,4 +37,66 @@ func TestState_Contains(t *testing.T) {
 // TODO: tech debt
 func TestLoad(t *testing.T) {
 
+}
+
+func TestStore_add(t *testing.T) {
+	tests := map[string]struct {
+		prepare   func() *Store
+		input     confgroup.Config
+		wantItems map[string]map[string]string
+	}{
+		"add an item to the empty store": {
+			prepare: func() *Store {
+				return &Store{}
+			},
+			input: prepareConfig(
+				"module", "modName",
+				"name", "jobName",
+			),
+			wantItems: map[string]map[string]string{
+				"modName": {
+					"jobName:18299273693089411682": "state",
+				},
+			},
+		},
+		"add an item with same module, same name, but specific options": {
+			prepare: func() *Store {
+				return &Store{
+					items: map[string]map[string]string{
+						"modName": {
+							"jobName:18299273693089411682": "state",
+						},
+					},
+				}
+			},
+			input: prepareConfig(
+				"module", "modName",
+				"name", "jobName",
+				"opt", "val",
+			),
+			wantItems: map[string]map[string]string{
+				"modName": {
+					"jobName:18299273693089411682": "state",
+					"jobName:6762067169527372123":  "state",
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			s := test.prepare()
+			s.add(test.input, "state")
+			fmt.Println(s.items)
+			assert.Equal(t, test.wantItems, s.items)
+		})
+	}
+}
+
+func prepareConfig(values ...string) confgroup.Config {
+	cfg := confgroup.Config{}
+	for i := 1; i < len(values); i += 2 {
+		cfg[values[i-1]] = values[i]
+	}
+	return cfg
 }


### PR DESCRIPTION
Fixes: #520

This PR changes job state store structure.

**The goal is to recognize the job**. This implemented by adding a config hash to the job states store key.

Current: `map[moduleName][jobName]state`

```cmd
[ilyam@pc netdata]$ sudo cat god-jobs-statuses.json | head -n 20
{
 "activemq": {
  "local": "failed"
 },
 "apache": {
  "local": "failed"
 },
 "bind": {
  "local": "failed"
 },
 "cockroachdb": {
  "local": "failed"
 },
 "consul": {
  "local": "failed"
 },
 "coredns": {
  "coredns": "failed"
 },
 "dnsdist": {
```

After this PR: `map[moduleName][jobName:cfgHash]state`

```cmd
[ilyam@pc netdata]$ sudo cat god-jobs-statuses.json | head -n 20
{
 "activemq": {
  "local:14596621561266494414": "failed"
 },
 "apache": {
  "local:1189662825161939815": "failed",
  "local:17111437997877908439": "failed"
 },
 "bind": {
  "local:100876918761637193": "failed",
  "local:2602159113841357685": "failed"
 },
 "cockroachdb": {
  "local:137299901498814718": "failed",
  "local:9635612216112347693": "failed"
 },
 "consul": {
  "local:10659601370355820704": "failed",
  "local:4163692686199009420": "failed"
 },
```

---

Could be improved a lot (tests especially), but i think it is ok for now 😅 