### PR TITLE
docker: remove data usage call

### DIFF
--- a/modules/docker/README.md
+++ b/modules/docker/README.md
@@ -23,8 +23,6 @@ All metrics have "docker." prefix.
 | unhealthy_containers | global |        unhealthy         | containers |
 | images               | global |     active, dangling     |   images   |
 | images_size          | global |           size           |     B      |
-| volumes              | global |     active, dangling     |   images   |
-| volumes_size         | global |           size           |     B      |
 
 ## Configuration
 

--- a/modules/docker/charts.go
+++ b/modules/docker/charts.go
@@ -10,8 +10,6 @@ const (
 	prioContainersUnhealthy
 	prioImagesCount
 	prioImagesSize
-	prioVolumesCount
-	prioVolumesSize
 )
 
 var charts = module.Charts{
@@ -21,9 +19,6 @@ var charts = module.Charts{
 
 	imagesCountChart.Copy(),
 	imagesSizeChart.Copy(),
-
-	volumesCountChart.Copy(),
-	volumesSizeChart.Copy(),
 }
 
 var (
@@ -88,33 +83,6 @@ var (
 		Priority: prioImagesSize,
 		Dims: module.Dims{
 			{ID: "images_size", Name: "size"},
-		},
-	}
-)
-
-var (
-	volumesCountChart = module.Chart{
-		ID:       "volumes_count",
-		Title:    "Number of volumes",
-		Units:    "volumes",
-		Fam:      "volumes",
-		Ctx:      "docker.volumes",
-		Priority: prioVolumesCount,
-		Type:     module.Stacked,
-		Dims: module.Dims{
-			{ID: "volumes_active", Name: "active"},
-			{ID: "volumes_dangling", Name: "dangling"},
-		},
-	}
-	volumesSizeChart = module.Chart{
-		ID:       "volumes_size",
-		Title:    "Volumes size",
-		Units:    "B",
-		Fam:      "volumes",
-		Ctx:      "docker.volumes_size",
-		Priority: prioVolumesSize,
-		Dims: module.Dims{
-			{ID: "volumes_size", Name: "size"},
 		},
 	}
 )

--- a/modules/docker/docker.go
+++ b/modules/docker/docker.go
@@ -15,9 +15,6 @@ import (
 
 func init() {
 	module.Register("docker", module.Creator{
-		Defaults: module.Defaults{
-			UpdateEvery: 5,
-		},
 		Create: func() module.Module { return New() },
 	})
 }
@@ -26,7 +23,7 @@ func New() *Docker {
 	return &Docker{
 		Config: Config{
 			Address: docker.DefaultDockerHost,
-			Timeout: web.Duration{Duration: time.Second * 1},
+			Timeout: web.Duration{Duration: time.Second * 5},
 		},
 		charts: charts.Copy(),
 		newClient: func(cfg Config) (dockerClient, error) {
@@ -51,7 +48,8 @@ type (
 		client    dockerClient
 	}
 	dockerClient interface {
-		DiskUsage(ctx context.Context) (types.DiskUsage, error)
+		Info(context.Context) (types.Info, error)
+		ImageList(context.Context, types.ImageListOptions) ([]types.ImageSummary, error)
 		ContainerList(context.Context, types.ContainerListOptions) ([]types.Container, error)
 		Close() error
 	}


### PR DESCRIPTION
[Data usage call](https://docs.docker.com/engine/api/v1.41/#tag/System/operation/SystemDataUsage) (`docker system df`) consumes a lot of CPU. Unfortunately, that was the only way to collect volume data usage.

Before/After
<img width="713" alt="Screenshot 2022-08-26 at 12 33 35" src="https://user-images.githubusercontent.com/22274335/186874800-13fd205b-8140-405d-b069-8001b9d75b1b.png">


