### PR TITLE
feat(postgres): collect connections % per database

### DIFF
--- a/modules/postgres/README.md
+++ b/modules/postgres/README.md
@@ -27,6 +27,7 @@ All metrics have "postgres." prefix.
 | bgwriter_maxwritten_clean      |  global  |                                                  maxwritten                                                   |    events/s    |
 | bgwriter_buffers_backend_fsync |  global  |                                                     fsync                                                     |  operations/s  |
 | db_transactions                | database |                                              committed, rollback                                              | transactions/s |
+| db_connections_utilization     | database |                                                     used                                                      |   percentage   |
 | db_connections                 | database |                                                  connections                                                  |  connections   |
 | db_buffer_cache                | database |                                                   hit, miss                                                   |    blocks/s    |
 | db_read_operations             | database |                                               returned, fetched                                               |     rows/s     |

--- a/modules/postgres/charts.go
+++ b/modules/postgres/charts.go
@@ -19,6 +19,7 @@ const (
 	prioBGWriterMaxWrittenClean
 	prioBGWriterBackedFsync
 	prioDBTransactions
+	prioDBConnectionsUtilization
 	prioDBConnections
 	prioDBBufferCache
 	prioDBReadOperations
@@ -149,6 +150,7 @@ var (
 var (
 	dbChartsTmpl = module.Charts{
 		dbTransactionsChartTmpl.Copy(),
+		dbConnectionsUtilizationChartTmpl.Copy(),
 		dbConnectionsChartTmpl.Copy(),
 		dbBufferCacheChartTmpl.Copy(),
 		dbReadOpsChartTmpl.Copy(),
@@ -172,6 +174,17 @@ var (
 		Dims: module.Dims{
 			{ID: "db_%s_xact_commit", Name: "committed", Algo: module.Incremental},
 			{ID: "db_%s_xact_rollback", Name: "rollback", Algo: module.Incremental},
+		},
+	}
+	dbConnectionsUtilizationChartTmpl = module.Chart{
+		ID:       "db_%s_connections_utilization",
+		Title:    "Database connections utilization withing limits",
+		Units:    "percentage",
+		Fam:      "db connections",
+		Ctx:      "postgres.db_connections_utilization",
+		Priority: prioDBConnectionsUtilization,
+		Dims: module.Dims{
+			{ID: "db_%s_numbackends_utilization", Name: "used"},
 		},
 	}
 	dbConnectionsChartTmpl = module.Chart{

--- a/modules/postgres/collect_checkpoints.go
+++ b/modules/postgres/collect_checkpoints.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"strconv"
 )
 
 func (p *Postgres) collectCheckpoints(mx map[string]int64) error {
@@ -18,10 +17,5 @@ func (p *Postgres) collectCheckpoints(mx map[string]int64) error {
 	}
 	defer func() { _ = rows.Close() }()
 
-	return collectRows(rows, func(column, value string) error {
-		if v, err := strconv.ParseInt(value, 10, 64); err == nil {
-			mx[column] = v
-		}
-		return nil
-	})
+	return collectRows(rows, func(column, value string) { mx[column] = safeParseInt(value) })
 }

--- a/modules/postgres/collect_connections.go
+++ b/modules/postgres/collect_connections.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package postgres
 
 import (

--- a/modules/postgres/collect_connections.go
+++ b/modules/postgres/collect_connections.go
@@ -14,14 +14,14 @@ func (p *Postgres) collectConnection(mx map[string]int64) error {
 	if err := p.db.QueryRowContext(ctx, q).Scan(&v); err != nil {
 		return err
 	}
-	num, err := strconv.Atoi(v)
+	num, err := strconv.ParseInt(v, 10, 64)
 	if err != nil {
 		return err
 	}
 
 	if p.maxConnections != 0 {
-		mx["server_connections_available"] = int64(p.maxConnections - num)
-		mx["server_connections_utilization"] = int64((num * 100) / p.maxConnections)
+		mx["server_connections_available"] = p.maxConnections - num
+		mx["server_connections_utilization"] = calcPercentage(num, p.maxConnections)
 	}
 	mx["server_connections_used"] = int64(num)
 

--- a/modules/postgres/postgres.go
+++ b/modules/postgres/postgres.go
@@ -48,7 +48,7 @@ type Postgres struct {
 
 	//isSuperUser   bool
 	serverVersion  int
-	maxConnections int
+	maxConnections int64
 
 	relistDatabaseTime   time.Time
 	relistDatabaseEvery  time.Duration

--- a/modules/postgres/postgres_test.go
+++ b/modules/postgres/postgres_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -199,16 +198,6 @@ func TestPostgres_Collect(t *testing.T) {
 				},
 				check: func(t *testing.T, pg *Postgres) {
 					mx := pg.Collect()
-
-					m := mx
-					l := make([]string, 0)
-					for k := range m {
-						l = append(l, k)
-					}
-					sort.Strings(l)
-					for _, value := range l {
-						fmt.Println(fmt.Sprintf("\"%s\": %d,", value, m[value]))
-					}
 
 					expected := map[string]int64{
 						"buffers_alloc":                                            27295744,

--- a/modules/postgres/postgres_test.go
+++ b/modules/postgres/postgres_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -199,6 +200,16 @@ func TestPostgres_Collect(t *testing.T) {
 				check: func(t *testing.T, pg *Postgres) {
 					mx := pg.Collect()
 
+					m := mx
+					l := make([]string, 0)
+					for k := range m {
+						l = append(l, k)
+					}
+					sort.Strings(l)
+					for _, value := range l {
+						fmt.Println(fmt.Sprintf("\"%s\": %d,", value, m[value]))
+					}
+
 					expected := map[string]int64{
 						"buffers_alloc":                                            27295744,
 						"buffers_backend":                                          0,
@@ -209,8 +220,8 @@ func TestPostgres_Collect(t *testing.T) {
 						"checkpoint_write_time":                                    167,
 						"checkpoints_req":                                          16,
 						"checkpoints_timed":                                        1814,
-						"db_postgres_blks_hit":                                     9245,
-						"db_postgres_blks_read":                                    246,
+						"db_postgres_blks_hit":                                     1221125,
+						"db_postgres_blks_read":                                    3252,
 						"db_postgres_confl_bufferpin":                              0,
 						"db_postgres_confl_deadlock":                               0,
 						"db_postgres_confl_lock":                                   0,
@@ -234,17 +245,18 @@ func TestPostgres_Collect(t *testing.T) {
 						"db_postgres_lock_mode_ShareRowExclusiveLock_held":         0,
 						"db_postgres_lock_mode_ShareUpdateExclusiveLock_awaited":   0,
 						"db_postgres_lock_mode_ShareUpdateExclusiveLock_held":      0,
-						"db_postgres_numbackends":                                  2,
+						"db_postgres_numbackends":                                  3,
+						"db_postgres_numbackends_utilization":                      10,
 						"db_postgres_size":                                         8758051,
 						"db_postgres_temp_bytes":                                   0,
 						"db_postgres_temp_files":                                   0,
 						"db_postgres_tup_deleted":                                  0,
-						"db_postgres_tup_fetched":                                  3577,
+						"db_postgres_tup_fetched":                                  359833,
 						"db_postgres_tup_inserted":                                 0,
-						"db_postgres_tup_returned":                                 65095,
+						"db_postgres_tup_returned":                                 13207245,
 						"db_postgres_tup_updated":                                  0,
-						"db_postgres_xact_commit":                                  1636,
-						"db_postgres_xact_rollback":                                2,
+						"db_postgres_xact_commit":                                  1438660,
+						"db_postgres_xact_rollback":                                70,
 						"db_production_blks_hit":                                   0,
 						"db_production_blks_read":                                  0,
 						"db_production_confl_bufferpin":                            0,
@@ -270,7 +282,8 @@ func TestPostgres_Collect(t *testing.T) {
 						"db_production_lock_mode_ShareRowExclusiveLock_held":       0,
 						"db_production_lock_mode_ShareUpdateExclusiveLock_awaited": 0,
 						"db_production_lock_mode_ShareUpdateExclusiveLock_held":    1,
-						"db_production_numbackends":                                0,
+						"db_production_numbackends":                                1,
+						"db_production_numbackends_utilization":                    1,
 						"db_production_size":                                       8602115,
 						"db_production_temp_bytes":                                 0,
 						"db_production_temp_files":                                 0,

--- a/modules/postgres/testdata/v14.4/database_stats.txt
+++ b/modules/postgres/testdata/v14.4/database_stats.txt
@@ -1,4 +1,4 @@
-   datname    | numbackends | xact_commit | xact_rollback | blks_read | blks_hit | tup_returned | tup_fetched | tup_inserted | tup_updated | tup_deleted | conflicts |  size   | temp_files | temp_bytes | deadlocks
---------------+-------------+-------------+---------------+-----------+----------+--------------+-------------+--------------+-------------+-------------+-----------+---------+------------+------------+-----------
- postgres     |           2 |        1636 |             2 |       246 |     9245 |        65095 |        3577 |            0 |           0 |           0 |         0 | 8758051 |          0 |          0 |         0
- production   |           0 |           0 |             0 |         0 |        0 |            0 |           0 |            0 |           0 |           0 |         0 | 8602115 |          0 |          0 |         0
+  datname   | numbackends | datconnlimit | xact_commit | xact_rollback | blks_read | blks_hit | tup_returned | tup_fetched | tup_inserted | tup_updated | tup_deleted | conflicts |  size   | temp_files | temp_bytes | deadlocks
+------------+-------------+--------------+-------------+---------------+-----------+----------+--------------+-------------+--------------+-------------+-------------+-----------+---------+------------+------------+-----------
+ postgres   |           3 |           30 |     1438660 |            70 |      3252 |  1221125 |     13207245 |      359833 |            0 |           0 |           0 |         0 | 8758051 |          0 |          0 |         0
+ production |           1 |           -1 |           0 |             0 |         0 |        0 |            0 |           0 |            0 |           0 |           0 |         0 | 8602115 |          0 |          0 |         0


### PR DESCRIPTION
Part of netdata/netdata#13387

This PR implements collecting connections utilization per database. This is handy when `CONNECTION LIMIT` is set on database creation.