### PR TITLE
modules/dnsmasq: remove `cache_entries` metric

### DIFF
--- a/modules/dnsmasq/README.md
+++ b/modules/dnsmasq/README.md
@@ -32,7 +32,7 @@ by [reading the response on the following query](https://manpages.debian.org/str
 ## Charts
 
 - Queries forwarded to the upstream servers in `queries/s`
-- Cache entries in `entries`
+- Cache size in `entries`
 - Cache operations in `operations/s`
 - Cache performance in `events/s`
 

--- a/modules/dnsmasq/charts.go
+++ b/modules/dnsmasq/charts.go
@@ -15,15 +15,13 @@ var cacheCharts = module.Charts{
 		},
 	},
 	{
-		ID:    "cache_entries",
-		Title: "Cache entries",
+		ID:    "cache_size",
+		Title: "Cache size",
 		Units: "entries",
 		Fam:   "cache",
-		Ctx:   "dnsmasq.cache_entries",
-		Type:  module.Area,
+		Ctx:   "dnsmasq.cache_size",
 		Dims: module.Dims{
-			{ID: "cachesize", Name: "max"},
-			{ID: "cache_entries", Name: "current"},
+			{ID: "cachesize", Name: "size"},
 		},
 	},
 	{

--- a/modules/dnsmasq/collect.go
+++ b/modules/dnsmasq/collect.go
@@ -15,20 +15,11 @@ func (d *Dnsmasq) collect() (map[string]int64, error) {
 	}
 
 	ms := make(map[string]int64)
-	err = d.collectResponse(ms, r)
-	if err != nil {
+	if err = d.collectResponse(ms, r); err != nil {
 		return nil, err
 	}
 
-	calcCacheEntries(ms)
 	return ms, nil
-}
-
-func calcCacheEntries(ms map[string]int64) {
-	if !has(ms, "insertions", "evictions") {
-		return
-	}
-	ms["cache_entries"] = ms["insertions"] - ms["evictions"]
 }
 
 func (d *Dnsmasq) collectResponse(ms map[string]int64, resp *dns.Msg) error {
@@ -127,13 +118,4 @@ func (d *Dnsmasq) queryCacheStatistics() (*dns.Msg, error) {
 		return nil, fmt.Errorf("'%s' returned '%s' (%d) response code", d.Address, s, r.Rcode)
 	}
 	return r, nil
-}
-
-func has(m map[string]int64, key string, keys ...string) bool {
-	switch _, ok := m[key]; len(keys) {
-	case 0:
-		return ok
-	default:
-		return ok && has(m, keys[0], keys[1:]...)
-	}
 }

--- a/modules/dnsmasq/dnsmasq_test.go
+++ b/modules/dnsmasq/dnsmasq_test.go
@@ -111,7 +111,6 @@ func TestDnsmasq_Collect(t *testing.T) {
 			prepare: prepareOKDnsmasq,
 			wantCollected: map[string]int64{
 				"auth":           5,
-				"cache_entries":  5,
 				"cachesize":      999,
 				"evictions":      5,
 				"failed_queries": 9,
@@ -193,7 +192,7 @@ type mockDNSClient struct {
 	rcodeServerFailureOnExchange bool
 }
 
-func (m mockDNSClient) Exchange(msg *dns.Msg, address string) (*dns.Msg, time.Duration, error) {
+func (m mockDNSClient) Exchange(msg *dns.Msg, _ string) (*dns.Msg, time.Duration, error) {
 	if m.errOnExchange {
 		return nil, 0, errors.New("'Exchange' error")
 	}


### PR DESCRIPTION
Fixes: #547

`cache_entries = insertions - evictions` was a wrong assumption, see https://github.com/netdata/go.d.plugin/issues/547#issuecomment-769818811

This PR removes `cache_entries` metric, because it is misleading. It looks like it is impossible to get current number of entries in the cache from the provided cache statistics.