### PR TITLE
feat(nginx): add common stub_status locations

### DIFF
--- a/config/go.d/nginx.conf
+++ b/config/go.d/nginx.conf
@@ -160,3 +160,10 @@ jobs:
 
   - name: local
     url: http://127.0.0.1/stub_status
+
+  - name: local
+    url: http://127.0.0.1/nginx_status
+
+  - name: local
+    url: http://127.0.0.1/status
+


### PR DESCRIPTION
Two more `stub_status` locations are commonly used, `nginx_status` and `status`. This PR adds the relevant NGINX jobs.

Tested with Ubuntu 20.04 and NGINX 1.18.0. Also with the NGINX package provided by Bitnami.