### PR TITLE
agent: fix mem leak

### DIFF
--- a/agent/job/build/build.go
+++ b/agent/job/build/build.go
@@ -222,6 +222,12 @@ func (m *Manager) handleAddCfg(ctx context.Context, cfg confgroup.Config) {
 		m.CurState.Save(cfg, buildError)
 		return
 	}
+	cleanupJob := true
+	defer func() {
+		if cleanupJob {
+			job.Cleanup()
+		}
+	}()
 
 	if isRetry {
 		job.AutoDetectEvery = task.timeout
@@ -245,6 +251,7 @@ func (m *Manager) handleAddCfg(ctx context.Context, cfg confgroup.Config) {
 			m.CurState.Save(cfg, success)
 			m.Runner.Start(job)
 			m.startCache.put(cfg)
+			cleanupJob = false
 		} else if isTooManyOpenFiles(err) {
 			m.Error(err)
 			m.CurState.Save(cfg, registrationError)

--- a/agent/job/job.go
+++ b/agent/job/job.go
@@ -10,4 +10,5 @@ type Job interface {
 	Tick(clock int)
 	Start()
 	Stop()
+	Cleanup()
 }

--- a/agent/module/job.go
+++ b/agent/module/job.go
@@ -188,7 +188,7 @@ LOOP:
 		}
 	}
 	j.module.Cleanup()
-	j.cleanup()
+	j.Cleanup()
 	j.stop <- struct{}{}
 }
 
@@ -203,7 +203,7 @@ func (j *Job) disableAutoDetection() {
 	j.AutoDetectEvery = 0
 }
 
-func (j *Job) cleanup() {
+func (j *Job) Cleanup() {
 	if j.Logger != nil {
 		logger.GlobalMsgCountWatcher.Unregister(j.Logger)
 	}
@@ -221,9 +221,11 @@ func (j *Job) cleanup() {
 			}
 		}
 	}
-	writeLock.Lock()
-	_, _ = io.Copy(j.out, j.buf)
-	writeLock.Unlock()
+	if j.buf.Len() > 0 {
+		writeLock.Lock()
+		_, _ = io.Copy(j.out, j.buf)
+		writeLock.Unlock()
+	}
 }
 
 func (j *Job) init() bool {


### PR DESCRIPTION
Fixes: #549

This PR fixes agent memory leak. For every configuration job we create a logger instance and register it 

https://github.com/netdata/go.d.plugin/blob/196e3eb42a40e9e86705165fbfeadd8f0741c264/logger/logger.go#L54-L60

> GlobalMsgCountWatcher.Register(logger)

That is current log flood protection implementation - there is global registry that contains logger instances references, it iterates over them every second and resets logged messages counter.

But we never unregister them for unsuccessful jobs (Check() returns false).

---

Test plan:
 - set `autodetection_retry: 10` in the default `prometheus.conf`
 - observe `go.d.plugin` memory consumption on the netdata dashboard (Applications->mem->apps.mem)

The difference before and after the patch is clearly visible:

<img width="1138" alt="Screenshot 2021-02-03 at 13 56 32" src="https://user-images.githubusercontent.com/22274335/106737449-bcaacd00-6627-11eb-873d-0530d5ae4e29.png">

