### PR TITLE
add traefik metrics endpoint to prometheus.conf

### DIFF
--- a/config/go.d/prometheus.conf
+++ b/config/go.d/prometheus.conf
@@ -1473,6 +1473,8 @@ jobs:
     url: 'http://127.0.0.1:5555/metrics'
   - name: midonet_agent_local
     url: 'http://127.0.0.1:7300/metrics'
+  - name: traefik_local
+    url: 'http://127.0.0.1:8080/metrics'
   - name: trickster_local
     url: 'http://127.0.0.1:8082/metrics'
   - name: fawkes_local


### PR DESCRIPTION
Hello Netdata folks.

First of all thank you for your work on this awesome tool 💛 

I tried to monitor a [Traefik](https://github.com/traefik/traefik) (v2) reverse proxy using Netdata. However it seems the documentation [here](https://learn.netdata.cloud/docs/agent/collectors/python.d.plugin/traefik) doesn't apply anymore for version 2.
So I decided to use the prometheus metrics endpoint that can be [configured](https://doc.traefik.io/traefik/observability/metrics/prometheus/) on the Traefik side and the prometheus collector on Netdata side.

I did not find the metrics url in the base *prometheus.conf*, and I thought that could be nice to add it. So we keep the "0 configuration required" mindset that we can find in a lot of Netdata features. What do you think ? 

The only downside that I can see doing this is that the 8080 port could be used by another service and metrics be reported as "Traefik Local". But in this case user can still override the configuration. Right ? 

I think the solution would also permit to close this : https://github.com/netdata/netdata/issues/8600

<details>
<summary>Here's an example of the exported metrics : </summary>

```
# HELP go_gc_duration_seconds A summary of the GC invocation durations.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 0.000180275
go_gc_duration_seconds{quantile="0.25"} 0.000237848
go_gc_duration_seconds{quantile="0.5"} 0.000293607
go_gc_duration_seconds{quantile="0.75"} 0.000613231
go_gc_duration_seconds{quantile="1"} 0.004340674
go_gc_duration_seconds_sum 0.009012896
go_gc_duration_seconds_count 14
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 41
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.15.6"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 7.946832e+06
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 4.441124e+07
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 733152
# HELP go_memstats_frees_total Total number of frees.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 433834
# HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
# TYPE go_memstats_gc_cpu_fraction gauge
go_memstats_gc_cpu_fraction 5.800793646765633e-05
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 2.411568e+06
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 7.946832e+06
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 5.971968e+06
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 1.0018816e+07
# HELP go_memstats_heap_objects Number of allocated objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 42549
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 4.186112e+06
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 1.5990784e+07
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 1.6109819652161615e+09
# HELP go_memstats_lookups_total Total number of pointer lookups.
# TYPE go_memstats_lookups_total counter
go_memstats_lookups_total 0
# HELP go_memstats_mallocs_total Total number of mallocs.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 476383
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 3472
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 16384
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 79360
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 114688
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 1.345704e+07
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 741356
# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 786432
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 786432
# HELP go_memstats_sys_bytes Number of bytes obtained from system.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 2.0794364e+07
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 10
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 8.96
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1.048576e+06
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 14
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 5.7462784e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.61098111836e+09
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 8.84912128e+08
# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE process_virtual_memory_max_bytes gauge
process_virtual_memory_max_bytes -1
# HELP traefik_config_last_reload_failure Last config reload failure
# TYPE traefik_config_last_reload_failure gauge
traefik_config_last_reload_failure 0
# HELP traefik_config_last_reload_success Last config reload success
# TYPE traefik_config_last_reload_success gauge
traefik_config_last_reload_success 1.610981122e+09
# HELP traefik_config_reloads_failure_total Config failure reloads
# TYPE traefik_config_reloads_failure_total counter
traefik_config_reloads_failure_total 0
# HELP traefik_config_reloads_total Config reloads
# TYPE traefik_config_reloads_total counter
traefik_config_reloads_total 2
# HELP traefik_entrypoint_open_connections How many open connections exist on an entrypoint, partitioned by method and protocol.
# TYPE traefik_entrypoint_open_connections gauge
traefik_entrypoint_open_connections{entrypoint="traefik",method="GET",protocol="http"} 1
traefik_entrypoint_open_connections{entrypoint="web",method="GET",protocol="http"} 0
# HELP traefik_entrypoint_request_duration_seconds How long it took to process the request on an entrypoint, partitioned by status code, protocol, and method.
# TYPE traefik_entrypoint_request_duration_seconds histogram
traefik_entrypoint_request_duration_seconds_bucket{code="200",entrypoint="traefik",method="GET",protocol="http",le="0.1"} 167
traefik_entrypoint_request_duration_seconds_bucket{code="200",entrypoint="traefik",method="GET",protocol="http",le="0.3"} 167
traefik_entrypoint_request_duration_seconds_bucket{code="200",entrypoint="traefik",method="GET",protocol="http",le="1.2"} 167
traefik_entrypoint_request_duration_seconds_bucket{code="200",entrypoint="traefik",method="GET",protocol="http",le="5"} 167
traefik_entrypoint_request_duration_seconds_bucket{code="200",entrypoint="traefik",method="GET",protocol="http",le="+Inf"} 167
traefik_entrypoint_request_duration_seconds_sum{code="200",entrypoint="traefik",method="GET",protocol="http"} 1.3099332049999997
traefik_entrypoint_request_duration_seconds_count{code="200",entrypoint="traefik",method="GET",protocol="http"} 167
traefik_entrypoint_request_duration_seconds_bucket{code="200",entrypoint="web",method="GET",protocol="http",le="0.1"} 8
traefik_entrypoint_request_duration_seconds_bucket{code="200",entrypoint="web",method="GET",protocol="http",le="0.3"} 9
traefik_entrypoint_request_duration_seconds_bucket{code="200",entrypoint="web",method="GET",protocol="http",le="1.2"} 9
traefik_entrypoint_request_duration_seconds_bucket{code="200",entrypoint="web",method="GET",protocol="http",le="5"} 10
traefik_entrypoint_request_duration_seconds_bucket{code="200",entrypoint="web",method="GET",protocol="http",le="+Inf"} 10
traefik_entrypoint_request_duration_seconds_sum{code="200",entrypoint="web",method="GET",protocol="http"} 1.507857878
traefik_entrypoint_request_duration_seconds_count{code="200",entrypoint="web",method="GET",protocol="http"} 10
traefik_entrypoint_request_duration_seconds_bucket{code="204",entrypoint="web",method="GET",protocol="http",le="0.1"} 1
traefik_entrypoint_request_duration_seconds_bucket{code="204",entrypoint="web",method="GET",protocol="http",le="0.3"} 1
traefik_entrypoint_request_duration_seconds_bucket{code="204",entrypoint="web",method="GET",protocol="http",le="1.2"} 1
traefik_entrypoint_request_duration_seconds_bucket{code="204",entrypoint="web",method="GET",protocol="http",le="5"} 1
traefik_entrypoint_request_duration_seconds_bucket{code="204",entrypoint="web",method="GET",protocol="http",le="+Inf"} 1
traefik_entrypoint_request_duration_seconds_sum{code="204",entrypoint="web",method="GET",protocol="http"} 0.001608716
traefik_entrypoint_request_duration_seconds_count{code="204",entrypoint="web",method="GET",protocol="http"} 1
traefik_entrypoint_request_duration_seconds_bucket{code="404",entrypoint="traefik",method="GET",protocol="http",le="0.1"} 14
traefik_entrypoint_request_duration_seconds_bucket{code="404",entrypoint="traefik",method="GET",protocol="http",le="0.3"} 14
traefik_entrypoint_request_duration_seconds_bucket{code="404",entrypoint="traefik",method="GET",protocol="http",le="1.2"} 14
traefik_entrypoint_request_duration_seconds_bucket{code="404",entrypoint="traefik",method="GET",protocol="http",le="5"} 14
traefik_entrypoint_request_duration_seconds_bucket{code="404",entrypoint="traefik",method="GET",protocol="http",le="+Inf"} 14
traefik_entrypoint_request_duration_seconds_sum{code="404",entrypoint="traefik",method="GET",protocol="http"} 0.004408174
traefik_entrypoint_request_duration_seconds_count{code="404",entrypoint="traefik",method="GET",protocol="http"} 14
traefik_entrypoint_request_duration_seconds_bucket{code="404",entrypoint="web",method="GET",protocol="http",le="0.1"} 55
traefik_entrypoint_request_duration_seconds_bucket{code="404",entrypoint="web",method="GET",protocol="http",le="0.3"} 55
traefik_entrypoint_request_duration_seconds_bucket{code="404",entrypoint="web",method="GET",protocol="http",le="1.2"} 55
traefik_entrypoint_request_duration_seconds_bucket{code="404",entrypoint="web",method="GET",protocol="http",le="5"} 55
traefik_entrypoint_request_duration_seconds_bucket{code="404",entrypoint="web",method="GET",protocol="http",le="+Inf"} 55
traefik_entrypoint_request_duration_seconds_sum{code="404",entrypoint="web",method="GET",protocol="http"} 0.007367014
traefik_entrypoint_request_duration_seconds_count{code="404",entrypoint="web",method="GET",protocol="http"} 55
# HELP traefik_entrypoint_requests_total How many HTTP requests processed on an entrypoint, partitioned by status code, protocol, and method.
# TYPE traefik_entrypoint_requests_total counter
traefik_entrypoint_requests_total{code="200",entrypoint="traefik",method="GET",protocol="http"} 167
traefik_entrypoint_requests_total{code="200",entrypoint="web",method="GET",protocol="http"} 10
traefik_entrypoint_requests_total{code="204",entrypoint="web",method="GET",protocol="http"} 1
traefik_entrypoint_requests_total{code="404",entrypoint="traefik",method="GET",protocol="http"} 14
traefik_entrypoint_requests_total{code="404",entrypoint="web",method="GET",protocol="http"} 55
# HELP traefik_service_open_connections How many open connections exist on a service, partitioned by method and protocol.
# TYPE traefik_service_open_connections gauge
traefik_service_open_connections{method="GET",protocol="http",service="portainer@docker"} 0
# HELP traefik_service_request_duration_seconds How long it took to process the request on a service, partitioned by status code, protocol, and method.
# TYPE traefik_service_request_duration_seconds histogram
traefik_service_request_duration_seconds_bucket{code="200",method="GET",protocol="http",service="portainer@docker",le="0.1"} 8
traefik_service_request_duration_seconds_bucket{code="200",method="GET",protocol="http",service="portainer@docker",le="0.3"} 9
traefik_service_request_duration_seconds_bucket{code="200",method="GET",protocol="http",service="portainer@docker",le="1.2"} 9
traefik_service_request_duration_seconds_bucket{code="200",method="GET",protocol="http",service="portainer@docker",le="5"} 10
traefik_service_request_duration_seconds_bucket{code="200",method="GET",protocol="http",service="portainer@docker",le="+Inf"} 10
traefik_service_request_duration_seconds_sum{code="200",method="GET",protocol="http",service="portainer@docker"} 1.5043375110000001
traefik_service_request_duration_seconds_count{code="200",method="GET",protocol="http",service="portainer@docker"} 10
traefik_service_request_duration_seconds_bucket{code="204",method="GET",protocol="http",service="portainer@docker",le="0.1"} 1
traefik_service_request_duration_seconds_bucket{code="204",method="GET",protocol="http",service="portainer@docker",le="0.3"} 1
traefik_service_request_duration_seconds_bucket{code="204",method="GET",protocol="http",service="portainer@docker",le="1.2"} 1
traefik_service_request_duration_seconds_bucket{code="204",method="GET",protocol="http",service="portainer@docker",le="5"} 1
traefik_service_request_duration_seconds_bucket{code="204",method="GET",protocol="http",service="portainer@docker",le="+Inf"} 1
traefik_service_request_duration_seconds_sum{code="204",method="GET",protocol="http",service="portainer@docker"} 0.001283998
traefik_service_request_duration_seconds_count{code="204",method="GET",protocol="http",service="portainer@docker"} 1
traefik_service_request_duration_seconds_bucket{code="404",method="GET",protocol="http",service="portainer@docker",le="0.1"} 1
traefik_service_request_duration_seconds_bucket{code="404",method="GET",protocol="http",service="portainer@docker",le="0.3"} 1
traefik_service_request_duration_seconds_bucket{code="404",method="GET",protocol="http",service="portainer@docker",le="1.2"} 1
traefik_service_request_duration_seconds_bucket{code="404",method="GET",protocol="http",service="portainer@docker",le="5"} 1
traefik_service_request_duration_seconds_bucket{code="404",method="GET",protocol="http",service="portainer@docker",le="+Inf"} 1
traefik_service_request_duration_seconds_sum{code="404",method="GET",protocol="http",service="portainer@docker"} 0.003317615
traefik_service_request_duration_seconds_count{code="404",method="GET",protocol="http",service="portainer@docker"} 1
# HELP traefik_service_requests_total How many HTTP requests processed on a service, partitioned by status code, protocol, and method.
# TYPE traefik_service_requests_total counter
traefik_service_requests_total{code="200",method="GET",protocol="http",service="portainer@docker"} 10
traefik_service_requests_total{code="204",method="GET",protocol="http",service="portainer@docker"} 1
traefik_service_requests_total{code="404",method="GET",protocol="http",service="portainer@docker"} 1
```
</details>