### PR TITLE
pihole: set default update_every and http timeout to 5

### DIFF
--- a/config/go.d/pihole.conf
+++ b/config/go.d/pihole.conf
@@ -115,7 +115,8 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 # [ GLOBAL ]
-# update_every        : 1
+# update_every        : 5
+# timeout             : 5
 # autodetection_retry : 0
 # priority            : 70000
 # top_clients_entries : 5

--- a/modules/pihole/pihole.go
+++ b/modules/pihole/pihole.go
@@ -11,6 +11,9 @@ import (
 
 func init() {
 	creator := module.Creator{
+		Defaults: module.Defaults{
+			UpdateEvery: 5,
+		},
 		Create: func() module.Module { return New() },
 	}
 
@@ -21,7 +24,7 @@ const supportedAPIVersion = 3
 
 const (
 	defaultURL           = "http://127.0.0.1"
-	defaultHTTPTimeout   = time.Second
+	defaultHTTPTimeout   = time.Second * 5
 	defaultTopClients    = 5
 	defaultTopItems      = 5
 	defaultSetupVarsPath = "/etc/pihole/setupVars.conf"


### PR DESCRIPTION
Fixes: netdata/netdata#10763

Related https://github.com/netdata/netdata/issues/9642

Gathering data every second is a problem for Raspberry Pi devices, see the above issues.