### PR TITLE
whoisquery: remove domain validation

### DIFF
--- a/modules/whoisquery/collect.go
+++ b/modules/whoisquery/collect.go
@@ -1,9 +1,11 @@
 package whoisquery
 
+import "fmt"
+
 func (wq *WhoisQuery) collect() (map[string]int64, error) {
 	remainingTime, err := wq.prov.remainingTime()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%v (source: %s)", err, wq.Source)
 	}
 
 	mx := make(map[string]int64)

--- a/modules/whoisquery/provider.go
+++ b/modules/whoisquery/provider.go
@@ -19,9 +19,8 @@ type fromNet struct {
 	client        *whois.Client
 }
 
-// https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch08s15.html
 // TODO: do we need this validation at all?
-var reValidDomain = regexp.MustCompile(`([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}`)
+var reValidDomain = regexp.MustCompile(`^(?i)[a-z0-9-]+(\.[a-z0-9-]+)+\.?$`)
 
 func newProvider(config Config) (provider, error) {
 	domain := config.Source

--- a/modules/whoisquery/provider.go
+++ b/modules/whoisquery/provider.go
@@ -1,8 +1,6 @@
 package whoisquery
 
 import (
-	"fmt"
-	"regexp"
 	"time"
 
 	"github.com/araddon/dateparse"
@@ -19,15 +17,8 @@ type fromNet struct {
 	client        *whois.Client
 }
 
-// TODO: do we need this validation at all?
-var reValidDomain = regexp.MustCompile(`^(?i)[a-z0-9-]+(\.[a-z0-9-]+)+\.?$`)
-
 func newProvider(config Config) (provider, error) {
 	domain := config.Source
-	if valid := reValidDomain.MatchString(domain); !valid {
-		return nil, fmt.Errorf("incorrect domain: %s, expected pattern: %s", domain, reValidDomain)
-	}
-
 	client := whois.NewClient()
 	client.SetTimeout(config.Timeout.Duration)
 

--- a/modules/whoisquery/provider.go
+++ b/modules/whoisquery/provider.go
@@ -19,7 +19,9 @@ type fromNet struct {
 	client        *whois.Client
 }
 
-var reValidDomain = regexp.MustCompile(`^[a-zA-Z0-9\-]+\.[a-zA-Z0-9]+$`)
+// https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch08s15.html
+// TODO: do we need this validation at all?
+var reValidDomain = regexp.MustCompile(`([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}`)
 
 func newProvider(config Config) (provider, error) {
 	domain := config.Source

--- a/modules/whoisquery/whoisquery_test.go
+++ b/modules/whoisquery/whoisquery_test.go
@@ -40,14 +40,6 @@ func TestWhoisQuery_Init(t *testing.T) {
 			config: Config{Source: ""},
 			err:    true,
 		},
-		"with http": {
-			config: Config{Source: "http://example.org"},
-			err:    true,
-		},
-		"with https": {
-			config: Config{Source: "https://example.org"},
-			err:    true,
-		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
The issue is reported in https://community.netdata.cloud/t/support-more-tlds-with-go-d-whoisquery/1839/2

No need in validating domains.