### PR TITLE
add supervisord module

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ If you have time and willing to help, there are a lof of ways to contribute:
 | [solr](https://github.com/netdata/go.d.plugin/tree/master/modules/solr)                           | `Solr`                          |
 | [squidlog](https://github.com/netdata/go.d.plugin/tree/master/modules/squidlog)                   | `Squid`                         |
 | [springboot2](https://github.com/netdata/go.d.plugin/tree/master/modules/springboot2)             | `Spring Boot2`                  |
+| [supervisord](https://github.com/netdata/go.d.plugin/tree/master/modules/supervisord)             | `Supervisor`                    |
 | [systemdunits](https://github.com/netdata/go.d.plugin/tree/master/modules/systemdunits)           | `Systemd unit state`            |
 | [tengine](https://github.com/netdata/go.d.plugin/tree/master/modules/tengine)                     | `Tengine`                       |
 | [unbound](https://github.com/netdata/go.d.plugin/tree/master/modules/unbound)                     | `Unbound`                       |

--- a/config/go.d.conf
+++ b/config/go.d.conf
@@ -61,6 +61,7 @@ modules:
 #  solr: yes
 #  springboot2: yes
 #  squidlog: yes
+#  supervisord: yes
 #  systemdunits: yes
 #  tengine: yes
 #  unbound: yes

--- a/config/go.d/supervisord.conf
+++ b/config/go.d/supervisord.conf
@@ -1,0 +1,119 @@
+# netdata go.d.plugin configuration for supervisord
+#
+# This file is in YAML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - GLOBAL
+#  - JOBS
+#
+#
+# [ GLOBAL ]
+# These variables set the defaults for all JOBs, however each JOB may define its own, overriding the defaults.
+#
+# The GLOBAL section format:
+# param1: value1
+# param2: value2
+#
+# Currently supported global parameters:
+#  - update_every
+#    Data collection frequency in seconds. Default: 1.
+#
+#  - autodetection_retry
+#    Re-check interval in seconds. Attempts to start the job are made once every interval.
+#    Zero means not to schedule re-check. Default: 0.
+#
+#  - priority
+#    Priority is the relative priority of the charts as rendered on the web page,
+#    lower numbers make the charts appear before the ones with higher numbers. Default: 70000.
+#
+#
+# [ JOBS ]
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# IMPORTANT:
+#  - Parameter 'name' is mandatory.
+#  - Jobs with the same name are mutually exclusive. Only one of them will be allowed running at any time.
+#
+# This allows autodetection to try several alternatives and pick the one that works.
+# Any number of jobs is supported.
+#
+# The JOBS section format:
+#
+# jobs:
+#   - name: job1
+#     param1: value1
+#     param2: value2
+#
+#   - name: job2
+#     param1: value1
+#     param2: value2
+#
+#   - name: job2
+#     param1: value1
+#
+#
+# [ List of JOB specific parameters ]:
+#  - url
+#    Server URL.
+#    Syntax:
+#      url: http://localhost:80
+#
+#  - timeout
+#    HTTP response timeout.
+#    Syntax:
+#      timeout: 1
+#
+#  - not_follow_redirects
+#    Whether to not follow redirects from the server.
+#    Syntax:
+#      not_follow_redirects: yes/no
+#
+#  - tls_skip_verify
+#    Whether to skip verifying server's certificate chain and hostname.
+#    Syntax:
+#      tls_skip_verify: yes/no
+#
+#  - tls_ca
+#    Certificate authority that client use when verifying server certificates.
+#    Syntax:
+#      tls_ca: path/to/ca.pem
+#
+#  - tls_cert
+#    Client tls certificate.
+#    Syntax:
+#      tls_cert: path/to/cert.pem
+#
+#  - tls_key
+#    Client tls key.
+#    Syntax:
+#      tls_key: path/to/key.pem
+#
+#
+# [ JOB defaults ]:
+#  url: http://127.0.0.1:9001/RPC2
+#  timeout: 1
+#  not_follow_redirects: no
+#  tls_skip_verify: no
+#
+#
+# [ JOB mandatory parameters ]:
+#  - name
+#  - url
+#
+# ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
+# [ GLOBAL ]
+# update_every: 1
+# autodetection_retry: 0
+# priority: 70000
+#
+#
+# [ JOBS ]
+jobs:
+  - name: local
+    url: 'http://127.0.0.1:9001/RPC2'
+
+  - name: local
+    url: 'unix:///run/supervisor.sock'

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/likexian/whois-go v1.7.1
 	github.com/likexian/whois-parser-go v1.14.5
 	github.com/mattn/go-isatty v0.0.12
+	github.com/mattn/go-xmlrpc v0.0.3
 	github.com/miekg/dns v1.1.29
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/likexian/whois-parser-go v1.14.5/go.mod h1:nhh8bZ0mHgLu3p0mUV2kh9DgUJ
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/mattn/go-xmlrpc v0.0.3 h1:Y6WEMLEsqs3RviBrAa1/7qmbGB7DVD3brZIbqMbQdGY=
+github.com/mattn/go-xmlrpc v0.0.3/go.mod h1:mqc2dz7tP5x5BKlCahN/n+hs7OSZKJkS9JsHNBRlrxA=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.1.29 h1:xHBEhR+t5RzcFJjBLJlax2daXOrTYtr9z4WdKEfWFzg=

--- a/modules/init.go
+++ b/modules/init.go
@@ -48,6 +48,7 @@ import (
 	_ "github.com/netdata/go.d.plugin/modules/solr"
 	_ "github.com/netdata/go.d.plugin/modules/springboot2"
 	_ "github.com/netdata/go.d.plugin/modules/squidlog"
+	_ "github.com/netdata/go.d.plugin/modules/supervisord"
 	_ "github.com/netdata/go.d.plugin/modules/systemdunits"
 	_ "github.com/netdata/go.d.plugin/modules/tengine"
 	_ "github.com/netdata/go.d.plugin/modules/unbound"

--- a/modules/supervisord/README.md
+++ b/modules/supervisord/README.md
@@ -1,0 +1,83 @@
+<!--
+title: "Supervisord monitoring with Netdata"
+description: "Monitor the processes running by Supervisor with zero configuration, per-second metric granularity, and interactive visualizations."
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/supervisord/README.md
+sidebar_label: "Supervisord"
+-->
+
+# Supervisord monitoring with Netdata
+
+[Supervisor](http://supervisord.org/) is a client/server system that allows its users to monitor and control a number of
+processes on UNIX-like operating systems.
+
+This module monitors one or more Supervisor instances, depending on your configuration.
+
+It can collect metrics from
+both [unix socket](http://supervisord.org/configuration.html?highlight=unix_http_server#unix-http-server-section-values)
+and [internal http server](http://supervisord.org/configuration.html?highlight=unix_http_server#inet-http-server-section-settings)
+
+Used methods:
+
+- [`supervisor.getAllProcessInfo`](http://supervisord.org/api.html#supervisor.rpcinterface.SupervisorNamespaceRPCInterface.getAllProcessInfo)
+
+## Charts
+
+Summary charts:
+
+- Processes in `processes`
+
+Processes groups charts:
+
+- Processes in `processes`
+- State code in `code`
+- Exit status in `status`
+- Uptime in `seconds`
+- Downtime in `seconds`
+
+## Configuration
+
+Edit the `go.d/supervisord.conf` configuration file using `edit-config` from the
+Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+
+```bash
+cd /etc/netdata # Replace this path with your Netdata config directory
+sudo ./edit-config go.d/supervisord.conf
+```
+
+Endpoints can be both local or remote as long as they expose their metrics on the provided URL.
+
+Here is an example with two endpoints:
+
+```yaml
+jobs:
+  # via [unix_http_server]
+  - name: local
+    url: 'unix:///run/supervisor.sock'
+
+  # via [inet_http_server]
+  - name: local
+    url: 'http://127.0.0.1:9001/RPC2'
+```
+
+For all available options, see the `supervisord`
+collector's [configuration file](https://github.com/netdata/go.d.plugin/blob/master/config/go.d/supervisord.conf).
+
+## Troubleshooting
+
+To troubleshoot issues with the `supervisord` collector, run the `go.d.plugin` with the debug option enabled. The output
+should give you clues as to why the collector isn't working.
+
+First, navigate to your plugins directory, usually at `/usr/libexec/netdata/plugins.d/`. If that's not the case on your
+system, open `netdata.conf` and look for the setting `plugins directory`. Once you're in the plugin's directory, switch
+to the `netdata` user.
+
+```bash
+cd /usr/libexec/netdata/plugins.d/
+sudo -u netdata -s
+```
+
+You can now run the `go.d.plugin` to debug the collector:
+
+```bash
+./go.d.plugin -d -m supervisord
+```

--- a/modules/supervisord/charts.go
+++ b/modules/supervisord/charts.go
@@ -44,28 +44,28 @@ var (
 	}
 	groupProcessesStateCodeChartTmpl = module.Chart{
 		ID:    "group_%s_processes_state_code",
-		Title: "Processes state code",
-		Units: "state",
+		Title: "State code",
+		Units: "code",
 		Fam:   "group %s",
 		Ctx:   "supervisord.process_state_code",
 	}
 	groupProcessesExitStatusChartTmpl = module.Chart{
 		ID:    "group_%s_processes_exit_status",
-		Title: "Processes exit status",
+		Title: "Exit status",
 		Units: "status",
 		Fam:   "group %s",
 		Ctx:   "supervisord.process_exit_status",
 	}
 	groupProcessesUptimeChartTmpl = module.Chart{
 		ID:    "group_%s_processes_uptime",
-		Title: "Processes uptime",
+		Title: "Uptime",
 		Units: "seconds",
 		Fam:   "group %s",
 		Ctx:   "supervisord.process_uptime",
 	}
 	groupProcessesDowntimeChartTmpl = module.Chart{
 		ID:    "group_%s_processes_downtime",
-		Title: "Processes downtime",
+		Title: "Downtime",
 		Units: "seconds",
 		Fam:   "group %s",
 		Ctx:   "supervisord.process_downtime",

--- a/modules/supervisord/charts.go
+++ b/modules/supervisord/charts.go
@@ -1,0 +1,85 @@
+package supervisord
+
+import (
+	"fmt"
+
+	"github.com/netdata/go.d.plugin/agent/module"
+)
+
+var summaryCharts = module.Charts{
+	{
+		ID:    "processes",
+		Title: "Processes",
+		Units: "processes",
+		Fam:   "summary",
+		Ctx:   "supervisord.summary_processes",
+		Type:  module.Stacked,
+		Dims: module.Dims{
+			{ID: "running_processes", Name: "running"},
+			{ID: "non_running_processes", Name: "non-running"},
+		},
+	},
+}
+
+var (
+	groupChartsTmpl = module.Charts{
+		groupProcessesChartTmpl.Copy(),
+		groupProcessesStateCodeChartTmpl.Copy(),
+		groupProcessesExitStatusChartTmpl.Copy(),
+		groupProcessesUptimeChartTmpl.Copy(),
+		groupProcessesDowntimeChartTmpl.Copy(),
+	}
+
+	groupProcessesChartTmpl = module.Chart{
+		ID:    "group_%s_processes",
+		Title: "Processes",
+		Units: "processes",
+		Fam:   "group %s",
+		Ctx:   "supervisord.processes",
+		Type:  module.Stacked,
+		Dims: module.Dims{
+			{ID: "group_%s_running_processes", Name: "running"},
+			{ID: "group_%s_non_running_processes", Name: "non-running"},
+		},
+	}
+	groupProcessesStateCodeChartTmpl = module.Chart{
+		ID:    "group_%s_processes_state_code",
+		Title: "Processes state code",
+		Units: "state",
+		Fam:   "group %s",
+		Ctx:   "supervisord.process_state_code",
+	}
+	groupProcessesExitStatusChartTmpl = module.Chart{
+		ID:    "group_%s_processes_exit_status",
+		Title: "Processes exit status",
+		Units: "status",
+		Fam:   "group %s",
+		Ctx:   "supervisord.process_exit_status",
+	}
+	groupProcessesUptimeChartTmpl = module.Chart{
+		ID:    "group_%s_processes_uptime",
+		Title: "Processes uptime",
+		Units: "seconds",
+		Fam:   "group %s",
+		Ctx:   "supervisord.process_uptime",
+	}
+	groupProcessesDowntimeChartTmpl = module.Chart{
+		ID:    "group_%s_processes_downtime",
+		Title: "Processes downtime",
+		Units: "seconds",
+		Fam:   "group %s",
+		Ctx:   "supervisord.process_downtime",
+	}
+)
+
+func newProcGroupCharts(group string) *module.Charts {
+	charts := groupChartsTmpl.Copy()
+	for _, c := range *charts {
+		c.ID = fmt.Sprintf(c.ID, group)
+		c.Fam = fmt.Sprintf(c.Fam, group)
+		for _, d := range c.Dims {
+			d.ID = fmt.Sprintf(d.ID, group)
+		}
+	}
+	return charts
+}

--- a/modules/supervisord/charts.go
+++ b/modules/supervisord/charts.go
@@ -6,14 +6,20 @@ import (
 	"github.com/netdata/go.d.plugin/agent/module"
 )
 
+const (
+	summaryChartsPriority = module.Priority
+	groupChartsPriority   = summaryChartsPriority + 20
+)
+
 var summaryCharts = module.Charts{
 	{
-		ID:    "processes",
-		Title: "Processes",
-		Units: "processes",
-		Fam:   "summary",
-		Ctx:   "supervisord.summary_processes",
-		Type:  module.Stacked,
+		ID:       "processes",
+		Title:    "Processes",
+		Units:    "processes",
+		Fam:      "summary",
+		Ctx:      "supervisord.summary_processes",
+		Type:     module.Stacked,
+		Priority: summaryChartsPriority,
 		Dims: module.Dims{
 			{ID: "running_processes", Name: "running"},
 			{ID: "non_running_processes", Name: "non-running"},
@@ -74,9 +80,10 @@ var (
 
 func newProcGroupCharts(group string) *module.Charts {
 	charts := groupChartsTmpl.Copy()
-	for _, c := range *charts {
+	for i, c := range *charts {
 		c.ID = fmt.Sprintf(c.ID, group)
 		c.Fam = fmt.Sprintf(c.Fam, group)
+		c.Priority = groupChartsPriority + i
 		for _, d := range c.Dims {
 			d.ID = fmt.Sprintf(d.ID, group)
 		}

--- a/modules/supervisord/client.go
+++ b/modules/supervisord/client.go
@@ -82,21 +82,21 @@ func parseGetAllProcessInfo(resp interface{}) ([]processStatus, error) {
 		for k, v := range s {
 			switch strings.ToLower(k) {
 			case "name":
-				p.name, ok = v.(string)
+				p.name, _ = v.(string)
 			case "group":
-				p.group, ok = v.(string)
+				p.group, _ = v.(string)
 			case "start":
-				p.start, ok = v.(int)
+				p.start, _ = v.(int)
 			case "stop":
-				p.stop, ok = v.(int)
+				p.stop, _ = v.(int)
 			case "now":
-				p.now, ok = v.(int)
+				p.now, _ = v.(int)
 			case "state":
-				p.state, ok = v.(int)
+				p.state, _ = v.(int)
 			case "statename":
-				p.stateName, ok = v.(string)
+				p.stateName, _ = v.(string)
 			case "exitstatus":
-				p.exitStatus, ok = v.(int)
+				p.exitStatus, _ = v.(int)
 			}
 		}
 		info = append(info, p)

--- a/modules/supervisord/client.go
+++ b/modules/supervisord/client.go
@@ -1,0 +1,105 @@
+package supervisord
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/mattn/go-xmlrpc"
+)
+
+type supervisorRPCClient struct {
+	client *xmlrpc.Client
+}
+
+func newSupervisorRPCClient(serverURL *url.URL, httpClient *http.Client) (supervisorClient, error) {
+	switch serverURL.Scheme {
+	case "http", "https":
+		c := xmlrpc.NewClient(serverURL.String())
+		c.HttpClient = httpClient
+		return &supervisorRPCClient{client: c}, nil
+	case "unix":
+		c := xmlrpc.NewClient("http://unix/RPC2")
+		t, ok := httpClient.Transport.(*http.Transport)
+		if !ok {
+			return nil, errors.New("unexpected HTTP client transport")
+		}
+		t.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
+			d := net.Dialer{Timeout: httpClient.Timeout}
+			return d.DialContext(ctx, "unix", serverURL.Path)
+		}
+		c.HttpClient = httpClient
+		return &supervisorRPCClient{client: c}, nil
+	default:
+		return nil, fmt.Errorf("unexpected URL scheme: %s", serverURL)
+	}
+}
+
+// http://supervisord.org/api.html#process-control
+type processStatus struct {
+	name       string // name of the process.
+	group      string // name of the process’ group.
+	start      int    // UNIX timestamp of when the process was started.
+	stop       int    // UNIX timestamp of when the process last ended, or 0 if the process has never been stopped.
+	now        int    // UNIX timestamp of the current time, which can be used to calculate process up-time.
+	state      int    // state code.
+	stateName  string // string description of state.
+	exitStatus int    // exit status (errorlevel) of process, or 0 if the process is still running.
+}
+
+func (c *supervisorRPCClient) getAllProcessInfo() ([]processStatus, error) {
+	const fn = "supervisor.getAllProcessInfo"
+	resp, err := c.client.Call(fn)
+	if err != nil {
+		return nil, fmt.Errorf("error on '%s' function call: %v", fn, err)
+	}
+	return parseGetAllProcessInfo(resp)
+}
+
+func (c *supervisorRPCClient) closeIdleConnections() {
+	c.client.HttpClient.CloseIdleConnections()
+}
+
+func parseGetAllProcessInfo(resp interface{}) ([]processStatus, error) {
+	arr, ok := resp.(xmlrpc.Array)
+	if !ok {
+		return nil, fmt.Errorf("unexpected response type, want=xmlrpc.Array, got=%T", resp)
+	}
+
+	var info []processStatus
+
+	for _, item := range arr {
+		s, ok := item.(xmlrpc.Struct)
+		if !ok {
+			continue
+		}
+
+		var p processStatus
+		for k, v := range s {
+			switch strings.ToLower(k) {
+			case "name":
+				p.name, ok = v.(string)
+			case "group":
+				p.group, ok = v.(string)
+			case "start":
+				p.start, ok = v.(int)
+			case "stop":
+				p.stop, ok = v.(int)
+			case "now":
+				p.now, ok = v.(int)
+			case "state":
+				p.state, ok = v.(int)
+			case "statename":
+				p.stateName, ok = v.(string)
+			case "exitstatus":
+				p.exitStatus, ok = v.(int)
+			}
+		}
+		info = append(info, p)
+	}
+	return info, nil
+}

--- a/modules/supervisord/client.go
+++ b/modules/supervisord/client.go
@@ -99,7 +99,9 @@ func parseGetAllProcessInfo(resp interface{}) ([]processStatus, error) {
 				p.exitStatus, _ = v.(int)
 			}
 		}
-		info = append(info, p)
+		if p.name != "" && p.group != "" && p.stateName != "" {
+			info = append(info, p)
+		}
 	}
 	return info, nil
 }

--- a/modules/supervisord/collect.go
+++ b/modules/supervisord/collect.go
@@ -1,0 +1,137 @@
+package supervisord
+
+import (
+	"fmt"
+
+	"github.com/netdata/go.d.plugin/agent/module"
+)
+
+const (
+	// http://supervisord.org/subprocess.html#process-states
+	// STOPPED  (0)
+	// STARTING (10)
+	// RUNNING (20)
+	// BACKOFF (30)
+	// STOPPING (40)
+	// EXITED (100)
+	// FATAL (200)
+	// UNKNOWN (1000)
+
+	stateRunning = 20
+)
+
+func (s *Supervisord) collect() (map[string]int64, error) {
+	info, err := s.client.getAllProcessInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	ms := make(map[string]int64)
+	s.collectAllProcessInfo(ms, info)
+
+	return ms, nil
+}
+
+func (s *Supervisord) collectAllProcessInfo(ms map[string]int64, info []processStatus) {
+	ms["running_processes"] = 0
+	ms["non_running_processes"] = 0
+	for _, p := range info {
+		if !s.collectedGroups[p.group] {
+			s.collectedGroups[p.group] = true
+			s.addProcessGroupCharts(p)
+		}
+		id := procID(p)
+		if !s.collectedProcesses[id] {
+			s.collectedProcesses[id] = true
+			s.addProcessToCharts(p)
+		}
+
+		ms[fmt.Sprintf("group_%s_running_processes", p.group)] += 0
+		ms[fmt.Sprintf("group_%s_non_running_processes", p.group)] += 0
+		if p.state == stateRunning {
+			ms["running_processes"] += 1
+			ms[fmt.Sprintf("group_%s_running_processes", p.group)] += 1
+		} else {
+			ms["non_running_processes"] += 1
+			ms[fmt.Sprintf("group_%s_non_running_processes", p.group)] += 1
+		}
+		ms[id+"_state"] = int64(p.state)
+		ms[id+"_exit_status"] = int64(p.exitStatus)
+		ms[id+"_uptime"] = calcProcessUptime(p)
+		ms[id+"_downtime"] = calcProcessDowntime(p)
+	}
+}
+
+func calcProcessUptime(p processStatus) int64 {
+	if p.state != stateRunning {
+		return 0
+	}
+	return int64(p.now - p.start)
+}
+
+func calcProcessDowntime(p processStatus) int64 {
+	if p.state == stateRunning || p.stop == 0 {
+		return 0
+	}
+	return int64(p.now - p.stop)
+}
+
+func (s *Supervisord) addProcessGroupCharts(p processStatus) {
+	charts := newProcGroupCharts(p.group)
+	if err := s.Charts().Add(*charts...); err != nil {
+		s.Warning(err)
+	}
+}
+
+func (s *Supervisord) addProcessToCharts(p processStatus) {
+	id := procID(p)
+	for _, c := range *s.Charts() {
+		var dimID string
+		switch c.ID {
+		case fmt.Sprintf(groupProcessesStateCodeChartTmpl.ID, p.group):
+			dimID = id + "_state"
+		case fmt.Sprintf(groupProcessesExitStatusChartTmpl.ID, p.group):
+			dimID = id + "_exit_status"
+		case fmt.Sprintf(groupProcessesUptimeChartTmpl.ID, p.group):
+			dimID = id + "_uptime"
+		case fmt.Sprintf(groupProcessesDowntimeChartTmpl.ID, p.group):
+			dimID = id + "_downtime"
+		default:
+			continue
+		}
+		dim := &module.Dim{ID: dimID, Name: p.name}
+		if err := c.AddDim(dim); err != nil {
+			s.Warning(err)
+			return
+		}
+		c.MarkNotCreated()
+	}
+}
+
+func (s *Supervisord) removeProcessFromCharts(p processStatus) {
+	id := procID(p)
+	for _, c := range *s.Charts() {
+		var dimID string
+		switch c.ID {
+		case fmt.Sprintf(groupProcessesStateCodeChartTmpl.ID, p.group):
+			dimID = id + "_state"
+		case fmt.Sprintf(groupProcessesExitStatusChartTmpl.ID, p.group):
+			dimID = id + "_exit_status"
+		case fmt.Sprintf(groupProcessesUptimeChartTmpl.ID, p.group):
+			dimID = id + "_uptime"
+		case fmt.Sprintf(groupProcessesDowntimeChartTmpl.ID, p.group):
+			dimID = id + "_downtime"
+		default:
+			continue
+		}
+		if err := c.MarkDimRemove(dimID, true); err != nil {
+			s.Warning(err)
+			return
+		}
+		c.MarkNotCreated()
+	}
+}
+
+func procID(p processStatus) string {
+	return fmt.Sprintf("group_%s_process_%s", p.group, p.name)
+}

--- a/modules/supervisord/collect.go
+++ b/modules/supervisord/collect.go
@@ -46,16 +46,16 @@ func (s *Supervisord) collectAllProcessInfo(ms map[string]int64, info []processS
 			s.addProcessToCharts(p)
 		}
 
-		ms[fmt.Sprintf("group_%s_running_processes", p.group)] += 0
-		ms[fmt.Sprintf("group_%s_non_running_processes", p.group)] += 0
+		ms["group_"+p.group+"_running_processes"] += 0
+		ms["group_"+p.group+"_non_running_processes"] += 0
 		if p.state == stateRunning {
 			ms["running_processes"] += 1
-			ms[fmt.Sprintf("group_%s_running_processes", p.group)] += 1
+			ms["group_"+p.group+"_running_processes"] += 1
 		} else {
 			ms["non_running_processes"] += 1
-			ms[fmt.Sprintf("group_%s_non_running_processes", p.group)] += 1
+			ms["group_"+p.group+"_non_running_processes"] += 1
 		}
-		ms[id+"_state"] = int64(p.state)
+		ms[id+"_state_code"] = int64(p.state)
 		ms[id+"_exit_status"] = int64(p.exitStatus)
 		ms[id+"_uptime"] = calcProcessUptime(p)
 		ms[id+"_downtime"] = calcProcessDowntime(p)
@@ -89,7 +89,7 @@ func (s *Supervisord) addProcessToCharts(p processStatus) {
 		var dimID string
 		switch c.ID {
 		case fmt.Sprintf(groupProcessesStateCodeChartTmpl.ID, p.group):
-			dimID = id + "_state"
+			dimID = id + "_state_code"
 		case fmt.Sprintf(groupProcessesExitStatusChartTmpl.ID, p.group):
 			dimID = id + "_exit_status"
 		case fmt.Sprintf(groupProcessesUptimeChartTmpl.ID, p.group):
@@ -114,7 +114,7 @@ func (s *Supervisord) removeProcessFromCharts(p processStatus) {
 		var dimID string
 		switch c.ID {
 		case fmt.Sprintf(groupProcessesStateCodeChartTmpl.ID, p.group):
-			dimID = id + "_state"
+			dimID = id + "_state_code"
 		case fmt.Sprintf(groupProcessesExitStatusChartTmpl.ID, p.group):
 			dimID = id + "_exit_status"
 		case fmt.Sprintf(groupProcessesUptimeChartTmpl.ID, p.group):

--- a/modules/supervisord/collect.go
+++ b/modules/supervisord/collect.go
@@ -2,22 +2,9 @@ package supervisord
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/netdata/go.d.plugin/agent/module"
-)
-
-const (
-	// http://supervisord.org/subprocess.html#process-states
-	// STOPPED  (0)
-	// STARTING (10)
-	// RUNNING (20)
-	// BACKOFF (30)
-	// STOPPING (40)
-	// EXITED (100)
-	// FATAL (200)
-	// UNKNOWN (1000)
-
-	stateRunning = 20
 )
 
 func (s *Supervisord) collect() (map[string]int64, error) {
@@ -33,44 +20,69 @@ func (s *Supervisord) collect() (map[string]int64, error) {
 }
 
 func (s *Supervisord) collectAllProcessInfo(ms map[string]int64, info []processStatus) {
+	s.resetCache()
 	ms["running_processes"] = 0
 	ms["non_running_processes"] = 0
 	for _, p := range info {
-		if !s.collectedGroups[p.group] {
-			s.collectedGroups[p.group] = true
+		if _, ok := s.cache[p.group]; !ok {
+			s.cache[p.group] = make(map[string]bool)
 			s.addProcessGroupCharts(p)
 		}
-		id := procID(p)
-		if !s.collectedProcesses[id] {
-			s.collectedProcesses[id] = true
+		if _, ok := s.cache[p.group][p.name]; !ok {
 			s.addProcessToCharts(p)
 		}
+		s.cache[p.group][p.name] = true
 
 		ms["group_"+p.group+"_running_processes"] += 0
 		ms["group_"+p.group+"_non_running_processes"] += 0
-		if p.state == stateRunning {
+		if isProcRunning(p) {
 			ms["running_processes"] += 1
 			ms["group_"+p.group+"_running_processes"] += 1
 		} else {
 			ms["non_running_processes"] += 1
 			ms["group_"+p.group+"_non_running_processes"] += 1
 		}
+		id := procID(p)
 		ms[id+"_state_code"] = int64(p.state)
 		ms[id+"_exit_status"] = int64(p.exitStatus)
 		ms[id+"_uptime"] = calcProcessUptime(p)
 		ms[id+"_downtime"] = calcProcessDowntime(p)
 	}
+	s.cleanupCache()
+}
+
+func (s *Supervisord) resetCache() {
+	for _, procs := range s.cache {
+		for name := range procs {
+			procs[name] = false
+		}
+	}
+}
+
+func (s *Supervisord) cleanupCache() {
+	for group, procs := range s.cache {
+		for name, ok := range procs {
+			if !ok {
+				s.removeProcessFromCharts(group, name)
+				delete(s.cache[group], name)
+			}
+		}
+		if len(s.cache[group]) == 0 {
+			s.removeProcessGroupCharts(group)
+			delete(s.cache, group)
+		}
+	}
 }
 
 func calcProcessUptime(p processStatus) int64 {
-	if p.state != stateRunning {
+	if !isProcRunning(p) {
 		return 0
 	}
 	return int64(p.now - p.start)
 }
 
 func calcProcessDowntime(p processStatus) int64 {
-	if p.state == stateRunning || p.stop == 0 {
+	if isProcRunning(p) || p.stop == 0 {
 		return 0
 	}
 	return int64(p.now - p.stop)
@@ -108,18 +120,28 @@ func (s *Supervisord) addProcessToCharts(p processStatus) {
 	}
 }
 
-func (s *Supervisord) removeProcessFromCharts(p processStatus) {
-	id := procID(p)
+func (s *Supervisord) removeProcessGroupCharts(group string) {
+	prefix := "group_" + group
+	for _, c := range *s.Charts() {
+		if strings.HasPrefix(c.ID, prefix) {
+			c.MarkRemove()
+			c.MarkNotCreated()
+		}
+	}
+}
+
+func (s *Supervisord) removeProcessFromCharts(group, name string) {
+	id := procID(processStatus{name: name, group: group})
 	for _, c := range *s.Charts() {
 		var dimID string
 		switch c.ID {
-		case fmt.Sprintf(groupProcessesStateCodeChartTmpl.ID, p.group):
+		case fmt.Sprintf(groupProcessesStateCodeChartTmpl.ID, group):
 			dimID = id + "_state_code"
-		case fmt.Sprintf(groupProcessesExitStatusChartTmpl.ID, p.group):
+		case fmt.Sprintf(groupProcessesExitStatusChartTmpl.ID, group):
 			dimID = id + "_exit_status"
-		case fmt.Sprintf(groupProcessesUptimeChartTmpl.ID, p.group):
+		case fmt.Sprintf(groupProcessesUptimeChartTmpl.ID, group):
 			dimID = id + "_uptime"
-		case fmt.Sprintf(groupProcessesDowntimeChartTmpl.ID, p.group):
+		case fmt.Sprintf(groupProcessesDowntimeChartTmpl.ID, group):
 			dimID = id + "_downtime"
 		default:
 			continue
@@ -134,4 +156,17 @@ func (s *Supervisord) removeProcessFromCharts(p processStatus) {
 
 func procID(p processStatus) string {
 	return fmt.Sprintf("group_%s_process_%s", p.group, p.name)
+}
+
+func isProcRunning(p processStatus) bool {
+	// http://supervisord.org/subprocess.html#process-states
+	// STOPPED  (0)
+	// STARTING (10)
+	// RUNNING (20)
+	// BACKOFF (30)
+	// STOPPING (40)
+	// EXITED (100)
+	// FATAL (200)
+	// UNKNOWN (1000)
+	return p.state == 20
 }

--- a/modules/supervisord/dev.md
+++ b/modules/supervisord/dev.md
@@ -1,0 +1,3 @@
+#### Setup Supervisor Lab
+
+Follow [the instructions](https://github.com/ilyam8/supervisor_laba#startstop-the-lab).

--- a/modules/supervisord/init.go
+++ b/modules/supervisord/init.go
@@ -1,0 +1,28 @@
+package supervisord
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/netdata/go.d.plugin/pkg/web"
+)
+
+func (s Supervisord) verifyConfig() error {
+	if s.URL == "" {
+		return errors.New("'url' not set")
+	}
+	return nil
+}
+
+func (s Supervisord) initSupervisorClient() (supervisorClient, error) {
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		return nil, fmt.Errorf("parse 'url': %v (%s)", err, s.URL)
+	}
+	httpClient, err := web.NewHTTPClient(s.Client)
+	if err != nil {
+		return nil, fmt.Errorf("create HTTP client: %v", err)
+	}
+	return newSupervisorRPCClient(u, httpClient)
+}

--- a/modules/supervisord/supervisord.go
+++ b/modules/supervisord/supervisord.go
@@ -1,0 +1,95 @@
+package supervisord
+
+import (
+	"time"
+
+	"github.com/netdata/go.d.plugin/agent/module"
+	"github.com/netdata/go.d.plugin/pkg/web"
+)
+
+func init() {
+	module.Register("supervisord", module.Creator{
+		Create: func() module.Module { return New() },
+	})
+}
+
+func New() *Supervisord {
+	return &Supervisord{
+		Config: Config{
+			//URL:     "http://127.0.0.1:9001/RPC2",
+			URL: "http://pc:9001/RPC2",
+			Client: web.Client{
+				Timeout: web.Duration{Duration: time.Second},
+			},
+		},
+
+		charts:             summaryCharts.Copy(),
+		collectedGroups:    make(map[string]bool),
+		collectedProcesses: make(map[string]bool),
+	}
+}
+
+type Config struct {
+	URL        string `yaml:"url"`
+	web.Client `yaml:",inline"`
+}
+
+type (
+	Supervisord struct {
+		module.Base
+		Config `yaml:",inline"`
+
+		client supervisorClient
+		charts *module.Charts
+
+		collectedGroups    map[string]bool
+		collectedProcesses map[string]bool
+	}
+	supervisorClient interface {
+		getAllProcessInfo() ([]processStatus, error)
+		closeIdleConnections()
+	}
+)
+
+func (s *Supervisord) Init() bool {
+	err := s.verifyConfig()
+	if err != nil {
+		s.Errorf("verify config: %v", err)
+		return false
+	}
+
+	client, err := s.initSupervisorClient()
+	if err != nil {
+		s.Errorf("init supervisord client: %v", err)
+		return false
+	}
+	s.client = client
+
+	return true
+}
+
+func (s *Supervisord) Check() bool {
+	return len(s.Collect()) > 0
+}
+
+func (s *Supervisord) Charts() *module.Charts {
+	return s.charts
+}
+
+func (s *Supervisord) Collect() map[string]int64 {
+	ms, err := s.collect()
+	if err != nil {
+		s.Error(err)
+	}
+
+	if len(ms) == 0 {
+		return nil
+	}
+	return ms
+}
+
+func (s *Supervisord) Cleanup() {
+	if s.client != nil {
+		s.client.closeIdleConnections()
+	}
+}

--- a/modules/supervisord/supervisord.go
+++ b/modules/supervisord/supervisord.go
@@ -16,16 +16,15 @@ func init() {
 func New() *Supervisord {
 	return &Supervisord{
 		Config: Config{
-			//URL:     "http://127.0.0.1:9001/RPC2",
-			URL: "http://pc:9001/RPC2",
+			URL: "http://127.0.0.1:9001/RPC2",
+			//URL: "http://pc:9001/RPC2",
 			Client: web.Client{
 				Timeout: web.Duration{Duration: time.Second},
 			},
 		},
 
-		charts:             summaryCharts.Copy(),
-		collectedGroups:    make(map[string]bool),
-		collectedProcesses: make(map[string]bool),
+		charts: summaryCharts.Copy(),
+		cache:  make(map[string]map[string]bool),
 	}
 }
 
@@ -42,8 +41,7 @@ type (
 		client supervisorClient
 		charts *module.Charts
 
-		collectedGroups    map[string]bool
-		collectedProcesses map[string]bool
+		cache map[string]map[string]bool // map[group][procName]collected
 	}
 	supervisorClient interface {
 		getAllProcessInfo() ([]processStatus, error)

--- a/modules/supervisord/supervisord.go
+++ b/modules/supervisord/supervisord.go
@@ -17,7 +17,6 @@ func New() *Supervisord {
 	return &Supervisord{
 		Config: Config{
 			URL: "http://127.0.0.1:9001/RPC2",
-			//URL: "http://pc:9001/RPC2",
 			Client: web.Client{
 				Timeout: web.Duration{Duration: time.Second},
 			},

--- a/modules/supervisord/supervisord_test.go
+++ b/modules/supervisord/supervisord_test.go
@@ -1,0 +1,249 @@
+package supervisord
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	assert.IsType(t, (*Supervisord)(nil), New())
+}
+
+func TestSupervisord_Init(t *testing.T) {
+	tests := map[string]struct {
+		config   Config
+		wantFail bool
+	}{
+		"success on default config": {
+			config: New().Config,
+		},
+		"fails on unset 'url'": {
+			wantFail: true,
+			config:   Config{URL: ""},
+		},
+		"fails on unexpected 'url' scheme": {
+			wantFail: true,
+			config:   Config{URL: "tcp://127.0.0.1:9001/RPC2"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			supvr := New()
+			supvr.Config = test.config
+
+			if test.wantFail {
+				assert.False(t, supvr.Init())
+			} else {
+				assert.True(t, supvr.Init())
+			}
+		})
+	}
+}
+
+func TestSupervisord_Check(t *testing.T) {
+	tests := map[string]struct {
+		prepare  func(t *testing.T) *Supervisord
+		wantFail bool
+	}{
+		"success on valid response": {
+			prepare: prepareSupervisordSuccessOnGetAllProcessInfo,
+		},
+		"success on zero processes response": {
+			prepare: prepareSupervisordZeroProcessesOnGetAllProcessInfo,
+		},
+		"fails on error": {
+			wantFail: true,
+			prepare:  prepareSupervisordErrorOnGetAllProcessInfo,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			supvr := test.prepare(t)
+			defer supvr.Cleanup()
+
+			if test.wantFail {
+				assert.False(t, supvr.Check())
+			} else {
+				assert.True(t, supvr.Check())
+			}
+		})
+	}
+}
+
+func TestSupervisord_Charts(t *testing.T) {
+	supvr := New()
+	require.True(t, supvr.Init())
+
+	assert.NotNil(t, supvr.Charts())
+}
+
+func TestSupervisord_Cleanup(t *testing.T) {
+	supvr := New()
+	assert.NotPanics(t, supvr.Cleanup)
+
+	require.True(t, supvr.Init())
+	m := &mockSupervisorClient{}
+	supvr.client = m
+
+	supvr.Cleanup()
+
+	assert.True(t, m.calledCloseIdleConnections)
+}
+
+func TestSupervisord_Collect(t *testing.T) {
+	tests := map[string]struct {
+		prepare       func(t *testing.T) *Supervisord
+		wantCollected map[string]int64
+	}{
+		"success on valid response": {
+			prepare: prepareSupervisordSuccessOnGetAllProcessInfo,
+			wantCollected: map[string]int64{
+				"group_proc1_non_running_processes":  1,
+				"group_proc1_process_00_downtime":    16276,
+				"group_proc1_process_00_exit_status": 0,
+				"group_proc1_process_00_state":       200,
+				"group_proc1_process_00_uptime":      0,
+				"group_proc1_running_processes":      0,
+				"group_proc2_non_running_processes":  0,
+				"group_proc2_process_00_downtime":    0,
+				"group_proc2_process_00_exit_status": 0,
+				"group_proc2_process_00_state":       20,
+				"group_proc2_process_00_uptime":      2,
+				"group_proc2_process_01_downtime":    0,
+				"group_proc2_process_01_exit_status": 0,
+				"group_proc2_process_01_state":       20,
+				"group_proc2_process_01_uptime":      2,
+				"group_proc2_process_02_downtime":    0,
+				"group_proc2_process_02_exit_status": 0,
+				"group_proc2_process_02_state":       20,
+				"group_proc2_process_02_uptime":      8,
+				"group_proc2_running_processes":      3,
+				"group_proc3_non_running_processes":  0,
+				"group_proc3_process_00_downtime":    0,
+				"group_proc3_process_00_exit_status": 0,
+				"group_proc3_process_00_state":       20,
+				"group_proc3_process_00_uptime":      16291,
+				"group_proc3_running_processes":      1,
+				"non_running_processes":              1,
+				"running_processes":                  4,
+			},
+		},
+		"success on response with zero processes": {
+			prepare: prepareSupervisordZeroProcessesOnGetAllProcessInfo,
+			wantCollected: map[string]int64{
+				"non_running_processes": 0,
+				"running_processes":     0,
+			},
+		},
+		"fails on error on getAllProcessesInfo": {
+			prepare: prepareSupervisordErrorOnGetAllProcessInfo,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			supvr := test.prepare(t)
+			defer supvr.Cleanup()
+
+			ms := supvr.Collect()
+			assert.Equal(t, test.wantCollected, ms)
+			if len(test.wantCollected) > 0 {
+				ensureCollectedHasAllChartsDimsVarsIDs(t, supvr, ms)
+			}
+		})
+	}
+}
+
+func ensureCollectedHasAllChartsDimsVarsIDs(t *testing.T, supvr *Supervisord, ms map[string]int64) {
+	for _, chart := range *supvr.Charts() {
+		if chart.Obsolete {
+			continue
+		}
+		for _, dim := range chart.Dims {
+			_, ok := ms[dim.ID]
+			assert.Truef(t, ok, "chart '%s' dim '%s': no dim in collected", dim.ID, chart.ID)
+		}
+		for _, v := range chart.Vars {
+			_, ok := ms[v.ID]
+			assert.Truef(t, ok, "chart '%s' dim '%s': no dim in collected", v.ID, chart.ID)
+		}
+	}
+}
+
+func prepareSupervisordSuccessOnGetAllProcessInfo(t *testing.T) *Supervisord {
+	supvr := New()
+	require.True(t, supvr.Init())
+	supvr.client = &mockSupervisorClient{}
+	return supvr
+}
+
+func prepareSupervisordZeroProcessesOnGetAllProcessInfo(t *testing.T) *Supervisord {
+	supvr := New()
+	require.True(t, supvr.Init())
+	supvr.client = &mockSupervisorClient{returnZeroProcesses: true}
+	return supvr
+}
+
+func prepareSupervisordErrorOnGetAllProcessInfo(t *testing.T) *Supervisord {
+	supvr := New()
+	require.True(t, supvr.Init())
+	supvr.client = &mockSupervisorClient{errOnGetAllProcessInfo: true}
+	return supvr
+}
+
+type mockSupervisorClient struct {
+	errOnGetAllProcessInfo     bool
+	returnZeroProcesses        bool
+	calledCloseIdleConnections bool
+}
+
+func (m mockSupervisorClient) getAllProcessInfo() ([]processStatus, error) {
+	if m.errOnGetAllProcessInfo {
+		return nil, errors.New("mock errOnGetAllProcessInfo")
+	}
+	if m.returnZeroProcesses {
+		return nil, nil
+	}
+	info := []processStatus{
+		{
+			name: "00", group: "proc1",
+			start: 1613374760, stop: 1613374762, now: 1613391038,
+			state: 200, stateName: "FATAL",
+			exitStatus: 0,
+		},
+		{
+			name: "00", group: "proc2",
+			start: 1613391036, stop: 1613391036, now: 1613391038,
+			state: 20, stateName: "RUNNING",
+			exitStatus: 0,
+		},
+		{
+			name: "01", group: "proc2",
+			start: 1613391036, stop: 1613391036, now: 1613391038,
+			state: 20, stateName: "RUNNING",
+			exitStatus: 0,
+		},
+		{
+			name: "02", group: "proc2",
+			start: 1613391030, stop: 1613391029, now: 1613391038,
+			state: 20, stateName: "RUNNING",
+			exitStatus: 0,
+		},
+		{
+			name: "00", group: "proc3",
+			start: 1613374747, stop: 0, now: 1613391038,
+			state: 20, stateName: "RUNNING",
+			exitStatus: 0,
+		},
+	}
+	return info, nil
+}
+
+func (m *mockSupervisorClient) closeIdleConnections() {
+	m.calledCloseIdleConnections = true
+}

--- a/modules/supervisord/supervisord_test.go
+++ b/modules/supervisord/supervisord_test.go
@@ -106,27 +106,27 @@ func TestSupervisord_Collect(t *testing.T) {
 				"group_proc1_non_running_processes":  1,
 				"group_proc1_process_00_downtime":    16276,
 				"group_proc1_process_00_exit_status": 0,
-				"group_proc1_process_00_state":       200,
+				"group_proc1_process_00_state_code":  200,
 				"group_proc1_process_00_uptime":      0,
 				"group_proc1_running_processes":      0,
 				"group_proc2_non_running_processes":  0,
 				"group_proc2_process_00_downtime":    0,
 				"group_proc2_process_00_exit_status": 0,
-				"group_proc2_process_00_state":       20,
+				"group_proc2_process_00_state_code":  20,
 				"group_proc2_process_00_uptime":      2,
 				"group_proc2_process_01_downtime":    0,
 				"group_proc2_process_01_exit_status": 0,
-				"group_proc2_process_01_state":       20,
+				"group_proc2_process_01_state_code":  20,
 				"group_proc2_process_01_uptime":      2,
 				"group_proc2_process_02_downtime":    0,
 				"group_proc2_process_02_exit_status": 0,
-				"group_proc2_process_02_state":       20,
+				"group_proc2_process_02_state_code":  20,
 				"group_proc2_process_02_uptime":      8,
 				"group_proc2_running_processes":      3,
 				"group_proc3_non_running_processes":  0,
 				"group_proc3_process_00_downtime":    0,
 				"group_proc3_process_00_exit_status": 0,
-				"group_proc3_process_00_state":       20,
+				"group_proc3_process_00_state_code":  20,
 				"group_proc3_process_00_uptime":      16291,
 				"group_proc3_running_processes":      1,
 				"non_running_processes":              1,
@@ -154,6 +154,7 @@ func TestSupervisord_Collect(t *testing.T) {
 			assert.Equal(t, test.wantCollected, ms)
 			if len(test.wantCollected) > 0 {
 				ensureCollectedHasAllChartsDimsVarsIDs(t, supvr, ms)
+				ensureCollectedProcessesAddedToCharts(t, supvr)
 			}
 		})
 	}
@@ -171,6 +172,14 @@ func ensureCollectedHasAllChartsDimsVarsIDs(t *testing.T, supvr *Supervisord, ms
 		for _, v := range chart.Vars {
 			_, ok := ms[v.ID]
 			assert.Truef(t, ok, "chart '%s' dim '%s': no dim in collected", v.ID, chart.ID)
+		}
+	}
+}
+
+func ensureCollectedProcessesAddedToCharts(t *testing.T, supvr *Supervisord) {
+	for group := range supvr.cache {
+		for _, c := range *newProcGroupCharts(group) {
+			assert.NotNilf(t, supvr.Charts().Get(c.ID), "'%s' chart is not in charts", c.ID)
 		}
 	}
 }


### PR DESCRIPTION
Fixes: netdata/netdata#4852

This PR adds initial [Supervisor](http://supervisord.org/) monitoring.

Collected metrics:

- Summary
  - Running/non-running processes
- [Per Process' group](http://supervisord.org/api.html#supervisor.rpcinterface.SupervisorNamespaceRPCInterface.getProcessInfo)
  - Running/non-running processes
  - State code (per process)
  - Exit status (per process)
  - Uptime (per process)
  - Downtime (per process)

@ekexcello i decided to add [all the summary charts](https://github.com/netdata/netdata/issues/4852#issuecomment-758039791) in the 2nd PR, i think we need to discuss them a little bit more.

