### PR TITLE
modules/prometheus: add `force_absolute_algorithm` config option

### DIFF
--- a/config/go.d/prometheus.conf
+++ b/config/go.d/prometheus.conf
@@ -83,6 +83,14 @@
 #        - selector: <PATTERN>
 #          by_label: <a space separated list of labels names>
 #
+#  - force_absolute_algorithm
+#    Force cumulative metrics charts dimensions algorithm to be absolute
+#    Pattern syntax is https://golang.org/pkg/path/filepath/#Match
+#    Syntax:
+#    force_absolute_algorithm:
+#      - '*_sum'
+#      - '*_count'
+#
 #  - max_time_series_per_metric
 #    Time series per metric (metric name) limit. Metrics with number of time series > limit are skipped.
 #    Syntax:

--- a/modules/prometheus/README.md
+++ b/modules/prometheus/README.md
@@ -48,6 +48,26 @@ jobs:
     url: http://203.0.113.0:9182/metrics
 ```
 
+### Dimension algorithm
+
+`incremental` algorithm (values displayed as rate) used when:
+
+- the metric type is `Counter`, `Histogram` or `Summary`.
+- the metrics suffix is `_total`, `_sum` or `_count`.
+
+`absoulte` algorithm (values displayed as is) is used in all other cases.
+
+Use `force_absolute_algorithm` configuration option to overwrite the logic.
+
+```yaml
+jobs:
+  - name: node_exporter_local
+    url: http://127.0.0.1:9100/metrics
+    force_absolute_algorithm:
+      - '*_sum'
+      - '*_count'
+```
+
 ### Time Series Selector (filtering)
 
 To filter unwanted time series (metrics) use `selector` configuration option.

--- a/modules/prometheus/collect_gauge_counter.go
+++ b/modules/prometheus/collect_gauge_counter.go
@@ -1,6 +1,8 @@
 package prometheus
 
 import (
+	"strings"
+
 	"github.com/netdata/go.d.plugin/agent/module"
 	"github.com/netdata/go.d.plugin/pkg/prometheus"
 )
@@ -30,6 +32,9 @@ func (p *Prometheus) collectAny(mx map[string]int64, pms prometheus.Metrics, met
 		if !cache.hasChart(chartID) {
 			chart := anyChart(chartID, pm, meta)
 			cache.putChart(chartID, chart)
+			if strings.HasSuffix(chart.Units, "/s") && p.forceAbsoluteAlgorithm.MatchString(pm.Name()) {
+				chart.Units = chart.Units[:len(chart.Units)-2]
+			}
 			if err := p.Charts().Add(chart); err != nil {
 				p.Warning(err)
 			}

--- a/modules/prometheus/collect_gauge_counter.go
+++ b/modules/prometheus/collect_gauge_counter.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	"github.com/netdata/go.d.plugin/agent/module"
 	"github.com/netdata/go.d.plugin/pkg/prometheus"
 )
 
@@ -37,6 +38,9 @@ func (p *Prometheus) collectAny(mx map[string]int64, pms prometheus.Metrics, met
 			cache.putDim(dimID)
 			chart := cache.getChart(chartID)
 			dim := anyChartDimension(dimID, dimName, pm, meta)
+			if dim.Algo == module.Incremental && p.forceAbsoluteAlgorithm.MatchString(pm.Name()) {
+				dim.Algo = module.Absolute
+			}
 			if err := chart.AddDim(dim); err != nil {
 				p.Warning(err)
 			}

--- a/modules/prometheus/init.go
+++ b/modules/prometheus/init.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/netdata/go.d.plugin/pkg/matcher"
 	"github.com/netdata/go.d.plugin/pkg/prometheus"
 	"github.com/netdata/go.d.plugin/pkg/prometheus/selector"
 	"github.com/netdata/go.d.plugin/pkg/web"
@@ -75,6 +76,18 @@ func (p Prometheus) initOptionalGrouping() ([]optionalGrouping, error) {
 		})
 	}
 	return optGrps, nil
+}
+
+func (p Prometheus) initForceAbsoluteAlgorithm() (matcher.Matcher, error) {
+	mr := matcher.FALSE()
+	for _, v := range p.ForceAbsoluteAlgorithm {
+		m, err := matcher.NewGlobMatcher(v)
+		if err != nil {
+			return nil, err
+		}
+		mr = matcher.Or(mr, m)
+	}
+	return mr, nil
 }
 
 func labelsContainsAll(lbs labels.Labels, names ...string) bool {


### PR DESCRIPTION
Fixes: #531

This PR allows to change dimension algorithm from `incremental` to `absolute` for cumulative metrics. Added new configuration option `force_absolute_algorithm`.

Pattern syntax is https://golang.org/pkg/path/filepath/#Match, example:

```yaml
jobs:
  - name: ...
    url: ...
    force_absolute_algorithm:
      - '*_sum'
      - '*_count'
```