### PR TITLE
Support VS Code container deven

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+    "image": "netdata/devenv", 
+    "extensions":[
+		"golang.go",
+		"exiasr.hadolint",
+		"ms-python.python",
+		"timonwong.shellcheck",
+		"redhat.vscode-yaml",
+		"dbaeumer.vscode-eslint",
+		"jasonnutter.search-node-modules",
+		"mgmcdermott.vscode-language-babel",		
+	],
+    "forwardPorts": [19999]
+}


### PR DESCRIPTION
Summary
With the existence of the .devcontainer directory, when a user opens the repository using VS Code, they will be automatically prompted to re-open the directory from inside the developer container. T

The VS Code window is connected to that container, being able to both use extensions to facilitate programming, tools. to check that the code is according to our standards (e.g flake8) and use VS Code sidebar as a GUI for file navigation inside the container. Finally, VS Code syncs the directory that we just opened inside the container, meaning that any file we place from our host machine into that directory (e.g netdata), it will be synced inside the container.

The developer container contains all the required dependencies to build from source:

- netdata
- python.d.plugin
- go.d.plugin
- netdata dashboard

The new contribution workflow will be the following:

- Fork the netdata/go.d.plugin repository
- git clone the forked repository locally
- open the directory using VS Code
- reopen from inside the devenv, ready to develop!

This new optional workflow greatly simplifies the contribution process, since the user only needs to have VS Code installed.

Component Name
Test Plan
Download the repository and open the directory using VS Code

Additional Information
- https://code.visualstudio.com/docs/remote/containers
- https://github.com/netdata/community/tree/main/devenv