### PR TITLE
feat(prometheus): add a config option to set application

### DIFF
--- a/modules/prometheus/charts.go
+++ b/modules/prometheus/charts.go
@@ -30,7 +30,7 @@ var statsCharts = Charts{
 	},
 }
 
-func anyChart(id string, pm prometheus.Metric, meta prometheus.Metadata) *module.Chart {
+func anyChart(id, app string, pm prometheus.Metric, meta prometheus.Metadata) *module.Chart {
 	units := extractUnits(pm.Name())
 	if isIncremental(pm, meta) && !isIncrementalUnitsException(units) {
 		units += "/s"
@@ -44,7 +44,7 @@ func anyChart(id string, pm prometheus.Metric, meta prometheus.Metadata) *module
 		Title: chartTitle(pm, meta),
 		Units: units,
 		Fam:   chartFamily(pm),
-		Ctx:   "prometheus." + pm.Name(),
+		Ctx:   chartContext(app, pm),
 		Type:  cType,
 	}
 }
@@ -57,19 +57,19 @@ func isIncrementalUnitsException(units string) bool {
 	return false
 }
 
-func summaryChart(id string, pm prometheus.Metric, meta prometheus.Metadata) *module.Chart {
+func summaryChart(id, app string, pm prometheus.Metric, meta prometheus.Metadata) *module.Chart {
 	return &module.Chart{
 		ID:    id,
 		Title: chartTitle(pm, meta),
 		Units: "observations",
 		Fam:   chartFamily(pm),
-		Ctx:   "prometheus." + pm.Name(),
+		Ctx:   chartContext(app, pm),
 		Type:  module.Stacked,
 	}
 }
 
-func histogramChart(id string, pm prometheus.Metric, meta prometheus.Metadata) *module.Chart {
-	return summaryChart(id, pm, meta)
+func histogramChart(id, app string, pm prometheus.Metric, meta prometheus.Metadata) *module.Chart {
+	return summaryChart(id, app, pm, meta)
 }
 
 func chartTitle(pm prometheus.Metric, meta prometheus.Metadata) string {
@@ -103,6 +103,13 @@ func chartFamily(pm prometheus.Metric) (fam string) {
 		return fam[:i+1]
 	}
 	return fam
+}
+
+func chartContext(app string, pm prometheus.Metric) string {
+	if app == "" {
+		return fmt.Sprintf("prometheus.%s", pm.Name())
+	}
+	return fmt.Sprintf("prometheus.%s.%s", app, pm.Name())
 }
 
 func anyChartDimension(id, name string, pm prometheus.Metric, meta prometheus.Metadata) *module.Dim {

--- a/modules/prometheus/collect.go
+++ b/modules/prometheus/collect.go
@@ -89,6 +89,13 @@ func (p *Prometheus) buildMetricSet(pms prometheus.Metrics) (names []string, met
 	return names[:i], metrics
 }
 
+func (p Prometheus) application() string {
+	if p.Application != "" {
+		return p.Application
+	}
+	return p.Name
+}
+
 func hasMetricWithPrefix(pms prometheus.Metrics, prefix string) bool {
 	for _, pm := range pms {
 		if strings.HasPrefix(pm.Name(), prefix) {

--- a/modules/prometheus/collect_gauge_counter.go
+++ b/modules/prometheus/collect_gauge_counter.go
@@ -30,7 +30,7 @@ func (p *Prometheus) collectAny(mx map[string]int64, pms prometheus.Metrics, met
 		mx[dimID] = int64(pm.Value * precision)
 
 		if !cache.hasChart(chartID) {
-			chart := anyChart(chartID, pm, meta)
+			chart := anyChart(chartID, p.application(), pm, meta)
 			cache.putChart(chartID, chart)
 			if strings.HasSuffix(chart.Units, "/s") && p.forceAbsoluteAlgorithm.MatchString(pm.Name()) {
 				chart.Units = chart.Units[:len(chart.Units)-2]

--- a/modules/prometheus/collect_histogram.go
+++ b/modules/prometheus/collect_histogram.go
@@ -40,7 +40,7 @@ func (p *Prometheus) collectHistogram(mx map[string]int64, pms prometheus.Metric
 		set[chartID] = pm.Value
 
 		if !cache.hasChart(chartID) {
-			chart := histogramChart(chartID, pm, meta)
+			chart := histogramChart(chartID, p.application(), pm, meta)
 			cache.putChart(chartID, chart)
 			if err := p.Charts().Add(chart); err != nil {
 				p.Warning(err)

--- a/modules/prometheus/collect_summary.go
+++ b/modules/prometheus/collect_summary.go
@@ -35,7 +35,7 @@ func (p *Prometheus) collectSummary(mx map[string]int64, pms prometheus.Metrics,
 		mx[dimID] = int64(pm.Value * precision)
 
 		if !cache.hasChart(chartID) {
-			chart := summaryChart(chartID, pm, meta)
+			chart := summaryChart(chartID, p.application(), pm, meta)
 			cache.putChart(chartID, chart)
 			if err := p.Charts().Add(chart); err != nil {
 				p.Warning(err)

--- a/modules/prometheus/prometheus.go
+++ b/modules/prometheus/prometheus.go
@@ -42,6 +42,8 @@ func New() *Prometheus {
 type (
 	Config struct {
 		web.HTTP               `yaml:",inline"`
+		Name                   string        `yaml:"name"`
+		Application            string        `yaml:"app"`
 		BearerTokenFile        string        `yaml:"bearer_token_file"` // TODO: part of web.Request?
 		MaxTS                  int           `yaml:"max_time_series"`
 		MaxTSPerMetric         int           `yaml:"max_time_series_per_metric"`


### PR DESCRIPTION
Fixes: netdata/netdata#12572

After this PR a chart's context will be: `prometheus.{application}.{metric_name}`. If "application" is not in the configuration the job name is used.

I keep "prometheus" prefix because our current parser is prometheus parser.