### PR TITLE
modules/vernemq: fix calculation of messages currently in the queues

### DIFF
--- a/modules/vernemq/collect.go
+++ b/modules/vernemq/collect.go
@@ -159,10 +159,10 @@ func collectQueues(mx map[string]float64, pms prometheus.Metrics) {
 }
 
 func calcQueueMessagesCurrent(mx map[string]float64) float64 {
-	undelivered := mx[metricQueueMessageDrop] + mx[metricQueueMessageExpired] + mx[metricQueueMessageUnhandled]
+	expired := mx[metricQueueMessageExpired]
 	out := mx[metricQueueMessageOut]
 	in := mx[metricQueueMessageIn]
-	return in - (out + undelivered)
+	return in - (out + expired)
 }
 
 func collectSubscriptions(mx map[string]float64, pms prometheus.Metrics) {

--- a/modules/vernemq/vernemq_test.go
+++ b/modules/vernemq/vernemq_test.go
@@ -529,7 +529,7 @@ var v1101ExpectedMetrics = map[string]int64{
 	"queue_message_in":                                        525722,
 	"queue_message_out":                                       525721,
 	"queue_message_unhandled":                                 1,
-	"queue_messages_current":                                  0,
+	"queue_messages_current":                                  1,
 	"queue_processes":                                         0,
 	"queue_setup":                                             338948,
 	"queue_teardown":                                          338948,


### PR DESCRIPTION
I noticed `queue_messages_current` metric is negative on our Netdata Agents (Cloud).

---

These are `queue_message_*` metrics:

- `queue_message_in`: the number of PUBLISH packets received by MQTT queue processes.
- `queue_message_out`: the number of PUBLISH packets sent from MQTT queue processes.
- `queue_message_drop`: the number of messages dropped due to full queues.
- `queue_message_expired`: the number of messages which expired before delivery.
- `queue_message_unhandled`: the number of unhandled messages when connecting with clean session=true.

We shouldn't take into account drop and unhandled calculating messages currently in the queues.