### PR TITLE
agent: fix job detection retry

### DIFF
--- a/agent/job/build/build.go
+++ b/agent/job/build/build.go
@@ -119,8 +119,8 @@ func (m *Manager) Run(ctx context.Context, in chan []*confgroup.Group) {
 }
 
 func (m *Manager) cleanup() {
-	for _, cancel := range *m.retryCache {
-		cancel()
+	for _, task := range *m.retryCache {
+		task.cancel()
 	}
 	for name := range *m.startCache {
 		_ = m.Registry.Unregister(name)
@@ -205,33 +205,35 @@ func (m *Manager) handleRemove(ctx context.Context, cfgs []confgroup.Config) {
 
 func (m *Manager) handleAddCfg(ctx context.Context, cfg confgroup.Config) {
 	if m.startCache.has(cfg) {
-		m.Infof("module '%s' job '%s' is being served by another job, skipping it", cfg.Module(), cfg.Name())
+		m.Infof("%s[%s] job is being served by another job, skipping it", cfg.Module(), cfg.Name())
 		m.CurState.Save(cfg, duplicateLocal)
 		return
 	}
 
-	cancel, isRetry := m.retryCache.lookup(cfg)
+	task, isRetry := m.retryCache.lookup(cfg)
 	if isRetry {
-		cancel()
+		task.cancel()
 		m.retryCache.remove(cfg)
 	}
 
 	job, err := m.buildJob(cfg)
 	if err != nil {
-		m.Warningf("couldn't build module '%s' job '%s': %v", cfg.Module(), cfg.Name(), err)
+		m.Warningf("couldn't build %s[%s]: %v", cfg.Module(), cfg.Name(), err)
 		m.CurState.Save(cfg, buildError)
 		return
 	}
 
-	if !isRetry && cfg.AutoDetectionRetry() == 0 {
+	if isRetry {
+		job.AutoDetectEvery = task.timeout
+		job.AutoDetectTries = task.retries
+	} else if job.AutoDetectionEvery() == 0 {
 		switch {
 		case m.PrevState.Contains(cfg, success, retry):
-			// TODO: method?
-			// 5 minutes
+			m.Infof("%s[%s] job last state is active/retry, applying recovering settings", cfg.Module(), cfg.Name())
 			job.AutoDetectEvery = 30
 			job.AutoDetectTries = 11
 		case isInsideK8sCluster() && cfg.Provider() == "file watcher":
-			// TODO: not sure this logic should belong to builder
+			m.Infof("%s[%s] is k8s job, applying recovering settings", cfg.Module(), cfg.Name())
 			job.AutoDetectEvery = 10
 			job.AutoDetectTries = 7
 		}
@@ -247,20 +249,25 @@ func (m *Manager) handleAddCfg(ctx context.Context, cfg confgroup.Config) {
 			m.Error(err)
 			m.CurState.Save(cfg, registrationError)
 		} else {
-			m.Infof("module '%s' job '%s'  is being served by another plugin, skipping it", cfg.Module(), cfg.Name())
+			m.Infof("%s[%s] job is being served by another plugin, skipping it", cfg.Module(), cfg.Name())
 			m.CurState.Save(cfg, duplicateGlobal)
 		}
 	case retry:
-		m.Infof("module '%s' job '%s' detection failed, will retry in %d seconds", cfg.Module(), cfg.Name(),
-			cfg.AutoDetectionRetry())
+		m.Infof("%s[%s] job detection failed, will retry in %d seconds (%d attempts left)",
+			cfg.Module(), cfg.Name(), job.AutoDetectionEvery(), job.AutoDetectTries)
 		m.CurState.Save(cfg, retry)
 		ctx, cancel := context.WithCancel(ctx)
-		m.retryCache.put(cfg, cancel)
-		go retryTask(ctx, m.retryCh, cfg)
+		m.retryCache.put(cfg, retryTask{
+			cancel:  cancel,
+			timeout: job.AutoDetectionEvery(),
+			retries: job.AutoDetectTries,
+		})
+		timeout := time.Second * time.Duration(job.AutoDetectionEvery())
+		go runRetryTask(ctx, m.retryCh, cfg, timeout)
 	case failed:
 		m.CurState.Save(cfg, failed)
 	default:
-		m.Warningf("module '%s' job '%s' detection: unknown state", cfg.Module(), cfg.Name())
+		m.Warningf("%s[%s] job detection: unknown state", cfg.Module(), cfg.Name())
 	}
 }
 
@@ -273,8 +280,8 @@ func (m *Manager) handleRemoveCfg(cfg confgroup.Config) {
 		m.startCache.remove(cfg)
 	}
 
-	if cancel, ok := m.retryCache.lookup(cfg); ok {
-		cancel()
+	if task, ok := m.retryCache.lookup(cfg); ok {
+		task.cancel()
 		m.retryCache.remove(cfg)
 	}
 }
@@ -282,7 +289,7 @@ func (m *Manager) handleRemoveCfg(cfg confgroup.Config) {
 func (m *Manager) buildJob(cfg confgroup.Config) (*module.Job, error) {
 	creator, ok := m.Modules[cfg.Module()]
 	if !ok {
-		return nil, fmt.Errorf("couldn't find '%s' module, job '%s'", cfg.Module(), cfg.Name())
+		return nil, fmt.Errorf("can not find %s module", cfg.Module())
 	}
 
 	m.Debugf("building %s[%s] job, config: %v", cfg.Module(), cfg.Name(), cfg)
@@ -316,8 +323,7 @@ func detection(job jobpkg.Job) state {
 	return success
 }
 
-func retryTask(ctx context.Context, in chan<- confgroup.Config, cfg confgroup.Config) {
-	timeout := time.Second * time.Duration(cfg.AutoDetectionRetry())
+func runRetryTask(ctx context.Context, in chan<- confgroup.Config, cfg confgroup.Config, timeout time.Duration) {
 	t := time.NewTimer(timeout)
 	defer t.Stop()
 

--- a/agent/job/build/build.go
+++ b/agent/job/build/build.go
@@ -253,8 +253,8 @@ func (m *Manager) handleAddCfg(ctx context.Context, cfg confgroup.Config) {
 			m.CurState.Save(cfg, duplicateGlobal)
 		}
 	case retry:
-		m.Infof("%s[%s] job detection failed, will retry in %d seconds (%d attempts left)",
-			cfg.Module(), cfg.Name(), job.AutoDetectionEvery(), job.AutoDetectTries)
+		m.Infof("%s[%s] job detection failed, will retry in %d seconds",
+			cfg.Module(), cfg.Name(), job.AutoDetectionEvery())
 		m.CurState.Save(cfg, retry)
 		ctx, cancel := context.WithCancel(ctx)
 		m.retryCache.put(cfg, retryTask{


### PR DESCRIPTION
Fixes: #522

Common flow is: `job.Check() ? job.Start() : drop`

We do `Check` only once, however there are some cases when we want to retry it and dont give up after first fail attempt. 

**1.** There is `autodetection_retry` configuration option.

```yaml
#  - autodetection_retry
#    Re-check interval in seconds. Attempts to start the job are made once every interval.
#    Zero means not to schedule re-check. Default: 0.
```

If its value > 0 we try to `Check()` every `autodetection_retry` and **never** give up.

**2**. Sometimes we need to retry finite number of times and do it w/o any configuration, current cases:
 - the job was active before the restart
 - the job is k8s job and there is a chance that a service is not ready to serve requests for some time after a container creation.

---

**1** was working, but **2** wasn't. This PR fixes it.

**Consider this PR as a quick workaround**, writing it i understood that there is logical/design problems and we need to rethink/refactor. 

Tests are done manually:

 - `autodetection_retry` not set, prev state != `success/retry`

One `Check()` attempt as expected

```cmd
[ilyam@pc netdata]$ date
Ср 09 дек 2020 15:39:01 MSK
[ilyam@pc netdata]$ grep "dnsmasq\[local\]" error.log
2020-12-09 15:38:01: go.d ERROR: dnsmasq[local] read udp 127.0.0.1:33142->127.0.0.1:53: read: connection refused
2020-12-09 15:38:01: go.d ERROR: dnsmasq[local] check failed
```

- `autodetection_retry` set to 5, prev state != `success/retry`

We see `Check()` every 5 seconds

```cmd
[ilyam@pc netdata]$ grep "dnsmasq\[local\]" error.log
2020-12-09 15:40:08: go.d ERROR: dnsmasq[local] read udp 127.0.0.1:35917->127.0.0.1:53: read: connection refused
2020-12-09 15:40:08: go.d ERROR: dnsmasq[local] check failed
2020-12-09 15:40:08: go.d INFO: build[manager] dnsmasq[local] job detection failed, will retry in 5 seconds
2020-12-09 15:40:13: go.d ERROR: dnsmasq[local] read udp 127.0.0.1:41027->127.0.0.1:53: read: connection refused
2020-12-09 15:40:13: go.d ERROR: dnsmasq[local] check failed
2020-12-09 15:40:13: go.d INFO: build[manager] dnsmasq[local] job detection failed, will retry in 5 seconds
2020-12-09 15:40:18: go.d ERROR: dnsmasq[local] read udp 127.0.0.1:35615->127.0.0.1:53: read: connection refused
2020-12-09 15:40:18: go.d ERROR: dnsmasq[local] check failed
2020-12-09 15:40:18: go.d INFO: build[manager] dnsmasq[local] job detection failed, will retry in 5 seconds
```

- `autodetection_retry` not set, but prev state == `success/retry`

We retry every 30 seconds 10 times.

```cmd
[ilyam@pc netdata]$ grep "dnsmasq\[local\]" error.log
2020-12-09 15:42:01: go.d INFO: build[manager] dnsmasq[local] job last state is active/retry, applying recovering settings
2020-12-09 15:42:01: go.d ERROR: dnsmasq[local] read udp 127.0.0.1:37068->127.0.0.1:53: read: connection refused
2020-12-09 15:42:01: go.d ERROR: dnsmasq[local] check failed
2020-12-09 15:42:01: go.d INFO: build[manager] dnsmasq[local] job detection failed, will retry in 30 seconds
2020-12-09 15:42:31: go.d ERROR: dnsmasq[local] read udp 127.0.0.1:57042->127.0.0.1:53: read: connection refused
2020-12-09 15:42:31: go.d ERROR: dnsmasq[local] check failed
2020-12-09 15:42:31: go.d INFO: build[manager] dnsmasq[local] job detection failed, will retry in 30 seconds
2020-12-09 15:43:01: go.d ERROR: dnsmasq[local] read udp 127.0.0.1:37658->127.0.0.1:53: read: connection refused
2020-12-09 15:43:01: go.d ERROR: dnsmasq[local] check failed
2020-12-09 15:43:01: go.d INFO: build[manager] dnsmasq[local] job detection failed, will retry in 30 seconds
2020-12-09 15:43:31: go.d ERROR: dnsmasq[local] read udp 127.0.0.1:40758->127.0.0.1:53: read: connection refused
2020-12-09 15:43:31: go.d ERROR: dnsmasq[local] check failed
2020-12-09 15:43:31: go.d INFO: build[manager] dnsmasq[local] job detection failed, will retry in 30 seconds
2020-12-09 15:44:01: go.d ERROR: dnsmasq[local] read udp 127.0.0.1:59926->127.0.0.1:53: read: connection refused
2020-12-09 15:44:01: go.d ERROR: dnsmasq[local] check failed
2020-12-09 15:44:01: go.d INFO: build[manager] dnsmasq[local] job detection failed, will retry in 30 seconds
2020-12-09 15:44:31: go.d ERROR: dnsmasq[local] read udp 127.0.0.1:46003->127.0.0.1:53: read: connection refused
2020-12-09 15:44:31: go.d ERROR: dnsmasq[local] check failed
2020-12-09 15:44:31: go.d INFO: build[manager] dnsmasq[local] job detection failed, will retry in 30 seconds
2020-12-09 15:45:01: go.d ERROR: dnsmasq[local] read udp 127.0.0.1:34183->127.0.0.1:53: read: connection refused
2020-12-09 15:45:01: go.d ERROR: dnsmasq[local] check failed
2020-12-09 15:45:01: go.d INFO: build[manager] dnsmasq[local] job detection failed, will retry in 30 seconds
2020-12-09 15:45:31: go.d ERROR: dnsmasq[local] read udp 127.0.0.1:57242->127.0.0.1:53: read: connection refused
2020-12-09 15:45:31: go.d ERROR: dnsmasq[local] check failed
2020-12-09 15:45:31: go.d INFO: build[manager] dnsmasq[local] job detection failed, will retry in 30 seconds
2020-12-09 15:46:01: go.d ERROR: dnsmasq[local] read udp 127.0.0.1:51649->127.0.0.1:53: read: connection refused
2020-12-09 15:46:01: go.d ERROR: dnsmasq[local] check failed
2020-12-09 15:46:01: go.d INFO: build[manager] dnsmasq[local] job detection failed, will retry in 30 seconds
2020-12-09 15:46:31: go.d ERROR: dnsmasq[local] read udp 127.0.0.1:50180->127.0.0.1:53: read: connection refused
2020-12-09 15:46:31: go.d ERROR: dnsmasq[local] check failed
2020-12-09 15:46:31: go.d INFO: build[manager] dnsmasq[local] job detection failed, will retry in 30 seconds
2020-12-09 15:47:01: go.d ERROR: dnsmasq[local] read udp 127.0.0.1:40207->127.0.0.1:53: read: connection refused
2020-12-09 15:47:01: go.d ERROR: dnsmasq[local] check failed
```
