### PR TITLE
nginx: add "/basic_status" job

### DIFF
--- a/config/go.d/nginx.conf
+++ b/config/go.d/nginx.conf
@@ -155,6 +155,9 @@
 # [ JOBS ]
 jobs:
   - name: local
+    url: http://127.0.0.1/basic_status
+
+  - name: local
     url: http://localhost/stub_status
 
   - name: local


### PR DESCRIPTION
Because that is [an example configuration](http://nginx.org/en/docs/http/ngx_http_stub_status_module.html)