### PR TITLE
vsphere - datastores

### DIFF
--- a/modules/vsphere/README.md
+++ b/modules/vsphere/README.md
@@ -47,6 +47,13 @@ It produces the following charts:
 - Overall Alarm Status in `status`
 - System Uptime in `seconds`
 
+#### Datastore
+
+- Storage Capacity in `KiB`
+- Storage Provisioned in `KiB`
+- Storage used in `KiB`
+- Storage Provisioned average in `KiB`
+
 ## Configuration
 
 Edit the `go.d/vsphere.conf` configuration file using `edit-config` from the
@@ -67,6 +74,7 @@ jobs:
     password: somepassword
     host_include: [ '/*' ]
     vm_include: [ '/*' ]
+    datastore_include: ['/*']
 
   - name: vcenter2
     url: https://203.0.113.10
@@ -74,17 +82,19 @@ jobs:
     password: somepassword
     host_include: [ '/*' ]
     vm_include: [ '/*' ]
+    datastore_include: ['/*']
 ```
 
 For all available options please see
 module [configuration file](https://github.com/netdata/go.d.plugin/blob/master/config/go.d/vsphere.conf).
 
-## Hosts/vms filtering
+## Hosts/vms/datastores filtering
 
 Module supports filtering hosts and vms. Filtering options are `host_include` and `vm_include`.
 
 - `host_include` is a list of match patterns: `/Dc pattern[/Cluster pattern/Host pattern]`.
 - `vm_include` is a list of match patterns: `/Dc pattern[/Cluster pattern/Host pattern/VM name]`.
+- `datastore_include` is a list of match patterns: `/Dc pattern[/Datastore pattern]`.
 
 Pattern should start with `/`. It matches name,
 syntax: [simple patterns](https://docs.netdata.cloud/libnetdata/simple_pattern/).
@@ -95,6 +105,8 @@ Examples:
     host_include: # filter all hosts
       - '/!*'
     vm_include: # allow all vms
+      - '/*'
+    datastore_include:
       - '/*'
 ```
 
@@ -127,22 +139,25 @@ Example (all not related debug lines were removed):
 [ DEBUG ] vsphere[vsphere] discover.go:116 discovering : found 3 clusters, process took 47.722692ms
 [ DEBUG ] vsphere[vsphere] discover.go:123 discovering : found 2 hosts, process took 52.966995ms
 [ DEBUG ] vsphere[vsphere] discover.go:130 discovering : found 2 vms, process took 49.832979ms
-[ INFO  ] vsphere[vsphere] discover.go:140 discovering : found 3 dcs, 12 folders, 3 clusters (2 dummy), 2 hosts, 3 vms, process took 249.655993ms
+[ DEBUG ] vsphere[vsphere] discover.go:130 discovering : found 4 datastores, process took 65.457101ms
+[ INFO  ] vsphere[vsphere] discover.go:140 discovering : found 3 dcs, 12 folders, 3 clusters (2 dummy), 2 hosts, 3 vms, 4/4 datastores, process took 249.655993ms
 [ DEBUG ] vsphere[vsphere] build.go:12 discovering : building : starting building resources process
-[ INFO  ] vsphere[vsphere] build.go:23 discovering : building : built 3/3 dcs, 12/12 folders, 3/3 clusters, 2/2 hosts, 3/3 vms, process took 63.3µs
+[ INFO  ] vsphere[vsphere] build.go:23 discovering : building : built 3/3 dcs, 12/12 folders, 3/3 clusters, 2/2 hosts, 3/3 vms, 4/4 datastores, process took 63.3µs
 [ DEBUG ] vsphere[vsphere] hierarchy.go:10 discovering : hierarchy : start setting resources hierarchy process
-[ INFO  ] vsphere[vsphere] hierarchy.go:18 discovering : hierarchy : set 3/3 clusters, 2/2 hosts, 3/3 vms, process took 6.522µs
+[ INFO  ] vsphere[vsphere] hierarchy.go:18 discovering : hierarchy : set 3/3 clusters, 2/2 hosts, 3/3 vms, 4/4 datastores, process took 6.522µs
 [ DEBUG ] vsphere[vsphere] filter.go:24 discovering : filtering : starting filtering resources process
 [ DEBUG ] vsphere[vsphere] filter.go:45 discovering : filtering : removed 0 unmatched hosts
 [ DEBUG ] vsphere[vsphere] filter.go:56 discovering : filtering : removed 0 unmatched vms
-[ INFO  ] vsphere[vsphere] filter.go:29 discovering : filtering : filtered 0/2 hosts, 0/3 vms, process took 42.973µs
+[ DEBUG ] vsphere[vsphere] filter.go:56 discovering : filtering : removed 0 unmatched datastores
+[ INFO  ] vsphere[vsphere] filter.go:29 discovering : filtering : filtered 0/2 hosts, 0/3 vms, 0/4 datastores, process took 42.973µs
 [ DEBUG ] vsphere[vsphere] metric_lists.go:14 discovering : metric lists : starting resources metric lists collection process
-[ INFO  ] vsphere[vsphere] metric_lists.go:30 discovering : metric lists : collected metric lists for 2/2 hosts, 3/3 vms, process took 275.60764ms
-[ INFO  ] vsphere[vsphere] discover.go:74 discovering : discovered 2/2 hosts, 3/3 vms, the whole process took 525.614041ms
+[ INFO  ] vsphere[vsphere] metric_lists.go:30 discovering : metric lists : collected metric lists for 2/2 hosts, 3/3 vms, 4/4 datastores, process took 275.60764ms
+[ INFO  ] vsphere[vsphere] discover.go:74 discovering : discovered 2/2 hosts, 3/3 vms, 4/4 datastores, the whole process took 525.614041ms
 [ INFO  ] vsphere[vsphere] discover.go:11 starting discovery process, will do discovery every 5m0s
 [ DEBUG ] vsphere[vsphere] collect.go:11 starting collection process
 [ DEBUG ] vsphere[vsphere] scrape.go:48 scraping : scraped metrics for 2/2 hosts, process took 96.257374ms
 [ DEBUG ] vsphere[vsphere] scrape.go:60 scraping : scraped metrics for 3/3 vms, process took 57.879697ms
+[ DEBUG ] vsphere[vsphere] scrape.go:60 scraping : scraped metrics for 4/4 datastores, process took 57.879697ms
 [ DEBUG ] vsphere[vsphere] collect.go:23 metrics collected, process took 154.77997ms
 
 ```

--- a/modules/vsphere/charts.go
+++ b/modules/vsphere/charts.go
@@ -24,6 +24,28 @@ const (
 )
 
 var (
+	datastoreCharts = func() Charts{
+		cs := Charts{}
+		panicIf(cs.Add(datastoreStorageCharts...))
+		return cs
+	}()
+	// Ref : https://www.vmware.com/support/developer/converter-sdk/conv51_apireference/disk_storutil_counters.html
+	datastoreStorageCharts = Charts{
+		{
+			ID:      "%s_disk_metrics",
+			Title:   "Disk Metrics",
+			Units:   "KiB",
+			Fam:     "datastore %s",
+			Ctx:     "vsphere.disk_metrics",
+			Dims: Dims{
+				{ID: "%s_disk.used.latest", Name:"used"},
+				{ID: "%s_disk.provisioned.latest", Name:"provisioned"},
+				{ID: "%s_disk.capacity.latest", Name:"capacity"},
+				{ID: "%s_disk.capacity.provisioned.average", Name:"provisioned average"},
+			},
+		},
+	}
+
 	vmCharts = func() Charts {
 		cs := Charts{}
 		panicIf(cs.Add(vmCPUCharts...))

--- a/modules/vsphere/client/client.go
+++ b/modules/vsphere/client/client.go
@@ -24,6 +24,7 @@ const (
 	computeResource = "ComputeResource"
 	hostSystem      = "HostSystem"
 	virtualMachine  = "VirtualMachine"
+	datastore       = "Datastore"
 
 	maxIdleConnections = 32
 )
@@ -170,6 +171,11 @@ func (c *Client) Hosts(pathSet ...string) (hosts []mo.HostSystem, err error) {
 
 func (c *Client) VirtualMachines(pathSet ...string) (vms []mo.VirtualMachine, err error) {
 	err = c.root.Retrieve(context.Background(), []string{virtualMachine}, pathSet, &vms)
+	return
+}
+
+func (c *Client) Datastores(pathSet ...string) (datastores []mo.Datastore, err error) {
+	err = c.root.Retrieve(context.Background(), []string{datastore}, pathSet, &datastores)
 	return
 }
 

--- a/modules/vsphere/client/client_test.go
+++ b/modules/vsphere/client/client_test.go
@@ -120,6 +120,15 @@ func TestClient_VirtualMachines(t *testing.T) {
 	assert.NotEmpty(t, vms)
 }
 
+func TestClient_Datastores(t *testing.T) {
+	client, teardown := prepareClient(t)
+	defer teardown()
+
+	datastores, err := client.Datastores()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, datastores)
+}
+
 func TestClient_PerformanceMetrics(t *testing.T) {
 	client, teardown := prepareClient(t)
 	defer teardown()

--- a/modules/vsphere/collect.go
+++ b/modules/vsphere/collect.go
@@ -253,13 +253,13 @@ func (vs *VSphere) removeStale() {
 		delete(vs.discoveredVMs, userVMID)
 	}
 	for userDatastoreID, fails := range vs.discoveredDatastores {
-	if fails < failedUpdatesLimit {
-		continue
+		if fails < failedUpdatesLimit {
+			continue
+		}
+		vs.removeFromCharts(userDatastoreID)
+		delete(vs.charted, userDatastoreID)
+		delete(vs.discoveredDatastores, userDatastoreID)
 	}
-	vs.removeFromCharts(userDatastoreID)
-	delete(vs.charted, userDatastoreID)
-	delete(vs.discoveredDatastores, userDatastoreID)
-}
 }
 
 func join(a, prefix, value string) string {

--- a/modules/vsphere/collect.go
+++ b/modules/vsphere/collect.go
@@ -19,15 +19,23 @@ func (vs *VSphere) collect() (map[string]int64, error) {
 	vs.Debug("starting collection process")
 	t := time.Now()
 	mx := make(map[string]int64)
+	var errs []error
 
-	err := vs.collectHosts(mx)
-	if err != nil {
-		return mx, err
+	errs = append(errs, vs.collectHosts(mx))
+	errs = append(errs, vs.collectVMs(mx))
+	errs = append(errs, vs.collectDatastores(mx))
+
+	var strErr = ""
+	for _, err := range errs {
+		if(err!=nil){
+			strErr=strErr+err.Error()+", "
+		}
 	}
-
-	err = vs.collectVMs(mx)
-	if err != nil {
-		return mx, err
+	if(strErr!=""){
+		if last := len(strErr) - 1; last >= 0 && (strErr[last] == ' ' || strErr[last] == ',' ){
+			strErr = strErr[:last]
+		}
+		return mx, errors.New(strErr)
 	}
 
 	vs.Debugf("metrics collected, process took %s", time.Since(t))
@@ -163,6 +171,62 @@ func (vs VSphere) vmID(vm *rs.VM) (id string) {
 	return cleanID(id)
 }
 
+func (vs *VSphere) collectDatastores(mx map[string]int64) error {
+	// NOTE: returns unsorted if at least one types.PerfMetricId Instance is not ""
+	metrics := vs.ScrapeDatastores(vs.resources.Datastores)
+	if len(metrics) == 0 {
+		return errors.New("failed to scrape datastores metrics")
+	}
+	datastores := vs.collectDatastoresMetrics(mx, metrics)
+	vs.updateDiscoveredDatastores(datastores)
+	vs.updateDatastoresCharts(datastores)
+	return nil
+}
+
+func (vs *VSphere) collectDatastoresMetrics(mx map[string]int64, metrics []performance.EntityMetric) map[string]string {
+	datastores := make(map[string]string)
+	for _, m := range metrics {
+		datastore := vs.resources.Datastores.Get(m.Entity.Value)
+		if datastore == nil {
+			continue
+		}
+		writeDatastoreMetrics(mx, datastore, m.Value)
+		datastores[datastore.ID] = vs.datastoreID(datastore)
+	}
+	return datastores
+}
+
+func writeDatastoreMetrics(mx map[string]int64, datastore *rs.Datastore, metrics []performance.MetricSeries) {
+	for _, m := range metrics {
+		if len(m.Value) == 0 || m.Value[0] == -1 {
+			continue
+		}
+		key := fmt.Sprintf("%s_%s", datastore.ID, m.Name)
+		mx[key] = m.Value[0]
+	}
+	key := fmt.Sprintf("%s_accessible", datastore.ID)
+	mx[key] = accessibleToInt(datastore.Accessible)
+}
+
+func (vs *VSphere) updateDiscoveredDatastores(collected map[string]string) {
+	for _, h := range vs.resources.Datastores {
+		id := vs.datastoreID(h)
+		if v, ok := collected[h.ID]; !ok || id != v {
+			vs.discoveredDatastores[id] += 1
+		} else {
+			vs.discoveredDatastores[id] = 0
+		}
+	}
+}
+
+func (vs VSphere) datastoreID(datastore *rs.Datastore) (id string) {
+	id = datastore.ID
+	if vs.DatastoreMetrics.Name {
+		id = join(id, "name", datastore.Name)
+	}
+	return cleanID(id)
+}
+
 const failedUpdatesLimit = 10
 
 func (vs *VSphere) removeStale() {
@@ -182,6 +246,14 @@ func (vs *VSphere) removeStale() {
 		delete(vs.charted, userVMID)
 		delete(vs.discoveredVMs, userVMID)
 	}
+	for userDatastoreID, fails := range vs.discoveredDatastores {
+	if fails < failedUpdatesLimit {
+		continue
+	}
+	vs.removeFromCharts(userDatastoreID)
+	delete(vs.charted, userDatastoreID)
+	delete(vs.discoveredDatastores, userDatastoreID)
+}
 }
 
 func join(a, prefix, value string) string {
@@ -209,6 +281,14 @@ func overallStatusToInt(status string) int64 {
 	case "yellow":
 		return 2
 	case "red":
+		return 3
+	}
+}
+
+func accessibleToInt(accessible bool) int64 {
+	if accessible == true {
+		return 1
+	}else{
 		return 3
 	}
 }

--- a/modules/vsphere/discover/build.go
+++ b/modules/vsphere/discover/build.go
@@ -31,6 +31,8 @@ func (d Discoverer) build(raw *resources) *rs.Resources {
 		len(raw.hosts),
 		len(res.VMs),
 		len(raw.vms),
+		len(res.Datastores),
+		len(raw.datastores),
 		time.Since(t),
 	)
 	return &res
@@ -173,6 +175,37 @@ func newVM(raw mo.VirtualMachine) *rs.VM {
 		ID:            raw.Reference().Value,
 		ParentID:      raw.Runtime.Host.Value,
 		OverallStatus: string(raw.Summary.OverallStatus),
+		Ref:           raw.Reference(),
+	}
+}
+
+func (d Discoverer) buildDatastores(raw []mo.Datastore) rs.Datastores {
+	var num int
+
+	datastores := make(rs.Datastores)
+	for _, da := range raw {
+		//	true | false
+		if da.Summary.Accessible != true {
+			num++
+			continue
+		}
+		// enteringMaintenance | inMaintenance | normal
+		//if da.Summary.MaintenanceModeState != "normal" {
+		//
+		//}
+		datastores.Put(newDatastore(da))
+	}
+	if num > 0 {
+		d.Infof("discovering : building : removed %d datastores (not accessible)", num)
+	}
+	return datastores
+}
+
+func newDatastore(raw mo.Datastore) *rs.Datastore {
+	return &rs.Datastore{
+		Name:          raw.Name,
+		ID:            raw.Reference().Value,
+		Accessible:	raw.Summary.Accessible,
 		Ref:           raw.Reference(),
 	}
 }

--- a/modules/vsphere/discover/build.go
+++ b/modules/vsphere/discover/build.go
@@ -20,7 +20,7 @@ func (d Discoverer) build(raw *resources) *rs.Resources {
 	res.Hosts = d.buildHosts(raw.hosts)
 	res.VMs = d.buildVMs(raw.vms)
 
-	d.Infof("discovering : building : built %d/%d dcs, %d/%d folders, %d/%d clusters, %d/%d hosts, %d/%d vms, process took %s",
+	d.Infof("discovering : building : built %d/%d dcs, %d/%d folders, %d/%d clusters, %d/%d hosts, %d/%d vms, %d/%d datastores, process took %s",
 		len(res.DataCenters),
 		len(raw.dcs),
 		len(res.Folders),

--- a/modules/vsphere/discover/build.go
+++ b/modules/vsphere/discover/build.go
@@ -206,7 +206,7 @@ func newDatastore(raw mo.Datastore) *rs.Datastore {
 	return &rs.Datastore{
 		Name:          raw.Name,
 		ID:            raw.Reference().Value,
-		Accessible:	raw.Summary.Accessible,
+		Accessible:	   raw.Summary.Accessible,
 		Ref:           raw.Reference(),
 	}
 }

--- a/modules/vsphere/discover/build.go
+++ b/modules/vsphere/discover/build.go
@@ -19,6 +19,7 @@ func (d Discoverer) build(raw *resources) *rs.Resources {
 	fixClustersParentID(&res)
 	res.Hosts = d.buildHosts(raw.hosts)
 	res.VMs = d.buildVMs(raw.vms)
+	res.Datastores = d.buildDatastores(raw.datastores)
 
 	d.Infof("discovering : building : built %d/%d dcs, %d/%d folders, %d/%d clusters, %d/%d hosts, %d/%d vms, %d/%d datastores, process took %s",
 		len(res.DataCenters),

--- a/modules/vsphere/discover/discover.go
+++ b/modules/vsphere/discover/discover.go
@@ -64,10 +64,10 @@ func (d Discoverer) Discover() (*rs.Resources, error) {
 
 	numH := len(res.Hosts)
 	numV := len(res.VMs)
-	removed := d.removeUnmatched(res)
 	numS := len(res.Datastores)
+	removed := d.removeUnmatched(res)
 	if removed == (numH + numV + numS) {
-		return nil, fmt.Errorf("all resoursces were filtered (%d hosts, %d vms, %d numS)", numH, numV, numS)
+		return nil, fmt.Errorf("all resources were filtered (%d hosts, %d vms, %d numS)", numH, numV, numS)
 	}
 
 	err = d.collectMetricLists(res)

--- a/modules/vsphere/discover/discover.go
+++ b/modules/vsphere/discover/discover.go
@@ -19,6 +19,7 @@ type Client interface {
 	ComputeResources(pathSet ...string) ([]mo.ComputeResource, error)
 	Hosts(pathSet ...string) ([]mo.HostSystem, error)
 	VirtualMachines(pathSet ...string) ([]mo.VirtualMachine, error)
+	Datastores(pathSet ...string) ([]mo.Datastore, error)
 
 	CounterInfoByName() (map[string]*types.PerfCounterInfo, error)
 }
@@ -34,6 +35,7 @@ type Discoverer struct {
 	Client
 	match.HostMatcher
 	match.VMMatcher
+	match.DatastoreMatcher
 }
 
 type resources struct {
@@ -42,6 +44,7 @@ type resources struct {
 	clusters []mo.ComputeResource
 	hosts    []mo.HostSystem
 	vms      []mo.VirtualMachine
+	datastores []mo.Datastore
 }
 
 func (d Discoverer) Discover() (*rs.Resources, error) {
@@ -62,7 +65,8 @@ func (d Discoverer) Discover() (*rs.Resources, error) {
 	numH := len(res.Hosts)
 	numV := len(res.VMs)
 	removed := d.removeUnmatched(res)
-	if removed == (numH + numV) {
+	numS := len(res.Datastores)
+	if removed == (numH + numV + numS) {
 		return nil, fmt.Errorf("all resoursces were filtered (%d hosts, %d vms)", numH, numV)
 	}
 
@@ -76,6 +80,8 @@ func (d Discoverer) Discover() (*rs.Resources, error) {
 		len(raw.hosts),
 		len(res.VMs),
 		len(raw.vms),
+		len(res.Datastores),
+		len(raw.datastores),
 		time.Since(startTime))
 
 	return res, nil
@@ -88,6 +94,7 @@ var (
 	clusterPathSet    = []string{"name", "parent"}
 	hostPathSet       = []string{"name", "parent", "runtime.powerState", "summary.overallStatus"}
 	vmPathSet         = []string{"name", "runtime.host", "runtime.powerState", "summary.overallStatus"}
+	datastorePathSet  = []string{"name", "summary.accessible"}
 )
 
 func (d Discoverer) discover() (*resources, error) {
@@ -129,12 +136,20 @@ func (d Discoverer) discover() (*resources, error) {
 	}
 	d.Debugf("discovering : found %d vms, process took %s", len(hosts), time.Since(t))
 
+	t = time.Now()
+	datastores, err := d.Datastores(datastorePathSet...)
+	if err != nil {
+		return nil, err
+	}
+	d.Debugf("discovering : found %d datastores, process took %s", len(datastores), time.Since(t))
+
 	raw := resources{
 		dcs:      datacenters,
 		folders:  folders,
 		clusters: clusters,
 		hosts:    hosts,
 		vms:      vms,
+		datastores: datastores,
 	}
 
 	d.Infof("discovering : found %d dcs, %d folders, %d clusters (%d dummy), %d hosts, %d vms, process took %s",
@@ -144,6 +159,7 @@ func (d Discoverer) discover() (*resources, error) {
 		numOfDummyClusters(clusters),
 		len(raw.hosts),
 		len(raw.vms),
+		len(raw.datastores),
 		time.Since(start),
 	)
 

--- a/modules/vsphere/discover/discover.go
+++ b/modules/vsphere/discover/discover.go
@@ -75,7 +75,7 @@ func (d Discoverer) Discover() (*rs.Resources, error) {
 		return nil, fmt.Errorf("collecting metric lists : %v", err)
 	}
 
-	d.Infof("discovering : discovered %d/%d hosts, %d/%d vms, the whole process took %s",
+	d.Infof("discovering : discovered %d/%d hosts, %d/%d vms, %d/%d datastores, the whole process took %s",
 		len(res.Hosts),
 		len(raw.hosts),
 		len(res.VMs),
@@ -152,7 +152,7 @@ func (d Discoverer) discover() (*resources, error) {
 		datastores: datastores,
 	}
 
-	d.Infof("discovering : found %d dcs, %d folders, %d clusters (%d dummy), %d hosts, %d vms, process took %s",
+	d.Infof("discovering : found %d dcs, %d folders, %d clusters (%d dummy), %d hosts, %d vms, %d datastores, process took %s",
 		len(raw.dcs),
 		len(raw.folders),
 		len(clusters),

--- a/modules/vsphere/discover/discover.go
+++ b/modules/vsphere/discover/discover.go
@@ -67,7 +67,7 @@ func (d Discoverer) Discover() (*rs.Resources, error) {
 	removed := d.removeUnmatched(res)
 	numS := len(res.Datastores)
 	if removed == (numH + numV + numS) {
-		return nil, fmt.Errorf("all resoursces were filtered (%d hosts, %d vms)", numH, numV)
+		return nil, fmt.Errorf("all resoursces were filtered (%d hosts, %d vms, %d numS)", numH, numV, numS)
 	}
 
 	err = d.collectMetricLists(res)

--- a/modules/vsphere/discover/discover_test.go
+++ b/modules/vsphere/discover/discover_test.go
@@ -156,11 +156,6 @@ func isHierarchySet(res *rs.Resources) bool {
 			return false
 		}
 	}
-	for _, s := range res.Datastores {
-		if !s.Hier.IsSet() {
-			return false
-		}
-	}
 	return true
 }
 

--- a/modules/vsphere/discover/discover_test.go
+++ b/modules/vsphere/discover/discover_test.go
@@ -27,6 +27,7 @@ func TestDiscoverer_Discover(t *testing.T) {
 	assert.True(t, len(res.Clusters) > 0)
 	assert.True(t, len(res.Hosts) > 0)
 	assert.True(t, len(res.VMs) > 0)
+	assert.True(t, len(res.Datastores) > 0)
 	assert.True(t, isHierarchySet(res))
 	assert.True(t, isMetricListsCollected(res))
 }
@@ -45,6 +46,7 @@ func TestDiscoverer_discover(t *testing.T) {
 	assert.Lenf(t, raw.clusters, count.Cluster+dummyClusters, "clusters")
 	assert.Lenf(t, raw.hosts, count.Host, "hosts")
 	assert.Lenf(t, raw.vms, count.Machine, "hosts")
+	assert.Lenf(t, raw.datastores, count.Datastore, "datastores")
 }
 
 func TestDiscoverer_build(t *testing.T) {
@@ -61,6 +63,7 @@ func TestDiscoverer_build(t *testing.T) {
 	assert.Lenf(t, res.Clusters, len(raw.clusters), "clusters")
 	assert.Lenf(t, res.Hosts, len(raw.hosts), "hosts")
 	assert.Lenf(t, res.VMs, len(raw.vms), "hosts")
+	assert.Lenf(t, res.Datastores, len(raw.datastores), "datastores")
 }
 
 func TestDiscoverer_setHierarchy(t *testing.T) {
@@ -83,14 +86,16 @@ func TestDiscoverer_removeUnmatched(t *testing.T) {
 
 	d.HostMatcher = falseHostMatcher{}
 	d.VMMatcher = falseVMMatcher{}
+	d.DatastoreMatcher = falseDatastoreMatcher{}
 	raw, err := d.discover()
 	require.NoError(t, err)
 	res := d.build(raw)
 
-	numVMs, numHosts := len(res.VMs), len(res.Hosts)
-	assert.Equal(t, numVMs+numHosts, d.removeUnmatched(res))
+	numVMs, numHosts, numDatastores := len(res.VMs), len(res.Hosts), len(res.Datastores)
+	assert.Equal(t, numVMs+numHosts+numDatastores, d.removeUnmatched(res))
 	assert.Lenf(t, res.Hosts, 0, "hosts")
 	assert.Lenf(t, res.VMs, 0, "vms")
+	assert.Lenf(t, res.Datastores, 0, "datastores")
 }
 
 func TestDiscoverer_collectMetricLists(t *testing.T) {
@@ -151,6 +156,11 @@ func isHierarchySet(res *rs.Resources) bool {
 			return false
 		}
 	}
+	for _, s := range res.Datastores {
+		if !s.Hier.IsSet() {
+			return false
+		}
+	}
 	return true
 }
 
@@ -165,6 +175,11 @@ func isMetricListsCollected(res *rs.Resources) bool {
 			return false
 		}
 	}
+	for _, s := range res.Datastores {
+		if s.MetricList == nil {
+			return false
+		}
+	}
 	return true
 }
 
@@ -175,3 +190,7 @@ func (falseHostMatcher) Match(*rs.Host) bool { return false }
 type falseVMMatcher struct{}
 
 func (falseVMMatcher) Match(*rs.VM) bool { return false }
+
+type falseDatastoreMatcher struct{}
+
+func (falseDatastoreMatcher) Match(*rs.Datastore) bool { return false }

--- a/modules/vsphere/discover/filter.go
+++ b/modules/vsphere/discover/filter.go
@@ -34,7 +34,7 @@ func (d Discoverer) removeUnmatched(res *rs.Resources) (removed int) {
 	removed += d.removeUnmatchedHosts(res.Hosts)
 	removed += d.removeUnmatchedVMs(res.VMs)
 	removed += d.removeUnmatchedDatastores(res.Datastores)
-	d.Infof("discovering : filtering : filtered %d/%d hosts, %d/%d vms, process took %s",
+	d.Infof("discovering : filtering : filtered %d/%d hosts, %d/%d vms, %d/%d datastores, process took %s",
 		numH-len(res.Hosts),
 		numH,
 		numV-len(res.VMs),

--- a/modules/vsphere/discover/filter.go
+++ b/modules/vsphere/discover/filter.go
@@ -20,17 +20,27 @@ func (d Discoverer) matchVM(vm *rs.VM) bool {
 	return d.VMMatcher.Match(vm)
 }
 
+func (d Discoverer) matchDatastore(datastore *rs.Datastore) bool {
+	if d.DatastoreMatcher == nil {
+		return true
+	}
+	return d.DatastoreMatcher.Match(datastore)
+}
+
 func (d Discoverer) removeUnmatched(res *rs.Resources) (removed int) {
 	d.Debug("discovering : filtering : starting filtering resources process")
 	t := time.Now()
 	numH, numV := len(res.Hosts), len(res.VMs)
 	removed += d.removeUnmatchedHosts(res.Hosts)
 	removed += d.removeUnmatchedVMs(res.VMs)
+	removed += d.removeUnmatchedDatastores(res.Datastores)
 	d.Infof("discovering : filtering : filtered %d/%d hosts, %d/%d vms, process took %s",
 		numH-len(res.Hosts),
 		numH,
 		numV-len(res.VMs),
 		numV,
+		numS-len(res.Datastores),
+		numS,
 		time.Since(t))
 	return
 }
@@ -54,5 +64,16 @@ func (d Discoverer) removeUnmatchedVMs(vms rs.VMs) (removed int) {
 		}
 	}
 	d.Debugf("discovering : filtering : removed %d unmatched vms", removed)
+	return removed
+}
+
+func (d Discoverer) removeUnmatchedDatastores(datastores rs.Datastores) (removed int) {
+	for _, v := range datastores {
+		if !d.matchDatastore(v) {
+			removed++
+			datastores.Remove(v.ID)
+		}
+	}
+	d.Debugf("discovering : filtering : removed %d unmatched datastores", removed)
 	return removed
 }

--- a/modules/vsphere/discover/filter.go
+++ b/modules/vsphere/discover/filter.go
@@ -30,7 +30,7 @@ func (d Discoverer) matchDatastore(datastore *rs.Datastore) bool {
 func (d Discoverer) removeUnmatched(res *rs.Resources) (removed int) {
 	d.Debug("discovering : filtering : starting filtering resources process")
 	t := time.Now()
-	numH, numV := len(res.Hosts), len(res.VMs)
+	numH, numV, numS := len(res.Hosts), len(res.VMs), len(res.Datastores)
 	removed += d.removeUnmatchedHosts(res.Hosts)
 	removed += d.removeUnmatchedVMs(res.VMs)
 	removed += d.removeUnmatchedDatastores(res.Datastores)

--- a/modules/vsphere/discover/hierarchy.go
+++ b/modules/vsphere/discover/hierarchy.go
@@ -2,7 +2,6 @@ package discover
 
 import (
 	"time"
-
 	rs "github.com/netdata/go.d.plugin/modules/vsphere/resources"
 )
 
@@ -13,14 +12,12 @@ func (d Discoverer) setHierarchy(res *rs.Resources) error {
 	c := d.setClustersHierarchy(res)
 	h := d.setHostsHierarchy(res)
 	v := d.setVMsHierarchy(res)
-	s := d.setDatastoresHierarchy(res)
 
 	// notSet := len(res.Clusters) + len(res.Hosts) + len(res.VMs) + len(res.Datastores) - (c + h + v + d)
-	d.Infof("discovering : hierarchy : set %d/%d clusters, %d/%d hosts, %d/%d vms, %d/%d datastores, process took %s",
+	d.Infof("discovering : hierarchy : set %d/%d clusters, %d/%d hosts, %d/%d vms, process took %s",
 		c, len(res.Clusters),
 		h, len(res.Hosts),
 		v, len(res.VMs),
-		s, len(res.Datastores),
 		time.Since(t),
 	)
 
@@ -48,15 +45,6 @@ func (d Discoverer) setHostsHierarchy(res *rs.Resources) (set int) {
 func (d Discoverer) setVMsHierarchy(res *rs.Resources) (set int) {
 	for _, vm := range res.VMs {
 		if setVMHierarchy(vm, res) {
-			set++
-		}
-	}
-	return set
-}
-
-func (d Discoverer) setDatastoresHierarchy(res *rs.Resources) (set int) {
-	for _, datastore := range res.Datastores {
-		if setDatastoreHierarchy(datastore, res) {
 			set++
 		}
 	}
@@ -106,19 +94,4 @@ func setVMHierarchy(vm *rs.VM, res *rs.Resources) bool {
 	}
 	vm.Hier.DC.Set(dc.ID, dc.Name)
 	return vm.Hier.IsSet()
-}
-
-func setDatastoreHierarchy(datastore *rs.Datastore, res *rs.Resources) bool {
-	cr := res.Clusters.Get(datastore.ParentID)
-	if cr == nil {
-		return false
-	}
-	datastore.Hier.Cluster.Set(cr.ID, cr.Name)
-
-	dc := res.DataCenters.Get(cr.ParentID)
-	if dc == nil {
-		return false
-	}
-	datastore.Hier.DC.Set(dc.ID,dc.Name)
-	return datastore.Hier.IsSet()
 }

--- a/modules/vsphere/discover/hierarchy.go
+++ b/modules/vsphere/discover/hierarchy.go
@@ -15,7 +15,7 @@ func (d Discoverer) setHierarchy(res *rs.Resources) error {
 	v := d.setVMsHierarchy(res)
 	s := d.setDatastoresHierarchy(res)
 
-	// notSet := len(res.Clusters) + len(res.Hosts) + len(res.VMs) - (c + h + v)
+	// notSet := len(res.Clusters) + len(res.Hosts) + len(res.VMs) + len(res.Datastores) - (c + h + v + d)
 	d.Infof("discovering : hierarchy : set %d/%d clusters, %d/%d hosts, %d/%d vms, %d/%d datastores, process took %s",
 		c, len(res.Clusters),
 		h, len(res.Hosts),
@@ -109,7 +109,13 @@ func setVMHierarchy(vm *rs.VM, res *rs.Resources) bool {
 }
 
 func setDatastoreHierarchy(datastore *rs.Datastore, res *rs.Resources) bool {
-	dc := res.DataCenters.Get(datastore.ParentID)
+	cr := res.Clusters.Get(datastore.ParentID)
+	if cr == nil {
+		return false
+	}
+	datastore.Hier.Cluster.Set(cr.ID, cr.Name)
+
+	dc := res.DataCenters.Get(cr.ParentID)
 	if dc == nil {
 		return false
 	}

--- a/modules/vsphere/discover/hierarchy.go
+++ b/modules/vsphere/discover/hierarchy.go
@@ -13,12 +13,14 @@ func (d Discoverer) setHierarchy(res *rs.Resources) error {
 	c := d.setClustersHierarchy(res)
 	h := d.setHostsHierarchy(res)
 	v := d.setVMsHierarchy(res)
+	s := d.setDatastoresHierarchy(res)
 
 	// notSet := len(res.Clusters) + len(res.Hosts) + len(res.VMs) - (c + h + v)
-	d.Infof("discovering : hierarchy : set %d/%d clusters, %d/%d hosts, %d/%d vms, process took %s",
+	d.Infof("discovering : hierarchy : set %d/%d clusters, %d/%d hosts, %d/%d vms, %d/%d datastores, process took %s",
 		c, len(res.Clusters),
 		h, len(res.Hosts),
 		v, len(res.VMs),
+		s, len(res.Datastores),
 		time.Since(t),
 	)
 
@@ -46,6 +48,15 @@ func (d Discoverer) setHostsHierarchy(res *rs.Resources) (set int) {
 func (d Discoverer) setVMsHierarchy(res *rs.Resources) (set int) {
 	for _, vm := range res.VMs {
 		if setVMHierarchy(vm, res) {
+			set++
+		}
+	}
+	return set
+}
+
+func (d Discoverer) setDatastoresHierarchy(res *rs.Resources) (set int) {
+	for _, datastore := range res.Datastores {
+		if setDatastoreHierarchy(datastore, res) {
 			set++
 		}
 	}
@@ -95,4 +106,13 @@ func setVMHierarchy(vm *rs.VM, res *rs.Resources) bool {
 	}
 	vm.Hier.DC.Set(dc.ID, dc.Name)
 	return vm.Hier.IsSet()
+}
+
+func setDatastoreHierarchy(datastore *rs.Datastore, res *rs.Resources) bool {
+	dc := res.DataCenters.Get(datastore.ParentID)
+	if dc == nil {
+		return false
+	}
+	datastore.Hier.DC.Set(dc.ID,dc.Name)
+	return datastore.Hier.IsSet()
 }

--- a/modules/vsphere/discover/metric_lists.go
+++ b/modules/vsphere/discover/metric_lists.go
@@ -143,8 +143,8 @@ var (
 
 	datastoreMetrics = []string{
 		"disk.used.latest",
-				"disk.provisioned.latest",
+		"disk.provisioned.latest",
 		"disk.capacity.latest",
-			"disk.capacity.provisioned.average",
+		"disk.capacity.provisioned.average",
 	}
 )

--- a/modules/vsphere/discover/metric_lists.go
+++ b/modules/vsphere/discover/metric_lists.go
@@ -26,12 +26,18 @@ func (d Discoverer) collectMetricLists(res *rs.Resources) error {
 	for _, v := range res.VMs {
 		v.MetricList = vmML
 	}
+	datastoreML := simpleDatastoreMetricList(perfCounters)
+	for _, d := range res.Datastores {
+		d.MetricList = datastoreML
+	}
 
 	d.Infof("discovering : metric lists : collected metric lists for %d/%d hosts, %d/%d vms, process took %s",
 		len(res.Hosts),
 		len(res.Hosts),
 		len(res.VMs),
 		len(res.VMs),
+		len(res.Datastores),
+		len(res.Datastores),
 		time.Since(t),
 	)
 
@@ -44,6 +50,10 @@ func simpleHostMetricList(pci map[string]*types.PerfCounterInfo) performance.Met
 
 func simpleVMMetricList(pci map[string]*types.PerfCounterInfo) performance.MetricList {
 	return simpleMetricList(vmMetrics, pci)
+}
+
+func simpleDatastoreMetricList(pci map[string]*types.PerfCounterInfo) performance.MetricList {
+	return simpleMetricList(datastoreMetrics, pci)
 }
 
 func simpleMetricList(metrics []string, pci map[string]*types.PerfCounterInfo) performance.MetricList {
@@ -129,5 +139,12 @@ var (
 		"disk.maxTotalLatency.latest",
 
 		"sys.uptime.latest",
+	}
+
+	datastoreMetrics = []string{
+		"disk.used.latest",
+				"disk.provisioned.latest",
+		"disk.capacity.latest",
+			"disk.capacity.provisioned.average",
 	}
 )

--- a/modules/vsphere/discover/metric_lists.go
+++ b/modules/vsphere/discover/metric_lists.go
@@ -31,7 +31,7 @@ func (d Discoverer) collectMetricLists(res *rs.Resources) error {
 		d.MetricList = datastoreML
 	}
 
-	d.Infof("discovering : metric lists : collected metric lists for %d/%d hosts, %d/%d vms, process took %s",
+	d.Infof("discovering : metric lists : collected metric lists for %d/%d hosts, %d/%d vms, %d/%d datastores process took %s",
 		len(res.Hosts),
 		len(res.Hosts),
 		len(res.VMs),

--- a/modules/vsphere/match/match.go
+++ b/modules/vsphere/match/match.go
@@ -29,7 +29,7 @@ type (
 	vmHostMatcher      struct{ m matcher.Matcher }
 	vmVMMatcher        struct{ m matcher.Matcher }
 	datastoreDCMatcher struct{ m matcher.Matcher }
-  datastoreDatastoreMatcher struct{ m matcher.Matcher }
+    datastoreDatastoreMatcher struct{ m matcher.Matcher }
 	orHostMatcher      struct{ lhs, rhs HostMatcher }
 	orVMMatcher        struct{ lhs, rhs VMMatcher }
 	orDatastoreMatcher			struct{ lhs, rhs DatastoreMatcher}
@@ -45,7 +45,6 @@ func (m vmDCMatcher) Match(vm *rs.VM) bool            { return m.m.MatchString(v
 func (m vmClusterMatcher) Match(vm *rs.VM) bool       { return m.m.MatchString(vm.Hier.Cluster.Name) }
 func (m vmHostMatcher) Match(vm *rs.VM) bool          { return m.m.MatchString(vm.Hier.Host.Name) }
 func (m vmVMMatcher) Match(vm *rs.VM) bool            { return m.m.MatchString(vm.Name) }
-func (m datastoreDCMatcher) Match(datastore *rs.Datastore) bool { return m.m.MatchString(datastore.Hier.DC.Name) }
 func (m datastoreDatastoreMatcher) Match(datastore *rs.Datastore) bool { return m.m.MatchString(datastore.Name) }
 func (m orHostMatcher) Match(host *rs.Host) bool      { return m.lhs.Match(host) || m.rhs.Match(host) }
 func (m orVMMatcher) Match(vm *rs.VM) bool            { return m.lhs.Match(vm) || m.rhs.Match(vm) }
@@ -277,7 +276,7 @@ func parseDatastoreInclude(include string) (DatastoreMatcher, error) {
 	}
 
 	include = cleanInclude(include)
-	parts := strings.Split(include, "/") // /dc/clusterIdx/hostIdx
+	parts := strings.Split(include, "/")
 	var ms []DatastoreMatcher
 
 	for i, v := range parts {
@@ -288,8 +287,6 @@ func parseDatastoreInclude(include string) (DatastoreMatcher, error) {
 		switch i {
 		case datastoreIdx:
 			ms = append(ms, datastoreDatastoreMatcher{m})
-		case datacenterIdx:
-			ms = append(ms, datastoreDCMatcher{m})
 		}
 	}
 

--- a/modules/vsphere/match/match.go
+++ b/modules/vsphere/match/match.go
@@ -16,6 +16,10 @@ type VMMatcher interface {
 	Match(*rs.VM) bool
 }
 
+type DatastoreMatcher interface {
+	Match(*rs.Datastore) bool
+}
+
 type (
 	hostDCMatcher      struct{ m matcher.Matcher }
 	hostClusterMatcher struct{ m matcher.Matcher }
@@ -24,10 +28,14 @@ type (
 	vmClusterMatcher   struct{ m matcher.Matcher }
 	vmHostMatcher      struct{ m matcher.Matcher }
 	vmVMMatcher        struct{ m matcher.Matcher }
+	datastoreDCMatcher struct{ m matcher.Matcher }
+  datastoreDatastoreMatcher struct{ m matcher.Matcher }
 	orHostMatcher      struct{ lhs, rhs HostMatcher }
 	orVMMatcher        struct{ lhs, rhs VMMatcher }
+	orDatastoreMatcher			struct{ lhs, rhs DatastoreMatcher}
 	andHostMatcher     struct{ lhs, rhs HostMatcher }
 	andVMMatcher       struct{ lhs, rhs VMMatcher }
+	andDatastoreMatcher	struct{ lhs, rhs DatastoreMatcher }
 )
 
 func (m hostDCMatcher) Match(host *rs.Host) bool      { return m.m.MatchString(host.Hier.DC.Name) }
@@ -37,10 +45,14 @@ func (m vmDCMatcher) Match(vm *rs.VM) bool            { return m.m.MatchString(v
 func (m vmClusterMatcher) Match(vm *rs.VM) bool       { return m.m.MatchString(vm.Hier.Cluster.Name) }
 func (m vmHostMatcher) Match(vm *rs.VM) bool          { return m.m.MatchString(vm.Hier.Host.Name) }
 func (m vmVMMatcher) Match(vm *rs.VM) bool            { return m.m.MatchString(vm.Name) }
+func (m datastoreDCMatcher) Match(datastore *rs.Datastore) bool { return m.m.MatchString(datastore.Hier.DC.Name) }
+func (m datastoreDatastoreMatcher) Match(datastore *rs.Datastore) bool { return m.m.MatchString(datastore.Name) }
 func (m orHostMatcher) Match(host *rs.Host) bool      { return m.lhs.Match(host) || m.rhs.Match(host) }
 func (m orVMMatcher) Match(vm *rs.VM) bool            { return m.lhs.Match(vm) || m.rhs.Match(vm) }
+func (m orDatastoreMatcher) Match(datastore *rs.Datastore) bool { return m.lhs.Match(datastore) || m.rhs.Match(datastore) }
 func (m andHostMatcher) Match(host *rs.Host) bool     { return m.lhs.Match(host) && m.rhs.Match(host) }
 func (m andVMMatcher) Match(vm *rs.VM) bool           { return m.lhs.Match(vm) && m.rhs.Match(vm) }
+func (m andDatastoreMatcher) Match(datastore *rs.Datastore) bool { return m.lhs.Match(datastore) && m.rhs.Match(datastore) }
 
 func newAndHostMatcher(lhs, rhs HostMatcher, others ...HostMatcher) andHostMatcher {
 	m := andHostMatcher{lhs: lhs, rhs: rhs}
@@ -59,6 +71,16 @@ func newAndVMMatcher(lhs, rhs VMMatcher, others ...VMMatcher) andVMMatcher {
 		return m
 	default:
 		return newAndVMMatcher(m, others[0], others[1:]...)
+	}
+}
+
+func newAndDatastoreMatcher(lhs, rhs DatastoreMatcher, others ...DatastoreMatcher) andDatastoreMatcher {
+	m := andDatastoreMatcher{lhs: lhs, rhs: rhs}
+	switch len(others) {
+	case 0:
+		return m
+	default:
+		return newAndDatastoreMatcher(m, others[0], others[1:]...)
 	}
 }
 
@@ -82,9 +104,20 @@ func newOrVMMatcher(lhs, rhs VMMatcher, others ...VMMatcher) orVMMatcher {
 	}
 }
 
+func newOrDatastoreMatcher(lhs, rhs DatastoreMatcher, others ...DatastoreMatcher) orDatastoreMatcher {
+	m := orDatastoreMatcher{lhs: lhs, rhs: rhs}
+	switch len(others) {
+	case 0:
+		return m
+	default:
+		return newOrDatastoreMatcher(m, others[0], others[1:]...)
+	}
+}
+
 type (
 	VMIncludes   []string
 	HostIncludes []string
+	DatastoreIncludes []string
 )
 
 func (vi VMIncludes) Parse() (VMMatcher, error) {
@@ -133,11 +166,35 @@ func (hi HostIncludes) Parse() (HostMatcher, error) {
 	}
 }
 
+func (hi DatastoreIncludes) Parse() (DatastoreMatcher, error) {
+	var ms []DatastoreMatcher
+	for _, v := range hi {
+		m, err := parseDatastoreInclude(v)
+		if err != nil {
+			return nil, err
+		}
+		if m == nil {
+			continue
+		}
+		ms = append(ms, m)
+	}
+
+	switch len(ms) {
+	case 0:
+		return nil, nil
+	case 1:
+		return ms[0], nil
+	default:
+		return newOrDatastoreMatcher(ms[0], ms[1], ms[2:]...), nil
+	}
+}
+
 const (
 	datacenterIdx = iota
 	clusterIdx
 	hostIdx
 	vmIdx
+	datastoreIdx
 )
 
 func cleanInclude(include string) string {
@@ -211,6 +268,38 @@ func parseVMInclude(include string) (VMMatcher, error) {
 		return ms[0], nil
 	default:
 		return newAndVMMatcher(ms[0], ms[1], ms[2:]...), nil
+	}
+}
+
+func parseDatastoreInclude(include string) (DatastoreMatcher, error) {
+	if !isIncludeFormatValid(include) {
+		return nil, fmt.Errorf("bad include format: %s", include)
+	}
+
+	include = cleanInclude(include)
+	parts := strings.Split(include, "/") // /dc/clusterIdx/hostIdx
+	var ms []DatastoreMatcher
+
+	for i, v := range parts {
+		m, err := parseSubInclude(v)
+		if err != nil {
+			return nil, err
+		}
+		switch i {
+		case datastoreIdx:
+			ms = append(ms, datastoreDatastoreMatcher{m})
+		case datacenterIdx:
+			ms = append(ms, datastoreDCMatcher{m})
+		}
+	}
+
+	switch len(ms) {
+	case 0:
+		return nil, nil
+	case 1:
+		return ms[0], nil
+	default:
+		return newAndDatastoreMatcher(ms[0], ms[1], ms[2:]...), nil
 	}
 }
 

--- a/modules/vsphere/match/match_test.go
+++ b/modules/vsphere/match/match_test.go
@@ -15,8 +15,6 @@ var (
 	falseHostDC = hostDCMatcher{matcher.FALSE()}
 	trueVMDC    = vmDCMatcher{matcher.TRUE()}
 	falseVMDC   = vmDCMatcher{matcher.FALSE()}
-	trueDatastoreDC = datastoreDCMatcher{matcher.TRUE()}
-	falseDatastoreDC = datastoreDCMatcher{matcher.FALSE()}
 )
 
 func TestOrHostMatcher_Match(t *testing.T) {
@@ -103,48 +101,6 @@ func TestAndVMMatcher_Match(t *testing.T) {
 	}
 }
 
-func TestOrDatastoreMatcher_Match(t *testing.T) {
-	tests := map[string]struct {
-		expected bool
-		lhs      DatastoreMatcher
-		rhs      DatastoreMatcher
-	}{
-		"true, true":   {expected: true, lhs: trueDatastoreDC, rhs: trueDatastoreDC},
-		"true, false":  {expected: true, lhs: trueDatastoreDC, rhs: falseDatastoreDC},
-		"false, true":  {expected: true, lhs: falseDatastoreDC, rhs: trueDatastoreDC},
-		"false, false": {expected: false, lhs: falseDatastoreDC, rhs: falseDatastoreDC},
-	}
-
-	var datastore resources.Datastore
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			m := newOrDatastoreMatcher(test.lhs, test.rhs)
-			assert.Equal(t, test.expected, m.Match(&datastore))
-		})
-	}
-}
-
-
-func TestAndDatastoreMatcher_Match(t *testing.T) {
-	tests := map[string]struct {
-		expected bool
-		lhs      DatastoreMatcher
-		rhs      DatastoreMatcher
-	}{
-		"true, true":   {expected: true, lhs: trueDatastoreDC, rhs: trueDatastoreDC},
-		"true, false":  {expected: false, lhs: trueDatastoreDC, rhs: falseDatastoreDC},
-		"false, true":  {expected: false, lhs: falseDatastoreDC, rhs: trueDatastoreDC},
-		"false, false": {expected: false, lhs: falseDatastoreDC, rhs: falseDatastoreDC},
-	}
-
-	var datastore resources.Datastore
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			m := newAndDatastoreMatcher(test.lhs, test.rhs)
-			assert.Equal(t, test.expected, m.Match(&datastore))
-		})
-	}
-}
 
 func TestHostIncludes_Parse(t *testing.T) {
 	tests := map[string]struct {
@@ -320,39 +276,6 @@ func TestVMIncludes_Parse(t *testing.T) {
 	}
 }
 
-func TestDatastoreIncludes_Parse(t *testing.T) {
-	tests := map[string]struct {
-		valid    bool
-		expected DatastoreMatcher
-	}{
-		"":        {valid: false},
-		"*/C1/H1": {valid: false},
-		"/":       {valid: true, expected: falseDatastoreDC},
-		"/*":      {valid: true, expected: trueDatastoreDC},
-		"/!*":     {valid: true, expected: falseDatastoreDC},
-		"/!*/":    {valid: true, expected: falseDatastoreDC},
-		"[/DC1*,/DC2*]": {
-			valid: true,
-			expected: orDatastoreMatcher{
-				lhs: datastoreDCMatcher{mustSP("DC1*")},
-				rhs: datastoreDCMatcher{mustSP("DC2*")},
-			},
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			includes := prepareIncludes(name)
-			m, err := DatastoreIncludes(includes).Parse()
-
-			if !test.valid {
-				assert.Error(t, err)
-			} else {
-				assert.Equal(t, test.expected, m)
-			}
-		})
-	}
-}
 
 func prepareIncludes(include string) []string {
 	trimmed := strings.Trim(include, "[]")

--- a/modules/vsphere/metrics.txt
+++ b/modules/vsphere/metrics.txt
@@ -326,3 +326,11 @@
 
 	vflashModule.numActiveVMDKs.latest [num, absolute, true] [Number of caches controlled by the virtual flash module]
 */
+/*
+	Datastore:
+
+	disk.used.latest
+	disk.provisioned.latest
+	disk.capacity.latest
+	disk.capacity.provisioned.average
+*/

--- a/modules/vsphere/resources/resources.go
+++ b/modules/vsphere/resources/resources.go
@@ -47,6 +47,7 @@ type Resources struct {
 	Clusters    Clusters
 	Hosts       Hosts
 	VMs         VMs
+	Datastores	Datastores
 }
 
 type (
@@ -104,6 +105,18 @@ type (
 		MetricList    performance.MetricList
 		Ref           types.ManagedObjectReference
 	}
+	DatastoreHierarchy struct {
+		DC      HierarchyValue
+	}
+	Datastore struct {
+		Name          string
+		ID            string
+		ParentID      string
+		Hier          DatastoreHierarchy
+		Accessible    bool
+		MetricList    performance.MetricList
+		Ref           types.ManagedObjectReference
+	}
 )
 
 func (v HierarchyValue) IsSet() bool          { return v.ID != "" && v.Name != "" }
@@ -112,6 +125,7 @@ func (v *HierarchyValue) Set(id, name string) { v.ID = id; v.Name = name }
 func (h ClusterHierarchy) IsSet() bool { return h.DC.IsSet() }
 func (h HostHierarchy) IsSet() bool    { return h.DC.IsSet() && h.Cluster.IsSet() }
 func (h VMHierarchy) IsSet() bool      { return h.DC.IsSet() && h.Cluster.IsSet() && h.Host.IsSet() }
+func (h DatastoreHierarchy) IsSet() bool {return h.DC.IsSet() }
 
 type (
 	DataCenters map[string]*Datacenter
@@ -119,6 +133,7 @@ type (
 	Clusters    map[string]*Cluster
 	Hosts       map[string]*Host
 	VMs         map[string]*VM
+	Datastores  map[string]*Datastore
 )
 
 func (dcs DataCenters) Put(dc *Datacenter)        { dcs[dc.ID] = dc }
@@ -133,3 +148,6 @@ func (hs Hosts) Get(id string) *Host              { return hs[id] }
 func (vs VMs) Put(vm *VM)                         { vs[vm.ID] = vm }
 func (vs VMs) Remove(id string)                   { delete(vs, id) }
 func (vs VMs) Get(id string) *VM                  { return vs[id] }
+func (ds Datastores) Put(datastore *Datastore)    { ds[datastore.ID] = datastore }
+func (ds Datastores) Remove(id string)            { delete(ds, id) }
+func (ds Datastores) Get(id string) *Datastore    { return ds[id] }

--- a/modules/vsphere/resources/resources.go
+++ b/modules/vsphere/resources/resources.go
@@ -105,15 +105,9 @@ type (
 		MetricList    performance.MetricList
 		Ref           types.ManagedObjectReference
 	}
-	DatastoreHierarchy struct {
-		DC      HierarchyValue
-		Cluster HierarchyValue
-	}
 	Datastore struct {
 		Name          string
 		ID            string
-		ParentID      string
-		Hier          DatastoreHierarchy
 		Accessible    bool
 		MetricList    performance.MetricList
 		Ref           types.ManagedObjectReference
@@ -126,7 +120,6 @@ func (v *HierarchyValue) Set(id, name string) { v.ID = id; v.Name = name }
 func (h ClusterHierarchy) IsSet() bool { return h.DC.IsSet() }
 func (h HostHierarchy) IsSet() bool    { return h.DC.IsSet() && h.Cluster.IsSet() }
 func (h VMHierarchy) IsSet() bool      { return h.DC.IsSet() && h.Cluster.IsSet() && h.Host.IsSet() }
-func (h DatastoreHierarchy) IsSet() bool {return h.DC.IsSet() && h.Cluster.IsSet() }
 
 type (
 	DataCenters map[string]*Datacenter

--- a/modules/vsphere/resources/resources.go
+++ b/modules/vsphere/resources/resources.go
@@ -107,6 +107,7 @@ type (
 	}
 	DatastoreHierarchy struct {
 		DC      HierarchyValue
+		Cluster HierarchyValue
 	}
 	Datastore struct {
 		Name          string
@@ -125,7 +126,7 @@ func (v *HierarchyValue) Set(id, name string) { v.ID = id; v.Name = name }
 func (h ClusterHierarchy) IsSet() bool { return h.DC.IsSet() }
 func (h HostHierarchy) IsSet() bool    { return h.DC.IsSet() && h.Cluster.IsSet() }
 func (h VMHierarchy) IsSet() bool      { return h.DC.IsSet() && h.Cluster.IsSet() && h.Host.IsSet() }
-func (h DatastoreHierarchy) IsSet() bool {return h.DC.IsSet() }
+func (h DatastoreHierarchy) IsSet() bool {return h.DC.IsSet() && h.Cluster.IsSet() }
 
 type (
 	DataCenters map[string]*Datacenter

--- a/modules/vsphere/scrape/scrape_test.go
+++ b/modules/vsphere/scrape/scrape_test.go
@@ -35,6 +35,14 @@ func TestScraper_ScrapeHosts(t *testing.T) {
 	assert.Len(t, metrics, len(res.Hosts))
 }
 
+func TestScraper_ScrapeDatastores(t *testing.T) {
+	s, res, teardown := prepareScraper(t)
+	defer teardown()
+
+	metrics := s.ScrapeDatastores(res.Datastores)
+	assert.Len(t, metrics, len(res.Datastores))
+}
+
 func prepareScraper(t *testing.T) (s *Scraper, res *rs.Resources, teardown func()) {
 	model, srv := createSim(t)
 	teardown = func() { model.Remove(); srv.Close() }

--- a/modules/vsphere/vsphere_test.go
+++ b/modules/vsphere/vsphere_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-	"regexp"
 
 	"github.com/netdata/go.d.plugin/modules/vsphere/discover"
 	"github.com/netdata/go.d.plugin/modules/vsphere/match"
@@ -300,8 +299,7 @@ func TestVSphere_Collect(t *testing.T) {
 
 	//working around ioutil.TempDir naming convention
 	for key, value := range collected {
-		match,_ := regexp.MatchString(".*LocalDS_.*",key)
-		if(match){
+		if(strings.Contains(key,"LocalDS_")){
 			expected[key]=value
 		}
 	}

--- a/modules/vsphere/vsphere_test.go
+++ b/modules/vsphere/vsphere_test.go
@@ -300,7 +300,7 @@ func TestVSphere_Collect(t *testing.T) {
 
 	//working around ioutil.TempDir naming convention
 	for key, value := range collected {
-		match,_ := regexp.MatchString("*LocalDS_*",key)
+		match,_ := regexp.MatchString(".*LocalDS_.*",key)
 		if(match){
 			expected[key]=value
 		}


### PR DESCRIPTION
Making vSphere module for Netdata's Go plugin able to monitor vsphere datastores (it was already able to monitor hosts and vms).
There is also a little modification on error handling in collect.go : before, an error prevented any metric to be collected, so i edited it so that, for example, hosts and datastores metrics can be collected even when vms metrics cannot be collected.