### PR TITLE
Add meta descriptions to each collector

### DIFF
--- a/modules/activemq/README.md
+++ b/modules/activemq/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "ActiveMQ monitoring with Netdata"
+description: "Monitor the health and performance of ActiveMQ message brokers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/activemq/README.md
 sidebar_label: "ActiveMQ"
 -->

--- a/modules/apache/README.md
+++ b/modules/apache/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Apache monitoring with Netdata"
+description: "Monitor the health and performance of Apache web servers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/apache/README.md
 sidebar_label: "Apache"
 -->

--- a/modules/bind/README.md
+++ b/modules/bind/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Bind9 monitoring with Netdata"
+description: "Monitor the health and performance of Bind9 DNS servers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/bind/README.md
 sidebar_label: "Bind9"
 -->

--- a/modules/cockroachdb/README.md
+++ b/modules/cockroachdb/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "CockroachDB monitoring with Netdata"
+description: "Monitor the health and performance of CockroachDB databases with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/cockroachdb/README.md
 sidebar_label: "CockroachDB"
 -->

--- a/modules/consul/README.md
+++ b/modules/consul/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Consul monitoring with Netdata"
+description: "Monitor the health and performance of Consul service meshes with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/consul/README.md
 sidebar_label: "Consul"
 -->

--- a/modules/coredns/README.md
+++ b/modules/coredns/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "CoreDNS monitoring with Netdata"
+description: "Monitor the health and performance of CoreDNS servers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/coredns/README.md
 sidebar_label: "CoreDNS"
 -->

--- a/modules/couchbase/README.md
+++ b/modules/couchbase/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Couchbase monitoring with Netdata"
+description: "Monitor the health and performance of Couchbase databases with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/couchbase/README.md
 sidebar_label: "Couchbase"
 -->

--- a/modules/couchdb/README.md
+++ b/modules/couchdb/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Apache CouchDB monitoring with Netdata"
+description: "Monitor the health and performance of CouchDB databases with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/couchdb/README.md
 sidebar_label: "CouchDB"
 -->

--- a/modules/dnsdist/README.md
+++ b/modules/dnsdist/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "DNSdist monitoring with Netdata"
+description: "Monitor the health and performance of DNSdist load balancers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/dnsdist/README.md
 sidebar_label: "DNSdist"
 -->

--- a/modules/dnsmasq/README.md
+++ b/modules/dnsmasq/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Dnsmasq DNS Forwarder"
+description: "Monitor the health and performance of Dnsmasq DNS forwarders with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/dnsmasq/README.md
 sidebar_label: "Dnsmasq DNS Forwarder"
 -->

--- a/modules/dnsmasq_dhcp/README.md
+++ b/modules/dnsmasq_dhcp/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Dnsmasq DHCP monitoring with Netdata"
+description: "Monitor the health and performance of Dnsmasq DHCP servers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/dnsmasq_dhcp/README.md
 sidebar_label: "Dnsmasq DHCP"
 -->

--- a/modules/dnsquery/README.md
+++ b/modules/dnsquery/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "DNS query monitoring with Netdata"
+description: "Monitor the health and performance of DNS query round-trip time with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/dnsquery/README.md
 sidebar_label: "DNS queries"
 -->

--- a/modules/docker_engine/README.md
+++ b/modules/docker_engine/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Docker Engine monitoring with Netdata"
+description: "Monitor the health and performance of the Docker Engine runtime with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/docker_engine/README.md
 sidebar_label: "Docker Engine"
 -->

--- a/modules/dockerhub/README.md
+++ b/modules/dockerhub/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Docker Hub repository monitoring with Netdata"
+description: "Monitor the health and performance of Docker Hub repositories with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/dockerhub/README.md
 sidebar_label: "Docker Hub repositories"
 -->

--- a/modules/elasticsearch/README.md
+++ b/modules/elasticsearch/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Elasticsearch monitoring with Netdata"
+description: "Monitor the health and performance of Elasticsearch engines with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/elasticsearch/README.md
 sidebar_label: "Elasticsearch"
 -->

--- a/modules/energid/README.md
+++ b/modules/energid/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Energi Core Wallet monitoring with Netdata"
+description: "Monitor the health and performance of Energi Core Wallets with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/energid/README.md
 sidebar_label: "Energi Core Wallet"
 -->

--- a/modules/example/README.md
+++ b/modules/example/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Example module"
+description: "Use this example data collection module, which produces example charts with random values, to better understand how to build your own collector in Go."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/example/README.md
 sidebar_label: "Example module"
 -->

--- a/modules/filecheck/README.md
+++ b/modules/filecheck/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Files and directories monitoring with Netdata"
+description: "Monitor the health and performance of files and directories with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/fileheck/README.md
 sidebar_label: "Files and Dirs"
 -->

--- a/modules/fluentd/README.md
+++ b/modules/fluentd/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Fluentd monitoring with Netdata"
+description: "Monitor the health and performance of Fluentd servers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/fluentd/README.md
 sidebar_label: "Fluentd"
 -->

--- a/modules/freeradius/README.md
+++ b/modules/freeradius/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "FreeRADIUS monitoring with Netdata"
+description: "Monitor the health and performance of FreeRADIUS servers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/freeradius/README.md
 sidebar_label: "FreeRADIUS"
 -->

--- a/modules/hdfs/README.md
+++ b/modules/hdfs/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "HDFS monitoring with Netdata"
+description: "Monitor the health and performance of HDFS nodes with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/hdfs/README.md
 sidebar_label: "HDFS"
 -->

--- a/modules/httpcheck/README.md
+++ b/modules/httpcheck/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "HTTP endpoint monitoring with Netdata"
+description: "Monitor the health and performance of any HTTP endpoint with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/httpcheck/README.md
 sidebar_label: "HTTP endpoints"
 -->

--- a/modules/isc_dhcpd/README.md
+++ b/modules/isc_dhcpd/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "ISC DHCPd monitoring with Netdata"
+description: "Monitor the health and performance of ISC DHCP servers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/isc_dhcpd/README.md
 sidebar_label: "ISC DHCPd"
 -->

--- a/modules/k8s_kubelet/README.md
+++ b/modules/k8s_kubelet/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Kubelet monitoring with Netdata"
+description: "Monitor the health and performance of Kubelet agents with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/k8s_kubelet/README.md
 sidebar_label: "Kubelet"
 -->

--- a/modules/k8s_kubeproxy/README.md
+++ b/modules/k8s_kubeproxy/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Kube-proxy monitoring with Netdata"
+description: "Monitor the health and performance of Kube-proxy instances with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/k8s_kubeproxy/README.md
 sidebar_label: "Kube-proxy"
 -->

--- a/modules/lighttpd/README.md
+++ b/modules/lighttpd/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Lighttpd monitoring with Netdata"
+description: "Monitor the health and performance of Lighttpd web servers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/lighttpd/README.md
 sidebar_label: "Lighttpd"
 -->

--- a/modules/lighttpd2/README.md
+++ b/modules/lighttpd2/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Lighttpd2 monitoring with Netdata"
+description: "Monitor the health and performance of Lighttpd2 web servers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/lighttpd2/README.md
 sidebar_label: "Lighttpd2"
 -->

--- a/modules/logstash/README.md
+++ b/modules/logstash/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Logstash monitoring with Netdata"
+description: "Monitor the health and performance of Logstash instances with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/logstash/README.md
 sidebar_label: "Logstash"
 -->

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -1,6 +1,6 @@
 <!--
 title: "MySQL monitoring with Netdata"
-description: "Monitor the health and performance of MySQL databases with zero configuration, per-second metric granularity, and interactive visualizations."
+description: "Monitor connections, slow queries, InnoDB memory and disk utilization, locks, and more with zero configuration and per-second metric granularity."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/mysql/README.md
 sidebar_label: "MySQL"
 -->

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "MySQL monitoring with Netdata"
+description: "Monitor the health and performance of MySQL databases with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/mysql/README.md
 sidebar_label: "MySQL"
 -->

--- a/modules/nginx/README.md
+++ b/modules/nginx/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "NGINX monitoring"
+description: "Monitor the health and performance of NGINX web servers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/nginx/README.md
 sidebar_label: "NGINX"
 -->

--- a/modules/openvpn/README.md
+++ b/modules/openvpn/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "OpenVPN monitoring with Netdata"
+description: "Monitor the health and performance of OpenVPN servers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/openvpn/README.md
 sidebar_label: "OpenVPN"
 -->

--- a/modules/phpdaemon/README.md
+++ b/modules/phpdaemon/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "phpDaemon monitoring with Netdata"
+description: "Monitor the health and performance of phpDaemon workers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/phpdaemon/README.md
 sidebar_label: "phpDaemon"
 -->

--- a/modules/phpfpm/README.md
+++ b/modules/phpfpm/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "PHP-FPM monitoring with Netdata"
+description: "Monitor the health and performance of PHP-FPM instances with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/phpfpm/README.md
 sidebar_label: "PHP-FPM"
 -->

--- a/modules/pihole/README.md
+++ b/modules/pihole/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Pi-hole monitoring with Netdata"
+description: "Monitor the health and performance of Pi-hole instances with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/pihole/README.md
 sidebar_label: "Pi-hole"
 -->

--- a/modules/pika/README.md
+++ b/modules/pika/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Pika monitoring with Netdata"
+description: "Monitor the health and performance of Pika storage services with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/redis/README.md
 sidebar_label: "Pika"
 -->

--- a/modules/portcheck/README.md
+++ b/modules/portcheck/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "TCP endpoint monitoring with Netdata"
+description: "Monitor the health and performance of any TCP endpoint with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/portcheck/README.md
 sidebar_label: "TCP endpoints"
 -->

--- a/modules/powerdns/README.md
+++ b/modules/powerdns/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "PowerDNS Authoritative Server monitoring with Netdata"
+description: "Monitor the health and performance of PowerDNS nameservers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/powerdns/README.md
 sidebar_label: "PowerDNS Authoritative Server"
 -->

--- a/modules/powerdns_recursor/README.md
+++ b/modules/powerdns_recursor/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "PowerDNS Recursor monitoring with Netdata"
+description: "Monitor the health and performance of PowerDNS recursor instances with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/powerdns_recursor/README.md
 sidebar_label: "PowerDNS Recursor"
 -->

--- a/modules/prometheus/README.md
+++ b/modules/prometheus/README.md
@@ -1,6 +1,6 @@
 <!--
 title: "Prometheus endpoint monitoring with Netdata"
-description: "Monitor 600+ services that support the Prometheus/OpenMetrics exposition format with Netdata's per-second frequency and zero configuration."
+description: "Monitor the health and performance of 600+ services that support the Prometheus metrics with Netdata's per-second frequency and zero configuration."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/prometheus/README.md
 sidebar_label: "Prometheus endpoints"
 -->

--- a/modules/pulsar/README.md
+++ b/modules/pulsar/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Apache Pulsar monitoring with Netdata"
+description: "Monitor the health and performance of Apache Pulsar messaging systems with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/pulsar/README.md
 sidebar_label: "Pulsar"
 -->

--- a/modules/rabbitmq/README.md
+++ b/modules/rabbitmq/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "RabbitMQ monitoring with Netdata"
+description: "Monitor the health and performance of RabbitMQ message brokers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/rabbitmq/README.md
 sidebar_label: "RabbitMQ"
 -->

--- a/modules/redis/README.md
+++ b/modules/redis/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Redis monitoring with Netdata"
+description: "Monitor the health and performance of Redis storage services with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/redis/README.md
 sidebar_label: "Redis"
 -->

--- a/modules/scaleio/README.md
+++ b/modules/scaleio/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "ScaleIO monitoring with Netdata"
+description: "Monitor the health and performance of ScaleIO storage with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/scaleio/README.md
 sidebar_label: "ScaleIO"
 -->

--- a/modules/solr/README.md
+++ b/modules/solr/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Solr monitoring with Netdata"
+description: "Monitor the health and performance of Solr search servers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/solr/README.md
 sidebar_label: "Solr"
 -->

--- a/modules/springboot2/README.md
+++ b/modules/springboot2/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Java Spring Boot 2 application monitoring with Netdata"
+description: "Monitor the health and performance of Spring Boot 2-compatible apps with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/springboot2/README.md
 sidebar_label: "Java Spring Boot 2 applications"
 -->

--- a/modules/squidlog/README.md
+++ b/modules/squidlog/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Web server log (Squid) monitoring with Netdata"
+description: "Monitor the health and performance of Squid web server logs with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/squidlog/README.md
 sidebar_label: "Web server logs (Squid)"
 -->

--- a/modules/systemdunits/README.md
+++ b/modules/systemdunits/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Systemd units state monitoring with Netdata"
+description: "Monitor the health and performance of Systemd units states with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/systemdunits/README.md
 sidebar_label: "Systemd units"
 -->

--- a/modules/tengine/README.md
+++ b/modules/tengine/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Tengine monitoring with Netdata"
+description: "Monitor the health and performance of Tengine web servers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/tengine/README.md
 sidebar_label: "Tengine"
 -->

--- a/modules/unbound/README.md
+++ b/modules/unbound/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Unbound monitoring with Netdata"
+description: "Monitor the health and performance of Unbound DNS resolvers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/unbound/README.md
 sidebar_label: "Unbound"
 -->

--- a/modules/vcsa/README.md
+++ b/modules/vcsa/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "vCenter Server Appliance monitoring with Netdata"
+description: "Monitor the health and performance of vCenter appliances with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/vsca/README.md
 sidebar_label: "vCenter Server Appliance"
 -->

--- a/modules/vernemq/README.md
+++ b/modules/vernemq/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "VerneMQ monitoring with Netdata"
+description: "Monitor the health and performance of VerneMQ MQTT brokers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/vernemq/README.md
 sidebar_label: "VerneMQ"
 -->

--- a/modules/vsphere/README.md
+++ b/modules/vsphere/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "vCenter Server monitoring with Netdata"
+description: "Monitor the health and performance of vCenter servers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/vsphere/README.md
 sidebar_label: "vCenter Servers"
 -->

--- a/modules/weblog/README.md
+++ b/modules/weblog/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Web server log (Apache, NGINX) monitoring with Netdata"
+description: "Monitor the health and performance of Apache or Nginx logs with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/weblog/README.md
 sidebar_label: "Web server logs (Apache, NGINX)"
 -->

--- a/modules/whoisquery/README.md
+++ b/modules/whoisquery/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Whois domain expiry monitoring with Netdata"
+description: "Monitor the health and performance of domain expiry with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/whoisquery/README.md
 sidebar_label: "Whois domain expiry"
 -->

--- a/modules/wmi/README.md
+++ b/modules/wmi/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Windows machine monitoring with Netdata"
+description: "Monitor the health and performance of Windows machines with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/wmi/README.md
 sidebar_label: "Windows machines"
 -->

--- a/modules/x509check/README.md
+++ b/modules/x509check/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "x509 certificate monitoring with Netdata"
+description: "Monitor the health and performance of x509 certificates with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/x509check/README.md
 sidebar_label: "x509 certificates"
 -->

--- a/modules/zookeeper/README.md
+++ b/modules/zookeeper/README.md
@@ -1,5 +1,6 @@
 <!--
 title: "Apache ZooKeeper monitoring with Netdata"
+description: "Monitor the health and performance of Zookeeper servers with zero configuration, per-second metric granularity, and interactive visualizations."
 custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/zookeeper/README.md
 sidebar_label: "ZooKeeper"
 -->


### PR DESCRIPTION
Nothing exciting here, just adding a `description` variable to the frontmatter with some proper meta descriptions. They're not very exciting right now, but there's opportunity to improve some of them later if and when we see an impact from this change.

Related to netdata/netdata#10388