### PR TITLE
vernemq: remove "queue_messages_in_queues" chart

### DIFF
--- a/modules/vernemq/README.md
+++ b/modules/vernemq/README.md
@@ -33,7 +33,6 @@ It produces the following charts:
 - Living Queues in an Online or an Offline State in `queue processes`
 - Queue Processes Setup and Teardown Events in `events/s`
 - Queue Processes Initialized from Offline Storage in `queue processes/s`
-- PUBLISH Messages that Currently in the Queues in `messages`
 - Received and Sent PUBLISH Messages in `messages/s`
 - Undelivered PUBLISH Messages in `messages`
 

--- a/modules/vernemq/charts.go
+++ b/modules/vernemq/charts.go
@@ -19,7 +19,6 @@ var charts = Charts{
 	chartQueueProcesses.Copy(),
 	chartQueueProcessesEvents.Copy(),
 	chartQueueProcessesOfflineStorage.Copy(),
-	chartQueueMessagesInQueues.Copy(),
 	chartQueueMessages.Copy(),
 	chartQueueUndeliveredMessages.Copy(),
 
@@ -178,16 +177,6 @@ var (
 		Ctx:   "vernemq.queue_process_init_from_storage",
 		Dims: Dims{
 			{ID: metricQueueInitializedFromStorage, Name: "queue processes", Algo: module.Incremental},
-		},
-	}
-	chartQueueMessagesInQueues = Chart{
-		ID:    "queue_messages_in_queues",
-		Title: "PUBLISH Messages that Currently in the Queues",
-		Units: "messages",
-		Fam:   "queues",
-		Ctx:   "vernemq.queue_messages_in_queues",
-		Dims: Dims{
-			{ID: "queue_messages_current", Name: "messages"},
 		},
 	}
 	chartQueueMessages = Chart{

--- a/modules/vernemq/collect.go
+++ b/modules/vernemq/collect.go
@@ -155,14 +155,6 @@ func collectQueues(mx map[string]float64, pms prometheus.Metrics) {
 		metricQueueTeardown,
 	)
 	collectNonMQTT(mx, pms)
-	mx["queue_messages_current"] = calcQueueMessagesCurrent(mx)
-}
-
-func calcQueueMessagesCurrent(mx map[string]float64) float64 {
-	expired := mx[metricQueueMessageExpired]
-	out := mx[metricQueueMessageOut]
-	in := mx[metricQueueMessageIn]
-	return in - (out + expired)
 }
 
 func collectSubscriptions(mx map[string]float64, pms prometheus.Metrics) {

--- a/modules/vernemq/vernemq_test.go
+++ b/modules/vernemq/vernemq_test.go
@@ -529,7 +529,6 @@ var v1101ExpectedMetrics = map[string]int64{
 	"queue_message_in":                                        525722,
 	"queue_message_out":                                       525721,
 	"queue_message_unhandled":                                 1,
-	"queue_messages_current":                                  1,
 	"queue_processes":                                         0,
 	"queue_setup":                                             338948,
 	"queue_teardown":                                          338948,


### PR DESCRIPTION
It is not possible to calculate messages currently in the queue using "queue_message_*" metrics.