### PR TITLE
make k8s_* collectors chart priority higher than cgroups

### DIFF
--- a/modules/k8s_kubelet/kubelet.go
+++ b/modules/k8s_kubelet/kubelet.go
@@ -16,7 +16,7 @@ func init() {
 	creator := module.Creator{
 		Defaults: module.Defaults{
 			// NETDATA_CHART_PRIO_CGROUPS_CONTAINERS        40000
-			Priority: 39900,
+			Priority: 40100,
 		},
 		Create: func() module.Module { return New() },
 	}

--- a/modules/k8s_kubeproxy/kubeproxy.go
+++ b/modules/k8s_kubeproxy/kubeproxy.go
@@ -20,7 +20,7 @@ func init() {
 	creator := module.Creator{
 		Defaults: module.Defaults{
 			// NETDATA_CHART_PRIO_CGROUPS_CONTAINERS        40000
-			Priority: 39900,
+			Priority: 40100,
 		},
 		Create: func() module.Module { return New() },
 	}

--- a/modules/k8s_state/charts.go
+++ b/modules/k8s_state/charts.go
@@ -11,10 +11,10 @@ import (
 )
 
 // NETDATA_CHART_PRIO_CGROUPS_CONTAINERS 40000
-const prioDiscoveryDiscovererState = 39999
+const prioDiscoveryDiscovererState = 40999
 
 const (
-	prioNodeAllocatableCPURequestsUtil = 38100 + iota
+	prioNodeAllocatableCPURequestsUtil = 40100 + iota
 	prioNodeAllocatableCPURequestsUsed
 	prioNodeAllocatableCPULimitsUtil
 	prioNodeAllocatableCPULimitsUsed


### PR DESCRIPTION
Fixes: netdata/netdata#13663

Waiting for an [answer](https://github.com/netdata/netdata/issues/13663#issuecomment-1246630763) before merging.