### PR TITLE
add glob support for filecheck modules directories

### DIFF
--- a/modules/filecheck/README.md
+++ b/modules/filecheck/README.md
@@ -64,7 +64,7 @@ cd /etc/netdata # Replace this path with your Netdata config directory
 sudo ./edit-config go.d/filecheck.conf
 ```
 
-Needs only a path to a file or a directory. **The path doesn't support any wildcards**.
+Needs only a path to a file or a directory. Wildcards are supported.
 
 Here is an example:
 
@@ -100,7 +100,6 @@ file](https://github.com/netdata/go.d.plugin/blob/master/config/go.d/filecheck.c
 
 ## Limitations
 
--   file/dir path pattern doesn't support any wildcards
 -   filecheck uses `stat` call to collect metrics, which is not very efficient.
 
 ## Troubleshooting

--- a/modules/filecheck/collect_dirs.go
+++ b/modules/filecheck/collect_dirs.go
@@ -13,7 +13,14 @@ import (
 func (fc *Filecheck) collectDirs(mx map[string]int64) {
 	curTime := time.Now()
 	for _, dirpath := range fc.Dirs.Include {
-		fc.collectDir(mx, dirpath, curTime)
+        subdirpaths , _ := filepath.Glob(dirpath)
+        if len(subdirpaths) == 0 {
+			fc.collectDir(mx, dirpath, curTime)
+        } else {
+		    for _, subdirpath := range subdirpaths {
+		        fc.collectDir(mx, subdirpath, curTime)
+		    }
+        }
 	}
 }
 

--- a/modules/filecheck/collect_dirs.go
+++ b/modules/filecheck/collect_dirs.go
@@ -13,9 +13,9 @@ import (
 func (fc *Filecheck) collectDirs(mx map[string]int64) {
 	curTime := time.Now()
 	for _, dirpath := range fc.Dirs.Include {
-		subdirpaths , _ := filepath.Glob(dirpath)
+		subdirpaths, _ := filepath.Glob(dirpath)
 		if len(subdirpaths) == 0 {
-         		fc.collectDir(mx, dirpath, curTime)
+			fc.collectDir(mx, dirpath, curTime)
 		} else {
 			for _, subdirpath := range subdirpaths {
 				fc.collectDir(mx, subdirpath, curTime)

--- a/modules/filecheck/collect_dirs.go
+++ b/modules/filecheck/collect_dirs.go
@@ -13,14 +13,14 @@ import (
 func (fc *Filecheck) collectDirs(mx map[string]int64) {
 	curTime := time.Now()
 	for _, dirpath := range fc.Dirs.Include {
-        subdirpaths , _ := filepath.Glob(dirpath)
-        if len(subdirpaths) == 0 {
-			fc.collectDir(mx, dirpath, curTime)
-        } else {
-		    for _, subdirpath := range subdirpaths {
-		        fc.collectDir(mx, subdirpath, curTime)
-		    }
-        }
+		subdirpaths , _ := filepath.Glob(dirpath)
+		if len(subdirpaths) == 0 {
+         		fc.collectDir(mx, dirpath, curTime)
+		} else {
+			for _, subdirpath := range subdirpaths {
+				fc.collectDir(mx, subdirpath, curTime)
+			}
+		}
 	}
 }
 

--- a/modules/filecheck/collect_dirs.go
+++ b/modules/filecheck/collect_dirs.go
@@ -14,7 +14,7 @@ func (fc *Filecheck) collectDirs(mx map[string]int64) {
 	curTime := time.Now()
 	for _, dirpath := range fc.Dirs.Include {
 		subdirpaths, _ := filepath.Glob(dirpath)
-		if len(subdirpaths) == 0 {
+		if subdirpaths == nil {
 			fc.collectDir(mx, dirpath, curTime)
 		} else {
 			for _, subdirpath := range subdirpaths {

--- a/modules/filecheck/collect_files.go
+++ b/modules/filecheck/collect_files.go
@@ -14,7 +14,7 @@ func (fc *Filecheck) collectFiles(mx map[string]int64) {
 	curTime := time.Now()
 	for _, filespath := range fc.Files.Include {
 		filepaths, _ := filepath.Glob(filespath)
-		if len(filepaths) == 0 {
+		if filepaths == nil {
 			fc.collectFile(mx, filespath, curTime)
 		} else {
 			for _, filepathpart := range filepaths {

--- a/modules/filecheck/collect_files.go
+++ b/modules/filecheck/collect_files.go
@@ -3,6 +3,7 @@ package filecheck
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -11,8 +12,15 @@ import (
 
 func (fc *Filecheck) collectFiles(mx map[string]int64) {
 	curTime := time.Now()
-	for _, filepath := range fc.Files.Include {
-		fc.collectFile(mx, filepath, curTime)
+	for _, filespath := range fc.Files.Include {
+		filepaths, _ := filepath.Glob(filespath)
+		if len(filepaths) == 0 {
+			fc.collectFile(mx, filespath, curTime)
+		} else {
+			for _, filepathpart := range filepaths {
+				fc.collectFile(mx, filepathpart, curTime)
+			}
+		}
 	}
 }
 

--- a/modules/filecheck/filecheck_test.go
+++ b/modules/filecheck/filecheck_test.go
@@ -76,18 +76,6 @@ func TestFilecheck_Init(t *testing.T) {
 			},
 			wantNumOfCharts: len(dirCharts),
 		},
-		"only wildcard dirs->include": {
-			config: Config{
-				Dirs: dirsConfig{
-					Include: []string{
-						"/path/to/dir1",
-						"/path/to/dir2",
-					},
-					CollectDirSize: true,
-				},
-			},
-			wantNumOfCharts: len(dirCharts),
-		},
 	}
 
 	for name, test := range tests {
@@ -111,6 +99,7 @@ func TestFilecheck_Check(t *testing.T) {
 	}{
 		"collect files":                   {prepare: prepareFilecheckFiles},
 		"collect only non existent files": {prepare: prepareFilecheckNonExistentFiles},
+		"collect wildcard files":          {prepare: prepareFilecheckWildcardFiles},
 		"collect dirs":                    {prepare: prepareFilecheckDirs},
 		"collect only non existent dirs":  {prepare: prepareFilecheckNonExistentDirs},
 		"collect wildcard dirs":           {prepare: prepareFilecheckWildcardDirs},
@@ -147,6 +136,18 @@ func TestFilecheck_Collect(t *testing.T) {
 		"collect only non existent files": {
 			prepare: prepareFilecheckNonExistentFiles,
 			wantCollected: map[string]int64{
+				"file_testdata/non_existent_file.log_exists": 0,
+			},
+		},
+		"collect wildcard files": {
+			prepare: prepareFilecheckFiles,
+			wantCollected: map[string]int64{
+				"file_testdata/empty_file.log_exists":        1,
+				"file_testdata/empty_file.log_mtime_ago":     5081,
+				"file_testdata/empty_file.log_size_bytes":    0,
+				"file_testdata/file.log_exists":              1,
+				"file_testdata/file.log_mtime_ago":           4161,
+				"file_testdata/file.log_size_bytes":          5707,
 				"file_testdata/non_existent_file.log_exists": 0,
 			},
 		},
@@ -260,6 +261,14 @@ func prepareFilecheckNonExistentFiles() *Filecheck {
 	return fc
 }
 
+func prepareFilecheckWildcardFiles() *Filecheck {
+	fc := New()
+	fc.Config.Files.Include = []string{
+		"testdata/*.log",
+		"testdata/non_existent_file.log",
+	}
+	return fc
+}
 func prepareFilecheckDirs() *Filecheck {
 	fc := New()
 	fc.Config.Dirs.Include = []string{

--- a/modules/filecheck/filecheck_test.go
+++ b/modules/filecheck/filecheck_test.go
@@ -76,6 +76,18 @@ func TestFilecheck_Init(t *testing.T) {
 			},
 			wantNumOfCharts: len(dirCharts),
 		},
+		"only wildcard dirs->include": {
+			config: Config{
+				Dirs: dirsConfig{
+					Include: []string{
+						"/path/to/dir1",
+						"/path/to/dir2",
+					},
+					CollectDirSize: true,
+				},
+			},
+			wantNumOfCharts: len(dirCharts),
+		},
 	}
 
 	for name, test := range tests {
@@ -101,6 +113,7 @@ func TestFilecheck_Check(t *testing.T) {
 		"collect only non existent files": {prepare: prepareFilecheckNonExistentFiles},
 		"collect dirs":                    {prepare: prepareFilecheckDirs},
 		"collect only non existent dirs":  {prepare: prepareFilecheckNonExistentDirs},
+		"collect wildcard dirs":           {prepare: prepareFilecheckWildcardDirs},
 		"collect files and dirs":          {prepare: prepareFilecheckFilesDirs},
 	}
 
@@ -145,6 +158,20 @@ func TestFilecheck_Collect(t *testing.T) {
 				"dir_testdata/dir_num_of_files":        3,
 				"dir_testdata/dir_size_bytes":          8160,
 				"dir_testdata/non_existent_dir_exists": 0,
+			},
+		},
+		"collect wildcard dirs": {
+			prepare: prepareFilecheckWildcardDirs,
+			wantCollected: map[string]int64{
+				"dir_testdata/dir/subdir_exists":            1,
+				"dir_testdata/dir/subdir_mtime_ago":         144864,
+				"dir_testdata/dir/subdir_num_of_files":      1,
+				"dir_testdata/dir/subdir_size_bytes":        0,
+				"dir_testdata/dir_exists":                   1,
+				"dir_testdata/dir_mtime_ago":                4087,
+				"dir_testdata/dir_num_of_files":             3,
+				"dir_testdata/dir_size_bytes":               8160,
+				"dir_testdata/non_existent_dir/*dir_exists": 0,
 			},
 		},
 		"collect dirs w/o size": {
@@ -256,6 +283,16 @@ func prepareFilecheckNonExistentDirs() *Filecheck {
 	fc := New()
 	fc.Config.Dirs.Include = []string{
 		"testdata/non_existent_dir",
+	}
+	return fc
+}
+
+func prepareFilecheckWildcardDirs() *Filecheck {
+	fc := New()
+	fc.Config.Dirs.Include = []string{
+		"testdata/dir/*dir",
+		"testdata/d*r",
+		"testdata/non_existent_dir/*dir",
 	}
 	return fc
 }


### PR DESCRIPTION
I tried to add glob support for the filecheck modules directory check, as this is a great extension of usability to monitor dynamic directories.
So far it worked on my tests I used in our test instance.

I hope the code is "ok" with my so far limited go experience.