### PR TITLE
[phpfpm] Added ability to directly connect to a TCP address:port and modify status path

### DIFF
--- a/config/go.d/phpfpm.conf
+++ b/config/go.d/phpfpm.conf
@@ -137,6 +137,18 @@
 #    Syntax:
 #      socket: /var/run/php/php-fpm.sock
 #
+#  - address
+#    Connect to address
+#    Syntax:
+#      address: localhost:9000
+#      address: 203.0.113.10:9000
+#      address: "[2001:db8::1]:9000"
+#
+#  - fcgi_path
+#    PHP-FPM status path
+#    Syntax:
+#      fcgi_path: /status
+#
 # [ JOB defaults ]:
 #  url: http://localhost/status?full&json
 #  timeout: 1

--- a/modules/phpfpm/README.md
+++ b/modules/phpfpm/README.md
@@ -17,7 +17,6 @@ This module will monitor one or more `php-fpm` instances, depending on your conf
 - `php-fpm` with enabled `status` page:
     - open the `php-fpm` configuration file.
     - inside this file, find and uncomment the variable `pm.status_path = /status`.
-- access to `status` page via web server.
 
 ## Charts
 
@@ -40,7 +39,7 @@ cd /etc/netdata # Replace this path with your Netdata config directory
 sudo ./edit-config go.d/phpfpm.conf
 ```
 
-Needs only `url` or `socket`. Here is an example for local and remote servers:
+Needs only `url`, `socket` or `address`. Here is an example for local and remote servers:
 
 ```yaml
 jobs:
@@ -55,6 +54,9 @@ jobs:
 
   - name: remote
     url: http://203.0.113.10/status?full&json
+
+  - name: remote
+    address: 203.0.113.10:9000
 ```
 
 For all available options please see

--- a/modules/phpfpm/client.go
+++ b/modules/phpfpm/client.go
@@ -189,4 +189,3 @@ func (c *tcpClient) getStatus() (*status, error) {
 	}
 	return st, nil
 }
-

--- a/modules/phpfpm/client.go
+++ b/modules/phpfpm/client.go
@@ -104,13 +104,13 @@ type socketClient struct {
 	env     map[string]string
 }
 
-func newSocketClient(socket string, timeout time.Duration) *socketClient {
+func newSocketClient(socket string, timeout time.Duration, fcgiPath string) *socketClient {
 	return &socketClient{
 		socket:  socket,
 		timeout: timeout,
 		env: map[string]string{
-			"SCRIPT_NAME":     "/status",
-			"SCRIPT_FILENAME": "/status",
+			"SCRIPT_NAME":     fcgiPath,
+			"SCRIPT_FILENAME": fcgiPath,
 			"SERVER_SOFTWARE": "go / fcgiclient ",
 			"REMOTE_ADDR":     "127.0.0.1",
 			"QUERY_STRING":    "json&full",
@@ -143,3 +143,50 @@ func (c *socketClient) getStatus() (*status, error) {
 	}
 	return st, nil
 }
+
+type tcpClient struct {
+	address string
+	timeout time.Duration
+	env     map[string]string
+}
+
+func newTcpClient(address string, timeout time.Duration, fcgiPath string) *tcpClient {
+	return &tcpClient{
+		address: address,
+		timeout: timeout,
+		env: map[string]string{
+			"SCRIPT_NAME":     fcgiPath,
+			"SCRIPT_FILENAME": fcgiPath,
+			"SERVER_SOFTWARE": "go / fcgiclient ",
+			"REMOTE_ADDR":     "127.0.0.1",
+			"QUERY_STRING":    "json&full",
+			"REQUEST_METHOD":  "GET",
+			"CONTENT_TYPE":    "application/json",
+		},
+	}
+}
+
+func (c *tcpClient) getStatus() (*status, error) {
+	client, err := fcgiclient.DialTimeout("tcp", c.address, c.timeout)
+	if err != nil {
+		return nil, fmt.Errorf("error on connecting to address '%s': %v", c.address, err)
+	}
+	defer client.Close()
+
+	resp, err := client.Get(c.env)
+	if err != nil {
+		return nil, fmt.Errorf("error on getting data from address '%s': %v", c.address, err)
+	}
+
+	content, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error on reading response from address '%s': %v", c.address, err)
+	}
+
+	st := &status{}
+	if err := json.Unmarshal(content, st); err != nil {
+		return nil, fmt.Errorf("error on decoding response from address '%s': %v", c.address, err)
+	}
+	return st, nil
+}
+

--- a/modules/phpfpm/init.go
+++ b/modules/phpfpm/init.go
@@ -12,6 +12,9 @@ func (p Phpfpm) initClient() (client, error) {
 	if p.Socket != "" {
 		return p.initSocketClient()
 	}
+	if p.Address != "" {
+		return p.initTcpClient()
+	}
 	if p.URL != "" {
 		return p.initHTTPClient()
 	}
@@ -34,5 +37,14 @@ func (p Phpfpm) initSocketClient() (*socketClient, error) {
 	}
 	p.Debugf("using socket client: %s", p.Socket)
 	p.Debugf("using timeout: %s", p.Timeout.Duration)
-	return newSocketClient(p.Socket, p.Timeout.Duration), nil
+	p.Debugf("using fcgi path: %s", p.FcgiPath)
+	return newSocketClient(p.Socket, p.Timeout.Duration, p.FcgiPath), nil
 }
+
+func (p Phpfpm) initTcpClient() (*tcpClient, error) {
+	p.Debugf("using tcp client: %s", p.Address)
+	p.Debugf("using timeout: %s", p.Timeout.Duration)
+	p.Debugf("using fcgi path: %s", p.FcgiPath)
+	return newTcpClient(p.Address, p.Timeout.Duration, p.FcgiPath), nil
+}
+

--- a/modules/phpfpm/init.go
+++ b/modules/phpfpm/init.go
@@ -47,4 +47,3 @@ func (p Phpfpm) initTcpClient() (*tcpClient, error) {
 	p.Debugf("using fcgi path: %s", p.FcgiPath)
 	return newTcpClient(p.Address, p.Timeout.Duration, p.FcgiPath), nil
 }
-

--- a/modules/phpfpm/phpfpm.go
+++ b/modules/phpfpm/phpfpm.go
@@ -25,6 +25,7 @@ func New() *Phpfpm {
 					Timeout: web.Duration{Duration: time.Second},
 				},
 			},
+			FcgiPath: "/status",
 		},
 	}
 }
@@ -33,6 +34,8 @@ type (
 	Config struct {
 		web.HTTP `yaml:",inline"`
 		Socket   string `yaml:"socket"`
+		Address  string `yaml:"address"`
+		FcgiPath string `yaml:"fcgi_path"`
 	}
 	Phpfpm struct {
 		module.Base


### PR DESCRIPTION
With this change, you can monitor non-socket PHP-FPM instances (PHP-FPM does not allow you to listen on a socket and a port at the same time) without a webserver.