### PR TITLE
Revamp readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/
 mocks/springboot2/.gradle/
 mocks/tmp/*
 !mocks/tmp/.gitkeep
+.DS_Store

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,0 @@
-# Netdata Community Code of Conduct
-
-This repository part of the Netdata Community, thus all contributors should follow our [Code of Conduct](https://github.com/netdata/netdata/blob/master/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If you want to contribute to this project, we are humbled. Please take a look at
 -   Take a look at our [contributing guidelines](https://learn.netdata.cloud/contribute/handbook).
 -   Read the [How to develop a collector in Go](/docs/how-to-write-a-module.md) guide.
 -   [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) this repository to your personal GitHub account.
--   [Clone](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository#:~:text=to%20GitHub%20Desktop-,On%20GitHub%2C%20navigate%20to%20the%20main%20page%20of%20the%20repository,Desktop%20to%20complete%20the%20clone.) locally the **forked** repository (e.g `git clone https://github.com/odyslam/go.d.plugin).
+-   [Clone](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository#:~:text=to%20GitHub%20Desktop-,On%20GitHub%2C%20navigate%20to%20the%20main%20page%20of%20the%20repository,Desktop%20to%20complete%20the%20clone.) locally the **forked** repository (e.g `git clone https://github.com/odyslam/go.d.plugin`).
 -   Using a terminal, `cd` into the directory (e.g `cd go.d.plugin`)
 -   Add your module to the [modules](https://github.com/netdata/go.d.plugin/tree/master/modules) directory.
 -   Import the module in the [main.go](https://github.com/netdata/go.d.plugin/blob/master/cmd/godplugin/main.go).

--- a/README.md
+++ b/README.md
@@ -18,14 +18,7 @@ custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/README.md
 
 ## Install
 
-Shipped with [`Netdata`](https://github.com/netdata/netdata).
-
-## Contributing
-
-If you have time and willing to help, there are a lof of ways to contribute:
-
--   Fix and [report bugs](https://github.com/netdata/go.d.plugin/issues/new)
--   [Review code and feature proposals](https://github.com/netdata/go.d.plugin/pulls)
+Go.d.plugin is shipped with [`Netdata`](https://github.com/netdata/netdata).
 
 ## Available modules
 
@@ -106,13 +99,24 @@ Configurations are written in [YAML](http://yaml.org/).
 -   [plugin configuration](https://github.com/netdata/go.d.plugin/blob/master/config/go.d.conf)
 -   [specific module configuration](https://github.com/netdata/go.d.plugin/tree/master/config/go.d)
 
-## Developing
+## Contributing
 
--   Add your module to the [modules dir](https://github.com/netdata/go.d.plugin/tree/master/modules).
+If you want to contribute to this project, we are humbled. Please take a look at our [contributing guidelines](https://learn.netdata.cloud/contribute/handbook) and don't hesitate to contact us in our forums. We have a whole [category](https://community.netdata.cloud/c/agent-development/9) just for this purpose!
+
+
+### How to develop a collector
+
+-   Take a look at our [contributing guidelines](https://learn.netdata.cloud/contribute/handbook).
+-   Read the [How to develop a collector in Go](/docs/how-to-write-a-module.md) guide.
+-   [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) this repository to your personal GitHub account.
+-   [Clone](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository#:~:text=to%20GitHub%20Desktop-,On%20GitHub%2C%20navigate%20to%20the%20main%20page%20of%20the%20repository,Desktop%20to%20complete%20the%20clone.) locally the **forked** repository (e.g `git clone https://github.com/odyslam/go.d.plugin).
+-   Using a terminal, `cd` into the directory (e.g `cd go.d.plugin`)
+-   Add your module to the [modules](https://github.com/netdata/go.d.plugin/tree/master/modules) directory.
 -   Import the module in the [main.go](https://github.com/netdata/go.d.plugin/blob/master/cmd/godplugin/main.go).
--   To build it execute `make` from the plugin root dir or `hack/go-build.sh`.
--   Run it in the debug mode `bin/godplugin -d -m <MODULE_NAME>`.
--   Use `make clean` when you are done with testing.
+-   To build it, run `make` from the plugin root dir. This will create a new `go.d.plugin` binary that includes your newly developed collector. It will be placed into the `bin` directory (e.g `go.d.plugin/bin`)
+-   Run it in the debug mode `bin/godplugin -d -m <MODULE_NAME>`. This will output the `STDOUT` of the collector, the same output that is sent to the Netdata Agent and is transformed into charts. You can read more about this collector API in our [documentation](https://learn.netdata.cloud/docs/agent/collectors/plugins.d#external-plugins-api).
+-   If you want to test the collector with the actual Netdata Agent, you need to replace the `go.d.plugin` binary that exists in the Netdata Agent installation directory with the one you just compiled. Once you [restart](https://learn.netdata.cloud/docs/configure/start-stop-restart) the Netdata Agent, it will detect and run it, creating all the charts. It is advised not to remove the default `go.d.plugin` binary, but simply rename it to `go.d.plugin.old` so that the Agent doesn't run it, but you can easily rename it back once you are done.
+-   Run `make clean` when you are done with testing.
 
 ## Troubleshooting
 
@@ -145,3 +149,10 @@ sudo su -s /bin/bash netdata
 
 Change `<module name>` to the module name you want to debug.
 See the [whole list](#available-modules) of available modules.
+
+## Netdata Community
+
+This repository follows the Netdata Code of Conduct and is part of the Netdata Community.
+
+- [Community Forums](https://community.netdata.cloud)
+- [Netdata Code of Conduct](https://learn.netdata.cloud/contribute/code-of-conduct)


### PR DESCRIPTION
This is part of an effort to align all the netdata repos into the same structure and quality, with aim to foster use contribution.

We will remove all community files (e.g contributing) from all our repos and instead use a set of default community health files that are located in [netdata/.github](https://github.com/netdata/.github). GitHub automatically detects those files and links them in all the repos at the appropriate places (e.g in PR tab, above the opens PRs it has a tool tip advising user to check the contributing guidelines).

You can read more about the health files in the README of the .github repository.

All the community files have been revamped. 