### PR TITLE
feat: add nvidia_smi collector

### DIFF
--- a/config/go.d.conf
+++ b/config/go.d.conf
@@ -50,6 +50,7 @@ modules:
 #  mysql: yes
 #  nginx: yes
 #  nginxvts: yes
+#  nvidia_smi: no
 #  openvpn: no
 #  openvpn_status_log: yes
 #  pgbouncer: yes

--- a/modules/init.go
+++ b/modules/init.go
@@ -41,6 +41,7 @@ import (
 	_ "github.com/netdata/go.d.plugin/modules/mysql"
 	_ "github.com/netdata/go.d.plugin/modules/nginx"
 	_ "github.com/netdata/go.d.plugin/modules/nginxvts"
+	_ "github.com/netdata/go.d.plugin/modules/nvidia_smi"
 	_ "github.com/netdata/go.d.plugin/modules/openvpn"
 	_ "github.com/netdata/go.d.plugin/modules/openvpn_status_log"
 	_ "github.com/netdata/go.d.plugin/modules/pgbouncer"

--- a/modules/nvidia_smi/README.md
+++ b/modules/nvidia_smi/README.md
@@ -1,0 +1,64 @@
+<!--
+title: "Nvidia GPU monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/modules/nvidia_smi/README.md
+description: "Monitors performance metrics using the nvidia-smi CLI tool."
+sidebar_label: "Nvidia GPUs"
+-->
+
+# Nvidia GPU monitoring with Netdata
+
+Monitors performance metrics (memory usage, fan speed, pcie bandwidth utilization, temperature, etc.)
+using the [nvidia-smi](https://developer.nvidia.com/nvidia-system-management-interface) CLI tool.
+
+> **Warning**: under development, collects fewer metrics then python version.
+
+## Metrics
+
+All metrics have "nvidia_smi." prefix.
+
+Labels per scope:
+
+- gpu: product_name, product_brand.
+
+| Metric                        | Scope |        Dimensions        |  Units  |
+|-------------------------------|:-----:|:------------------------:|:-------:|
+| gpu_pcie_bandwidth_usage      |  gpu  |          rx, tx          |   B/s   |
+| gpu_fan_speed_perc            |  gpu  |        fan_speed         |    %    |
+| gpu_utilization               |  gpu  |           gpu            |    %    |
+| gpu_memory_utilization        |  gpu  |          memory          |    %    |
+| gpu_decoder_utilization       |  gpu  |         decoder          |    %    |
+| gpu_encoder_utilization       |  gpu  |         encoder          |    %    |
+| gpu_frame_buffer_memory_usage |  gpu  |   free, used, reserved   |    %    |
+| gpu_bar1_memory_usage         |  gpu  |        free, used        |    %    |
+| gpu_temperature               |  gpu  |       temperature        | Celsius |
+| gpu_clock_freq                |  gpu  | graphics, video, sm, mem |   MHz   |
+| gpu_power_draw                |  gpu  |        power_draw        |  Watts  |
+| gpu_performance_state         |  gpu  |          P0-P15          |  state  |
+
+## Configuration
+
+No configuration required.
+
+## Troubleshooting
+
+To troubleshoot issues with the `nvidia_smi` collector, run the `go.d.plugin` with the debug option enabled. The
+output should give you clues as to why the collector isn't working.
+
+- Navigate to the `plugins.d` directory, usually at `/usr/libexec/netdata/plugins.d/`. If that's not the case on
+  your system, open `netdata.conf` and look for the `plugins` setting under `[directories]`.
+
+  ```bash
+  cd /usr/libexec/netdata/plugins.d/
+  ```
+
+- Switch to the `netdata` user.
+
+  ```bash
+  sudo -u netdata -s
+  ```
+
+- Run the `go.d.plugin` to debug the collector:
+
+  ```bash
+  ./go.d.plugin -d -m nvidia_smi
+  ```

--- a/modules/nvidia_smi/README.md
+++ b/modules/nvidia_smi/README.md
@@ -28,8 +28,8 @@ Labels per scope:
 | gpu_memory_utilization        |  gpu  |          memory          |    %    |
 | gpu_decoder_utilization       |  gpu  |         decoder          |    %    |
 | gpu_encoder_utilization       |  gpu  |         encoder          |    %    |
-| gpu_frame_buffer_memory_usage |  gpu  |   free, used, reserved   |    %    |
-| gpu_bar1_memory_usage         |  gpu  |        free, used        |    %    |
+| gpu_frame_buffer_memory_usage |  gpu  |   free, used, reserved   |    B    |
+| gpu_bar1_memory_usage         |  gpu  |        free, used        |    B    |
 | gpu_temperature               |  gpu  |       temperature        | Celsius |
 | gpu_clock_freq                |  gpu  | graphics, video, sm, mem |   MHz   |
 | gpu_power_draw                |  gpu  |        power_draw        |  Watts  |

--- a/modules/nvidia_smi/charts.go
+++ b/modules/nvidia_smi/charts.go
@@ -1,0 +1,240 @@
+package nvidia_smi
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/netdata/go.d.plugin/agent/module"
+)
+
+const (
+	prioGPUPCIBandwidthUsage = module.Priority + iota
+	prioGPUFanSpeed
+	prioGPUUtilization
+	prioGPUMemUtilization
+	prioGPUDecoderUtilization
+	prioGPUEncoderUtilization
+	prioGPUFBMemoryUsage
+	prioGPUBAR1MemoryUsage
+	prioGPUTemperatureChart
+	prioGPUClockFreq
+	prioGPUPowerDraw
+	prioGPUPerformanceState
+)
+
+var gpuCharts = module.Charts{
+	gpuPCIBandwidthUsageChartTmpl.Copy(),
+	gpuFanSpeedPercChartTmpl.Copy(),
+	gpuUtilizationChartTmpl.Copy(),
+	gpuMemUtilizationChartTmpl.Copy(),
+	gpuDecoderUtilizationChartTmpl.Copy(),
+	gpuEncoderUtilizationChartTmpl.Copy(),
+	gpuFrameBufferMemoryUsageChartTmpl.Copy(),
+	gpuBAR1MemoryUsageChartTmpl.Copy(),
+	gpuTemperatureChartTmpl.Copy(),
+	gpuClockFreqChartTmpl.Copy(),
+	gpuPowerDrawChartTmpl.Copy(),
+	gpuPerformanceStateChartTmpl.Copy(),
+}
+
+var (
+	gpuPCIBandwidthUsageChartTmpl = module.Chart{
+		ID:       "gpu_%s_pcie_bandwidth_usage",
+		Title:    "PCI Express Bandwidth Usage",
+		Units:    "B/s",
+		Fam:      "pcie bandwidth",
+		Ctx:      "nvidia_smi.gpu_pcie_bandwidth_usage",
+		Type:     module.Area,
+		Priority: prioGPUPCIBandwidthUsage,
+		Dims: module.Dims{
+			{ID: "gpu_%s_pcie_bandwidth_usage_rx", Name: "rx"},
+			{ID: "gpu_%s_pcie_bandwidth_usage_tx", Name: "tx", Mul: -1},
+		},
+	}
+	gpuFanSpeedPercChartTmpl = module.Chart{
+		ID:       "gpu_%s_fan_speed_perc",
+		Title:    "Fan speed",
+		Units:    "%",
+		Fam:      "fan speed",
+		Ctx:      "nvidia_smi.gpu_fan_speed_perc",
+		Priority: prioGPUFanSpeed,
+		Dims: module.Dims{
+			{ID: "gpu_%s_fan_speed_perc", Name: "fan_speed"},
+		},
+	}
+	gpuUtilizationChartTmpl = module.Chart{
+		ID:       "gpu_%s_gpu_utilization",
+		Title:    "GPU utilization",
+		Units:    "%",
+		Fam:      "gpu utilization",
+		Ctx:      "nvidia_smi.gpu_utilization",
+		Priority: prioGPUUtilization,
+		Dims: module.Dims{
+			{ID: "gpu_%s_gpu_utilization", Name: "gpu"},
+		},
+	}
+	gpuMemUtilizationChartTmpl = module.Chart{
+		ID:       "gpu_%s_memory_utilization",
+		Title:    "Memory utilization",
+		Units:    "%",
+		Fam:      "mem utilization",
+		Ctx:      "nvidia_smi.gpu_memory_utilization",
+		Priority: prioGPUMemUtilization,
+		Dims: module.Dims{
+			{ID: "gpu_%s_mem_utilization", Name: "memory"},
+		},
+	}
+	gpuDecoderUtilizationChartTmpl = module.Chart{
+		ID:       "gpu_%s_decoder_utilization",
+		Title:    "Decoder utilization",
+		Units:    "%",
+		Fam:      "dec utilization",
+		Ctx:      "nvidia_smi.gpu_decoder_utilization",
+		Priority: prioGPUDecoderUtilization,
+		Dims: module.Dims{
+			{ID: "gpu_%s_decoder_utilization", Name: "decoder"},
+		},
+	}
+	gpuEncoderUtilizationChartTmpl = module.Chart{
+		ID:       "gpu_%s_encoder_utilization",
+		Title:    "Encoder utilization",
+		Units:    "%",
+		Fam:      "enc utilization",
+		Ctx:      "nvidia_smi.gpu_encoder_utilization",
+		Priority: prioGPUEncoderUtilization,
+		Dims: module.Dims{
+			{ID: "gpu_%s_encoder_utilization", Name: "encoder"},
+		},
+	}
+	gpuFrameBufferMemoryUsageChartTmpl = module.Chart{
+		ID:       "gpu_%s_frame_buffer_memory_usage",
+		Title:    "Frame buffer memory usage",
+		Units:    "B",
+		Fam:      "fb mem usage",
+		Ctx:      "nvidia_smi.gpu_frame_buffer_memory_usage",
+		Type:     module.Stacked,
+		Priority: prioGPUFBMemoryUsage,
+		Dims: module.Dims{
+			{ID: "gpu_%s_frame_buffer_memory_usage_free", Name: "free"},
+			{ID: "gpu_%s_frame_buffer_memory_usage_used", Name: "used"},
+			{ID: "gpu_%s_frame_buffer_memory_usage_reserved", Name: "reserved"},
+		},
+	}
+	gpuBAR1MemoryUsageChartTmpl = module.Chart{
+		ID:       "gpu_%s_bar1_memory_usage",
+		Title:    "BAR1 memory usage",
+		Units:    "B",
+		Fam:      "bar1 mem usage",
+		Ctx:      "nvidia_smi.gpu_bar1_memory_usage",
+		Type:     module.Stacked,
+		Priority: prioGPUBAR1MemoryUsage,
+		Dims: module.Dims{
+			{ID: "gpu_%s_bar1_memory_usage_free", Name: "free"},
+			{ID: "gpu_%s_bar1_memory_usage_used", Name: "used"},
+		},
+	}
+	gpuTemperatureChartTmpl = module.Chart{
+		ID:       "gpu_%s_temperature",
+		Title:    "Temperature",
+		Units:    "Celsius",
+		Fam:      "temperature",
+		Ctx:      "nvidia_smi.gpu_temperature",
+		Priority: prioGPUTemperatureChart,
+		Dims: module.Dims{
+			{ID: "gpu_%s_temperature", Name: "temperature"},
+		},
+	}
+	gpuClockFreqChartTmpl = module.Chart{
+		ID:       "gpu_%s_clock_freq",
+		Title:    "Clock current frequency",
+		Units:    "MHz",
+		Fam:      "clocks",
+		Ctx:      "nvidia_smi.gpu_clock_freq",
+		Priority: prioGPUClockFreq,
+		Dims: module.Dims{
+			{ID: "gpu_%s_graphics_clock", Name: "graphics"},
+			{ID: "gpu_%s_video_clock", Name: "video"},
+			{ID: "gpu_%s_sm_clock", Name: "sm"},
+			{ID: "gpu_%s_mem_clock", Name: "mem"},
+		},
+	}
+	gpuPowerDrawChartTmpl = module.Chart{
+		ID:       "gpu_%s_power_draw",
+		Title:    "Power draw",
+		Units:    "Watts",
+		Fam:      "power draw",
+		Ctx:      "nvidia_smi.gpu_power_draw",
+		Priority: prioGPUPowerDraw,
+		Dims: module.Dims{
+			{ID: "gpu_%s_power_draw", Name: "power_draw"},
+		},
+	}
+	gpuPerformanceStateChartTmpl = module.Chart{
+		ID:       "gpu_%s_performance_state",
+		Title:    "Performance state",
+		Units:    "state",
+		Fam:      "performance state",
+		Ctx:      "nvidia_smi.gpu_performance_state",
+		Priority: prioGPUPerformanceState,
+		Dims: module.Dims{
+			{ID: "gpu_%s_performance_state_P0", Name: "P0"},
+			{ID: "gpu_%s_performance_state_P1", Name: "P1"},
+			{ID: "gpu_%s_performance_state_P2", Name: "P2"},
+			{ID: "gpu_%s_performance_state_P3", Name: "P3"},
+			{ID: "gpu_%s_performance_state_P4", Name: "P4"},
+			{ID: "gpu_%s_performance_state_P5", Name: "P5"},
+			{ID: "gpu_%s_performance_state_P6", Name: "P6"},
+			{ID: "gpu_%s_performance_state_P7", Name: "P7"},
+			{ID: "gpu_%s_performance_state_P8", Name: "P8"},
+			{ID: "gpu_%s_performance_state_P9", Name: "P9"},
+			{ID: "gpu_%s_performance_state_P10", Name: "P10"},
+			{ID: "gpu_%s_performance_state_P11", Name: "P11"},
+			{ID: "gpu_%s_performance_state_P12", Name: "P12"},
+			{ID: "gpu_%s_performance_state_P13", Name: "P13"},
+			{ID: "gpu_%s_performance_state_P14", Name: "P14"},
+			{ID: "gpu_%s_performance_state_P15", Name: "P15"},
+		},
+	}
+)
+
+func newGPUCharts(gpu xmlGPUInfo) *module.Charts {
+	charts := gpuCharts.Copy()
+	if !isValidValue(gpu.FanSpeed) {
+		_ = charts.Remove(gpuFanSpeedPercChartTmpl.ID)
+	}
+	if !isValidValue(gpu.PowerReadings.PowerDraw) {
+		_ = charts.Remove(gpuPowerDrawChartTmpl.ID)
+	}
+
+	for _, c := range *charts {
+		c.ID = fmt.Sprintf(c.ID, strings.ToLower(gpu.UUID))
+		c.Labels = []module.Label{
+			{Key: "product_name", Value: gpu.ProductName},
+			{Key: "product_brand", Value: gpu.ProductBrand},
+		}
+		for _, d := range c.Dims {
+			d.ID = fmt.Sprintf(d.ID, gpu.UUID)
+		}
+	}
+
+	return charts
+}
+
+func (nv *NvidiaSMI) addGPUCharts(gpu xmlGPUInfo) {
+	charts := newGPUCharts(gpu)
+
+	if err := nv.Charts().Add(*charts...); err != nil {
+		nv.Warning(err)
+	}
+}
+
+func (nv *NvidiaSMI) removeGPUCharts(uuid string) {
+	prefix := "gpu_" + strings.ToLower(uuid)
+
+	for _, c := range *nv.Charts() {
+		if strings.HasPrefix(c.ID, prefix) {
+			c.MarkRemove()
+			c.MarkNotCreated()
+		}
+	}
+}

--- a/modules/nvidia_smi/collect.go
+++ b/modules/nvidia_smi/collect.go
@@ -1,0 +1,110 @@
+package nvidia_smi
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func (nv *NvidiaSMI) collect() (map[string]int64, error) {
+	if nv.exec == nil {
+		return nil, errors.New("")
+	}
+
+	mx := make(map[string]int64)
+
+	bs, err := nv.exec.queryXML()
+	if err != nil {
+		return nil, fmt.Errorf("error on quering GPU info: %v", err)
+	}
+
+	info := &xmlInfo{}
+	if err := xml.Unmarshal(bs, info); err != nil {
+		return nil, fmt.Errorf("error on unmarshaling GPU info response: %v", err)
+	}
+
+	nv.collectXMLInfo(mx, info)
+
+	return mx, nil
+}
+
+func (nv *NvidiaSMI) collectXMLInfo(mx map[string]int64, info *xmlInfo) {
+	seen := make(map[string]bool)
+
+	for _, gpu := range info.GPUs {
+		if !isValidValue(gpu.UUID) {
+			continue
+		}
+
+		seen[gpu.UUID] = true
+
+		if !nv.gpus[gpu.UUID] {
+			nv.gpus[gpu.UUID] = true
+			nv.addGPUCharts(gpu)
+		}
+
+		px := "gpu_" + gpu.UUID + "_"
+
+		addMetric(mx, px+"pcie_bandwidth_usage_rx", gpu.PCI.RxUtil, 1024)
+		addMetric(mx, px+"pcie_bandwidth_usage_tx", gpu.PCI.TxUtil, 1024)
+		addMetric(mx, px+"fan_speed_perc", gpu.FanSpeed, 0)
+		addMetric(mx, px+"gpu_utilization", gpu.Utilization.GpuUtil, 0)
+		addMetric(mx, px+"mem_utilization", gpu.Utilization.MemoryUtil, 0)
+		addMetric(mx, px+"decoder_utilization", gpu.Utilization.DecoderUtil, 0)
+		addMetric(mx, px+"encoder_utilization", gpu.Utilization.EncoderUtil, 0)
+		addMetric(mx, px+"frame_buffer_memory_usage_free", gpu.FBMemoryUsage.Free, 1024*1024)
+		addMetric(mx, px+"frame_buffer_memory_usage_used", gpu.FBMemoryUsage.Used, 1024*1024)
+		addMetric(mx, px+"frame_buffer_memory_usage_reserved", gpu.FBMemoryUsage.Reserved, 1024*1024)
+		addMetric(mx, px+"bar1_memory_usage_free", gpu.Bar1MemoryUsage.Free, 1024*1024)
+		addMetric(mx, px+"bar1_memory_usage_used", gpu.Bar1MemoryUsage.Used, 1024*1024)
+		addMetric(mx, px+"temperature", gpu.Temperature.GpuTemp, 0)
+		addMetric(mx, px+"graphics_clock", gpu.Clocks.GraphicsClock, 0)
+		addMetric(mx, px+"video_clock", gpu.Clocks.VideoClock, 0)
+		addMetric(mx, px+"sm_clock", gpu.Clocks.SmClock, 0)
+		addMetric(mx, px+"mem_clock", gpu.Clocks.MemClock, 0)
+		addMetric(mx, px+"power_draw", gpu.PowerReadings.PowerDraw, 0)
+		for i := 0; i < 16; i++ {
+			if s := "P" + strconv.Itoa(i); gpu.PerformanceState == s {
+				mx[px+"performance_state_"+s] = 1
+			} else {
+				mx[px+"performance_state_"+s] = 0
+			}
+		}
+	}
+
+	for uuid := range nv.gpus {
+		if !seen[uuid] {
+			delete(nv.gpus, uuid)
+			nv.removeGPUCharts(uuid)
+		}
+	}
+}
+
+func addMetric(mx map[string]int64, key, value string, mul int) {
+	if !isValidValue(value) {
+		return
+	}
+
+	var i int
+	if i = strings.IndexByte(value, ' '); i == -1 {
+		return
+	}
+	value = value[:i]
+
+	v, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return
+	}
+
+	if mul > 0 {
+		v *= float64(mul)
+	}
+
+	mx[key] = int64(v)
+}
+
+func isValidValue(v string) bool {
+	return v != "" && v != "N/A"
+}

--- a/modules/nvidia_smi/exec.go
+++ b/modules/nvidia_smi/exec.go
@@ -1,0 +1,94 @@
+package nvidia_smi
+
+import (
+	"context"
+	"os/exec"
+	"time"
+)
+
+func newNvidiaSMIExec(path string, cfg Config) (*nvidiaSMIExec, error) {
+	return &nvidiaSMIExec{
+		binPath: path,
+		timeout: cfg.Timeout.Duration,
+	}, nil
+}
+
+type nvidiaSMIExec struct {
+	binPath string
+	timeout time.Duration
+}
+
+func (e *nvidiaSMIExec) queryXML() ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
+	defer cancel()
+
+	return exec.CommandContext(ctx, e.binPath, "-x", "-q").Output()
+}
+
+type (
+	xmlInfo struct {
+		GPUs []xmlGPUInfo `xml:"gpu"`
+	}
+	xmlGPUInfo struct {
+		ID                  string `xml:"id,attr"`
+		ProductName         string `xml:"product_name"`
+		ProductBrand        string `xml:"product_brand"`
+		ProductArchitecture string `xml:"product_architecture"`
+		UUID                string `xml:"uuid"`
+		FanSpeed            string `xml:"fan_speed"`
+		PerformanceState    string `xml:"performance_state"`
+		PCI                 struct {
+			TxUtil string `xml:"tx_util"`
+			RxUtil string `xml:"rx_util"`
+		} `xml:"pci"`
+		Utilization struct {
+			GpuUtil     string `xml:"gpu_util"`
+			MemoryUtil  string `xml:"memory_util"`
+			EncoderUtil string `xml:"encoder_util"`
+			DecoderUtil string `xml:"decoder_util"`
+		} `xml:"utilization"`
+		FBMemoryUsage struct {
+			Total    string `xml:"total"`
+			Reserved string `xml:"reserved"`
+			Used     string `xml:"used"`
+			Free     string `xml:"free"`
+		} `xml:"fb_memory_usage"`
+		Bar1MemoryUsage struct {
+			Total string `xml:"total"`
+			Used  string `xml:"used"`
+			Free  string `xml:"free"`
+		} `xml:"bar1_memory_usage"`
+		Temperature struct {
+			GpuTemp                string `xml:"gpu_temp"`
+			GpuTempMaxThreshold    string `xml:"gpu_temp_max_threshold"`
+			GpuTempSlowThreshold   string `xml:"gpu_temp_slow_threshold"`
+			GpuTempMaxGpuThreshold string `xml:"gpu_temp_max_gpu_threshold"`
+			GpuTargetTemperature   string `xml:"gpu_target_temperature"`
+			MemoryTemp             string `xml:"memory_temp"`
+			GpuTempMaxMemThreshold string `xml:"gpu_temp_max_mem_threshold"`
+		} `xml:"temperature"`
+		Clocks struct {
+			GraphicsClock string `xml:"graphics_clock"`
+			SmClock       string `xml:"sm_clock"`
+			MemClock      string `xml:"mem_clock"`
+			VideoClock    string `xml:"video_clock"`
+		} `xml:"clocks"`
+		PowerReadings struct {
+			PowerState         string `xml:"power_state"`
+			PowerManagement    string `xml:"power_management"`
+			PowerDraw          string `xml:"power_draw"`
+			PowerLimit         string `xml:"power_limit"`
+			DefaultPowerLimit  string `xml:"default_power_limit"`
+			EnforcedPowerLimit string `xml:"enforced_power_limit"`
+			MinPowerLimit      string `xml:"min_power_limit"`
+			MaxPowerLimit      string `xml:"max_power_limit"`
+		} `xml:"power_readings"`
+		Processes struct {
+			ProcessInfo []struct {
+				PID         string `xml:"pid"`
+				ProcessName string `xml:"process_name"`
+				UsedMemory  string `xml:"used_memory"`
+			} `sml:"process_info"`
+		} `xml:"processes"`
+	}
+)

--- a/modules/nvidia_smi/init.go
+++ b/modules/nvidia_smi/init.go
@@ -1,0 +1,20 @@
+package nvidia_smi
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func (nv *NvidiaSMI) initNvidiaSMIExec() (nvidiaSMI, error) {
+	binPath := nv.BinaryPath
+	if _, err := os.Stat(binPath); os.IsNotExist(err) {
+		path, err := exec.LookPath(nv.binName)
+		if err != nil {
+			return nil, fmt.Errorf("error on lookup '%s': %v", nv.binName, err)
+		}
+		binPath = path
+	}
+
+	return newNvidiaSMIExec(binPath, nv.Config)
+}

--- a/modules/nvidia_smi/nvidia_smi.go
+++ b/modules/nvidia_smi/nvidia_smi.go
@@ -1,0 +1,87 @@
+package nvidia_smi
+
+import (
+	"time"
+
+	"github.com/netdata/go.d.plugin/agent/module"
+	"github.com/netdata/go.d.plugin/pkg/web"
+)
+
+func init() {
+	module.Register("nvidia_smi", module.Creator{
+		Defaults: module.Defaults{
+			Disabled:    true,
+			UpdateEvery: 5,
+		},
+		Create: func() module.Module { return New() },
+	})
+}
+
+func New() *NvidiaSMI {
+	return &NvidiaSMI{
+		Config: Config{
+			Timeout: web.Duration{Duration: time.Second * 5},
+		},
+		binName: "nvidia-smi",
+		charts:  &module.Charts{},
+		gpus:    make(map[string]bool),
+	}
+
+}
+
+type Config struct {
+	Timeout    web.Duration
+	BinaryPath string `yaml:"binary_path"`
+}
+
+type (
+	NvidiaSMI struct {
+		module.Base
+		Config `yaml:",inline"`
+
+		charts *module.Charts
+
+		binName string
+		exec    nvidiaSMI
+
+		gpus map[string]bool
+	}
+	nvidiaSMI interface {
+		queryXML() ([]byte, error)
+	}
+)
+
+func (nv *NvidiaSMI) Init() bool {
+	if nv.exec == nil {
+		smi, err := nv.initNvidiaSMIExec()
+		if err != nil {
+			nv.Error(err)
+			return false
+		}
+		nv.exec = smi
+	}
+
+	return true
+}
+
+func (nv *NvidiaSMI) Check() bool {
+	return len(nv.Collect()) > 0
+}
+
+func (nv *NvidiaSMI) Charts() *module.Charts {
+	return nv.charts
+}
+
+func (nv *NvidiaSMI) Collect() map[string]int64 {
+	mx, err := nv.collect()
+	if err != nil {
+		nv.Error(err)
+	}
+
+	if len(mx) == 0 {
+		return nil
+	}
+	return mx
+}
+
+func (nv *NvidiaSMI) Cleanup() {}

--- a/modules/nvidia_smi/nvidia_smi_test.go
+++ b/modules/nvidia_smi/nvidia_smi_test.go
@@ -1,0 +1,296 @@
+package nvidia_smi
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	dataRTX2080Win, _ = os.ReadFile("testdata/rtx-2080-win.xml")
+	dataRTX3060, _    = os.ReadFile("testdata/rtx-3060.xml")
+	dataTeslaP100, _  = os.ReadFile("testdata/tesla-p100.xml")
+)
+
+func Test_testDataIsValid(t *testing.T) {
+	for name, data := range map[string][]byte{
+		"dataRTX2080Win": dataRTX2080Win,
+		"dataRTX3060":    dataRTX3060,
+		"dataTeslaP100":  dataTeslaP100,
+	} {
+		require.NotNilf(t, data, name)
+	}
+}
+
+func TestNvidiaSMI_Init(t *testing.T) {
+	tests := map[string]struct {
+		prepare  func(nv *NvidiaSMI)
+		wantFail bool
+	}{
+		"fails if can't local nvidia-smi": {
+			wantFail: true,
+			prepare: func(nv *NvidiaSMI) {
+				nv.binName += "!!!"
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			nv := New()
+
+			test.prepare(nv)
+
+			if test.wantFail {
+				assert.False(t, nv.Init())
+			} else {
+				assert.True(t, nv.Init())
+			}
+		})
+	}
+}
+
+func TestNvidiaSMI_Charts(t *testing.T) {
+	assert.NotNil(t, New().Charts())
+}
+
+func TestNvidiaSMI_Check(t *testing.T) {
+	tests := map[string]struct {
+		prepare  func(nv *NvidiaSMI)
+		wantFail bool
+	}{
+		"success RTX 3060": {
+			wantFail: false,
+			prepare:  prepareCaseRTX3060,
+		},
+		"success Tesla P100": {
+			wantFail: false,
+			prepare:  prepareCaseTeslaP100,
+		},
+		"success RTX 2080 Win": {
+			wantFail: false,
+			prepare:  prepareCaseRTX2080Win,
+		},
+		"fail on queryXML error": {
+			wantFail: true,
+			prepare:  prepareCaseErrOnQueryXML,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			nv := New()
+
+			test.prepare(nv)
+
+			if test.wantFail {
+				assert.False(t, nv.Check())
+			} else {
+				assert.True(t, nv.Check())
+			}
+		})
+	}
+}
+
+func TestNvidiaSMI_Collect(t *testing.T) {
+	type testCaseStep struct {
+		prepare func(nv *NvidiaSMI)
+		check   func(t *testing.T, nv *NvidiaSMI)
+	}
+	tests := map[string][]testCaseStep{
+		"success RTX 3060": {
+			{
+				prepare: prepareCaseRTX3060,
+				check: func(t *testing.T, nv *NvidiaSMI) {
+					mx := nv.Collect()
+
+					expected := map[string]int64{
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_bar1_memory_usage_free":             8586788864,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_bar1_memory_usage_used":             3145728,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_decoder_utilization":                0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_encoder_utilization":                0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_frame_buffer_memory_usage_free":     6228541440,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_frame_buffer_memory_usage_reserved": 206569472,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_frame_buffer_memory_usage_used":     5242880,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_gpu_utilization":                    0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_graphics_clock":                     210,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_mem_clock":                          405,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_mem_utilization":                    0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_pcie_bandwidth_usage_rx":            0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_pcie_bandwidth_usage_tx":            0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_performance_state_P0":               0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_performance_state_P1":               0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_performance_state_P10":              0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_performance_state_P11":              0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_performance_state_P12":              0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_performance_state_P13":              0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_performance_state_P14":              0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_performance_state_P15":              0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_performance_state_P2":               0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_performance_state_P3":               0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_performance_state_P4":               0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_performance_state_P5":               0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_performance_state_P6":               0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_performance_state_P7":               0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_performance_state_P8":               1,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_performance_state_P9":               0,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_power_draw":                         8,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_sm_clock":                           210,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_temperature":                        45,
+						"gpu_GPU-473d8d0f-d462-185c-6b36-6fc23e23e571_video_clock":                        555,
+					}
+
+					assert.Equal(t, expected, mx)
+				},
+			},
+		},
+		"success Tesla P100": {
+			{
+				prepare: prepareCaseTeslaP100,
+				check: func(t *testing.T, nv *NvidiaSMI) {
+					mx := nv.Collect()
+
+					expected := map[string]int64{
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_bar1_memory_usage_free":             17177772032,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_bar1_memory_usage_used":             2097152,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_decoder_utilization":                0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_encoder_utilization":                0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_frame_buffer_memory_usage_free":     17070817280,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_frame_buffer_memory_usage_reserved": 108003328,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_frame_buffer_memory_usage_used":     0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_gpu_utilization":                    0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_graphics_clock":                     405,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_mem_clock":                          715,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_mem_utilization":                    0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_pcie_bandwidth_usage_rx":            0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_pcie_bandwidth_usage_tx":            0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_performance_state_P0":               1,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_performance_state_P1":               0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_performance_state_P10":              0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_performance_state_P11":              0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_performance_state_P12":              0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_performance_state_P13":              0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_performance_state_P14":              0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_performance_state_P15":              0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_performance_state_P2":               0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_performance_state_P3":               0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_performance_state_P4":               0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_performance_state_P5":               0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_performance_state_P6":               0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_performance_state_P7":               0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_performance_state_P8":               0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_performance_state_P9":               0,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_power_draw":                         26,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_sm_clock":                           405,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_temperature":                        38,
+						"gpu_GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e_video_clock":                        835,
+					}
+
+					assert.Equal(t, expected, mx)
+				},
+			},
+		},
+		"success RTX 2080 Win": {
+			{
+				prepare: prepareCaseRTX2080Win,
+				check: func(t *testing.T, nv *NvidiaSMI) {
+					mx := nv.Collect()
+
+					expected := map[string]int64{
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_bar1_memory_usage_free":             266338304,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_bar1_memory_usage_used":             2097152,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_decoder_utilization":                0,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_encoder_utilization":                0,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_fan_speed_perc":                     37,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_frame_buffer_memory_usage_free":     7494172672,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_frame_buffer_memory_usage_reserved": 190840832,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_frame_buffer_memory_usage_used":     903872512,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_gpu_utilization":                    2,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_graphics_clock":                     193,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_mem_clock":                          403,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_mem_utilization":                    7,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_pcie_bandwidth_usage_rx":            93184000,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_pcie_bandwidth_usage_tx":            13312000,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_performance_state_P0":               0,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_performance_state_P1":               0,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_performance_state_P10":              0,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_performance_state_P11":              0,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_performance_state_P12":              0,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_performance_state_P13":              0,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_performance_state_P14":              0,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_performance_state_P15":              0,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_performance_state_P2":               0,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_performance_state_P3":               0,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_performance_state_P4":               0,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_performance_state_P5":               0,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_performance_state_P6":               0,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_performance_state_P7":               0,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_performance_state_P8":               1,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_performance_state_P9":               0,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_power_draw":                         14,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_sm_clock":                           193,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_temperature":                        29,
+						"gpu_GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3_video_clock":                        539,
+					}
+
+					assert.Equal(t, expected, mx)
+				},
+			},
+		},
+		"fail on queryXML error": {
+			{
+				prepare: prepareCaseErrOnQueryXML,
+				check: func(t *testing.T, nv *NvidiaSMI) {
+					mx := nv.Collect()
+
+					assert.Equal(t, map[string]int64(nil), mx)
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			nv := New()
+
+			for i, step := range test {
+				t.Run(fmt.Sprintf("step[%d]", i), func(t *testing.T) {
+					step.prepare(nv)
+					step.check(t, nv)
+				})
+			}
+		})
+	}
+}
+
+type mockNvidiaSMI struct {
+	respXML       []byte
+	errOnQueryXML bool
+}
+
+func (m *mockNvidiaSMI) queryXML() ([]byte, error) {
+	if m.errOnQueryXML {
+		return nil, errors.New("error on mock.queryXML()")
+	}
+	return m.respXML, nil
+}
+
+func prepareCaseRTX3060(nv *NvidiaSMI) {
+	nv.exec = &mockNvidiaSMI{respXML: dataRTX3060}
+}
+
+func prepareCaseTeslaP100(nv *NvidiaSMI) {
+	nv.exec = &mockNvidiaSMI{respXML: dataTeslaP100}
+}
+
+func prepareCaseRTX2080Win(nv *NvidiaSMI) {
+	nv.exec = &mockNvidiaSMI{respXML: dataRTX2080Win}
+}
+
+func prepareCaseErrOnQueryXML(nv *NvidiaSMI) {
+	nv.exec = &mockNvidiaSMI{errOnQueryXML: true}
+}

--- a/modules/nvidia_smi/testdata/rtx-2080-win.xml
+++ b/modules/nvidia_smi/testdata/rtx-2080-win.xml
@@ -1,0 +1,776 @@
+<?xml version="1.0" ?>
+<!DOCTYPE nvidia_smi_log SYSTEM "nvsmi_device_v11.dtd">
+<nvidia_smi_log>
+    <timestamp>Tue Sep 20 14:07:39 2022</timestamp>
+    <driver_version>516.59</driver_version>
+    <cuda_version>11.7</cuda_version>
+    <attached_gpus>1</attached_gpus>
+    <gpu id="00000000:0A:00.0">
+        <product_name>NVIDIA GeForce RTX 2080</product_name>
+        <product_brand>GeForce</product_brand>
+        <product_architecture>Turing</product_architecture>
+        <display_mode>Enabled</display_mode>
+        <display_active>Enabled</display_active>
+        <persistence_mode>N/A</persistence_mode>
+        <mig_mode>
+            <current_mig>N/A</current_mig>
+            <pending_mig>N/A</pending_mig>
+        </mig_mode>
+        <mig_devices>
+            None
+        </mig_devices>
+        <accounting_mode>Disabled</accounting_mode>
+        <accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+        <driver_model>
+            <current_dm>WDDM</current_dm>
+            <pending_dm>WDDM</pending_dm>
+        </driver_model>
+        <serial>N/A</serial>
+        <uuid>GPU-fbd55ed4-1eec-4423-0a47-ad594b4333e3</uuid>
+        <minor_number>N/A</minor_number>
+        <vbios_version>90.04.23.00.db</vbios_version>
+        <multigpu_board>No</multigpu_board>
+        <board_id>0xa00</board_id>
+        <gpu_part_number>N/A</gpu_part_number>
+        <gpu_module_id>0</gpu_module_id>
+        <inforom_version>
+            <img_version>G001.0000.02.04</img_version>
+            <oem_object>1.1</oem_object>
+            <ecc_object>N/A</ecc_object>
+            <pwr_object>N/A</pwr_object>
+        </inforom_version>
+        <gpu_operation_mode>
+            <current_gom>N/A</current_gom>
+            <pending_gom>N/A</pending_gom>
+        </gpu_operation_mode>
+        <gsp_firmware_version>N/A</gsp_firmware_version>
+        <gpu_virtualization_mode>
+            <virtualization_mode>None</virtualization_mode>
+            <host_vgpu_mode>N/A</host_vgpu_mode>
+        </gpu_virtualization_mode>
+        <ibmnpu>
+            <relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+        </ibmnpu>
+        <pci>
+            <pci_bus>0A</pci_bus>
+            <pci_device>00</pci_device>
+            <pci_domain>0000</pci_domain>
+            <pci_device_id>1E8710DE</pci_device_id>
+            <pci_bus_id>00000000:0A:00.0</pci_bus_id>
+            <pci_sub_system_id>37AF1458</pci_sub_system_id>
+            <pci_gpu_link_info>
+                <pcie_gen>
+                    <max_link_gen>3</max_link_gen>
+                    <current_link_gen>3</current_link_gen>
+                </pcie_gen>
+                <link_widths>
+                    <max_link_width>16x</max_link_width>
+                    <current_link_width>8x</current_link_width>
+                </link_widths>
+            </pci_gpu_link_info>
+            <pci_bridge_chip>
+                <bridge_chip_type>N/A</bridge_chip_type>
+                <bridge_chip_fw>N/A</bridge_chip_fw>
+            </pci_bridge_chip>
+            <replay_counter>0</replay_counter>
+            <replay_rollover_counter>0</replay_rollover_counter>
+            <tx_util>13000 KB/s</tx_util>
+            <rx_util>91000 KB/s</rx_util>
+        </pci>
+        <fan_speed>37 %</fan_speed>
+        <performance_state>P8</performance_state>
+        <clocks_throttle_reasons>
+            <clocks_throttle_reason_gpu_idle>Active</clocks_throttle_reason_gpu_idle>
+            <clocks_throttle_reason_applications_clocks_setting>Not Active</clocks_throttle_reason_applications_clocks_setting>
+            <clocks_throttle_reason_sw_power_cap>Not Active</clocks_throttle_reason_sw_power_cap>
+            <clocks_throttle_reason_hw_slowdown>Not Active</clocks_throttle_reason_hw_slowdown>
+            <clocks_throttle_reason_hw_thermal_slowdown>Not Active</clocks_throttle_reason_hw_thermal_slowdown>
+            <clocks_throttle_reason_hw_power_brake_slowdown>Not Active</clocks_throttle_reason_hw_power_brake_slowdown>
+            <clocks_throttle_reason_sync_boost>Not Active</clocks_throttle_reason_sync_boost>
+            <clocks_throttle_reason_sw_thermal_slowdown>Not Active</clocks_throttle_reason_sw_thermal_slowdown>
+            <clocks_throttle_reason_display_clocks_setting>Not Active</clocks_throttle_reason_display_clocks_setting>
+        </clocks_throttle_reasons>
+        <fb_memory_usage>
+            <total>8192 MiB</total>
+            <reserved>182 MiB</reserved>
+            <used>862 MiB</used>
+            <free>7147 MiB</free>
+        </fb_memory_usage>
+        <bar1_memory_usage>
+            <total>256 MiB</total>
+            <used>2 MiB</used>
+            <free>254 MiB</free>
+        </bar1_memory_usage>
+        <compute_mode>Default</compute_mode>
+        <utilization>
+            <gpu_util>2 %</gpu_util>
+            <memory_util>7 %</memory_util>
+            <encoder_util>0 %</encoder_util>
+            <decoder_util>0 %</decoder_util>
+        </utilization>
+        <encoder_stats>
+            <session_count>0</session_count>
+            <average_fps>0</average_fps>
+            <average_latency>0</average_latency>
+        </encoder_stats>
+        <fbc_stats>
+            <session_count>0</session_count>
+            <average_fps>0</average_fps>
+            <average_latency>0</average_latency>
+        </fbc_stats>
+        <ecc_mode>
+            <current_ecc>N/A</current_ecc>
+            <pending_ecc>N/A</pending_ecc>
+        </ecc_mode>
+        <ecc_errors>
+            <volatile>
+                <sram_correctable>N/A</sram_correctable>
+                <sram_uncorrectable>N/A</sram_uncorrectable>
+                <dram_correctable>N/A</dram_correctable>
+                <dram_uncorrectable>N/A</dram_uncorrectable>
+            </volatile>
+            <aggregate>
+                <sram_correctable>N/A</sram_correctable>
+                <sram_uncorrectable>N/A</sram_uncorrectable>
+                <dram_correctable>N/A</dram_correctable>
+                <dram_uncorrectable>N/A</dram_uncorrectable>
+            </aggregate>
+        </ecc_errors>
+        <retired_pages>
+            <multiple_single_bit_retirement>
+                <retired_count>N/A</retired_count>
+                <retired_pagelist>N/A</retired_pagelist>
+            </multiple_single_bit_retirement>
+            <double_bit_retirement>
+                <retired_count>N/A</retired_count>
+                <retired_pagelist>N/A</retired_pagelist>
+            </double_bit_retirement>
+            <pending_blacklist>N/A</pending_blacklist>
+            <pending_retirement>N/A</pending_retirement>
+        </retired_pages>
+        <remapped_rows>N/A</remapped_rows>
+        <temperature>
+            <gpu_temp>29 C</gpu_temp>
+            <gpu_temp_max_threshold>100 C</gpu_temp_max_threshold>
+            <gpu_temp_slow_threshold>97 C</gpu_temp_slow_threshold>
+            <gpu_temp_max_gpu_threshold>88 C</gpu_temp_max_gpu_threshold>
+            <gpu_target_temperature>83 C</gpu_target_temperature>
+            <memory_temp>N/A</memory_temp>
+            <gpu_temp_max_mem_threshold>N/A</gpu_temp_max_mem_threshold>
+        </temperature>
+        <supported_gpu_target_temp>
+            <gpu_target_temp_min>65 C</gpu_target_temp_min>
+            <gpu_target_temp_max>88 C</gpu_target_temp_max>
+        </supported_gpu_target_temp>
+        <power_readings>
+            <power_state>P8</power_state>
+            <power_management>Supported</power_management>
+            <power_draw>14.50 W</power_draw>
+            <power_limit>275.00 W</power_limit>
+            <default_power_limit>275.00 W</default_power_limit>
+            <enforced_power_limit>275.00 W</enforced_power_limit>
+            <min_power_limit>105.00 W</min_power_limit>
+            <max_power_limit>350.00 W</max_power_limit>
+        </power_readings>
+        <clocks>
+            <graphics_clock>193 MHz</graphics_clock>
+            <sm_clock>193 MHz</sm_clock>
+            <mem_clock>403 MHz</mem_clock>
+            <video_clock>539 MHz</video_clock>
+        </clocks>
+        <applications_clocks>
+            <graphics_clock>N/A</graphics_clock>
+            <mem_clock>N/A</mem_clock>
+        </applications_clocks>
+        <default_applications_clocks>
+            <graphics_clock>N/A</graphics_clock>
+            <mem_clock>N/A</mem_clock>
+        </default_applications_clocks>
+        <max_clocks>
+            <graphics_clock>3060 MHz</graphics_clock>
+            <sm_clock>3060 MHz</sm_clock>
+            <mem_clock>7560 MHz</mem_clock>
+            <video_clock>1950 MHz</video_clock>
+        </max_clocks>
+        <max_customer_boost_clocks>
+            <graphics_clock>N/A</graphics_clock>
+        </max_customer_boost_clocks>
+        <clock_policy>
+            <auto_boost>N/A</auto_boost>
+            <auto_boost_default>N/A</auto_boost_default>
+        </clock_policy>
+        <voltage>
+            <graphics_volt>N/A</graphics_volt>
+        </voltage>
+        <supported_clocks>
+            <supported_mem_clock>
+                <value>7560 MHz</value>
+                <supported_graphics_clock>2220 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2205 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2190 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2175 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2160 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2145 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2130 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2115 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2100 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2085 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2070 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2055 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2040 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2025 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2010 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1995 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1980 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1965 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1950 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1935 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1920 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1905 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1890 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1875 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1860 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1845 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1830 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1815 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1800 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1785 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1770 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1755 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1740 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1725 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1710 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1695 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1680 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1665 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1650 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1635 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1620 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1605 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1590 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1575 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1560 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1545 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1530 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1515 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1500 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1485 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1470 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1455 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1440 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1425 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1410 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1395 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1380 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1365 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1350 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1335 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1320 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1305 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1290 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1275 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1260 MHz</supported_graphics_clock>
+            </supported_mem_clock>
+            <supported_mem_clock>
+                <value>7360 MHz</value>
+                <supported_graphics_clock>2220 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2205 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2190 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2175 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2160 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2145 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2130 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2115 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2100 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2085 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2070 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2055 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2040 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2025 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2010 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1995 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1980 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1965 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1950 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1935 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1920 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1905 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1890 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1875 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1860 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1845 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1830 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1815 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1800 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1785 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1770 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1755 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1740 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1725 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1710 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1695 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1680 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1665 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1650 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1635 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1620 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1605 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1590 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1575 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1560 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1545 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1530 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1515 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1500 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1485 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1470 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1455 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1440 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1425 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1410 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1395 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1380 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1365 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1350 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1335 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1320 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1305 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1290 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1275 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1260 MHz</supported_graphics_clock>
+            </supported_mem_clock>
+            <supported_mem_clock>
+                <value>5000 MHz</value>
+                <supported_graphics_clock>2220 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2205 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2190 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2175 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2160 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2145 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2130 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2115 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2100 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2085 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2070 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2055 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2040 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2025 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2010 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1995 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1980 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1965 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1950 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1935 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1920 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1905 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1890 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1875 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1860 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1845 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1830 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1815 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1800 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1785 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1770 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1755 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1740 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1725 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1710 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1695 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1680 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1665 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1650 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1635 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1620 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1605 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1590 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1575 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1560 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1545 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1530 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1515 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1500 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1485 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1470 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1455 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1440 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1425 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1410 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1395 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1380 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1365 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1350 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1335 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1320 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1305 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1290 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1275 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1260 MHz</supported_graphics_clock>
+            </supported_mem_clock>
+            <supported_mem_clock>
+                <value>810 MHz</value>
+                <supported_graphics_clock>2100 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2085 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2070 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2055 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2040 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2025 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2010 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1995 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1980 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1965 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1950 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1935 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1920 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1905 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1890 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1875 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1860 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1845 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1830 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1815 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1800 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1785 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1770 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1755 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1740 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1725 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1710 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1695 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1680 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1665 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1650 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1635 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1620 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1605 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1590 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1575 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1560 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1545 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1530 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1515 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1500 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1485 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1470 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1455 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1440 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1425 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1410 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1395 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1380 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1365 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1350 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1335 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1320 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1305 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1290 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1275 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1260 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1245 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1230 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1215 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1200 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1185 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1170 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1155 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1140 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1125 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1110 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1095 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1080 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1065 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1050 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1035 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1020 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1005 MHz</supported_graphics_clock>
+                <supported_graphics_clock>990 MHz</supported_graphics_clock>
+                <supported_graphics_clock>975 MHz</supported_graphics_clock>
+                <supported_graphics_clock>960 MHz</supported_graphics_clock>
+                <supported_graphics_clock>945 MHz</supported_graphics_clock>
+                <supported_graphics_clock>930 MHz</supported_graphics_clock>
+                <supported_graphics_clock>915 MHz</supported_graphics_clock>
+                <supported_graphics_clock>900 MHz</supported_graphics_clock>
+                <supported_graphics_clock>885 MHz</supported_graphics_clock>
+                <supported_graphics_clock>870 MHz</supported_graphics_clock>
+                <supported_graphics_clock>855 MHz</supported_graphics_clock>
+                <supported_graphics_clock>840 MHz</supported_graphics_clock>
+                <supported_graphics_clock>825 MHz</supported_graphics_clock>
+                <supported_graphics_clock>810 MHz</supported_graphics_clock>
+                <supported_graphics_clock>795 MHz</supported_graphics_clock>
+                <supported_graphics_clock>780 MHz</supported_graphics_clock>
+                <supported_graphics_clock>765 MHz</supported_graphics_clock>
+                <supported_graphics_clock>750 MHz</supported_graphics_clock>
+                <supported_graphics_clock>735 MHz</supported_graphics_clock>
+                <supported_graphics_clock>720 MHz</supported_graphics_clock>
+                <supported_graphics_clock>705 MHz</supported_graphics_clock>
+                <supported_graphics_clock>690 MHz</supported_graphics_clock>
+                <supported_graphics_clock>675 MHz</supported_graphics_clock>
+                <supported_graphics_clock>660 MHz</supported_graphics_clock>
+                <supported_graphics_clock>645 MHz</supported_graphics_clock>
+                <supported_graphics_clock>630 MHz</supported_graphics_clock>
+                <supported_graphics_clock>615 MHz</supported_graphics_clock>
+                <supported_graphics_clock>600 MHz</supported_graphics_clock>
+                <supported_graphics_clock>585 MHz</supported_graphics_clock>
+                <supported_graphics_clock>570 MHz</supported_graphics_clock>
+                <supported_graphics_clock>555 MHz</supported_graphics_clock>
+                <supported_graphics_clock>540 MHz</supported_graphics_clock>
+                <supported_graphics_clock>525 MHz</supported_graphics_clock>
+                <supported_graphics_clock>510 MHz</supported_graphics_clock>
+                <supported_graphics_clock>495 MHz</supported_graphics_clock>
+                <supported_graphics_clock>480 MHz</supported_graphics_clock>
+                <supported_graphics_clock>465 MHz</supported_graphics_clock>
+                <supported_graphics_clock>450 MHz</supported_graphics_clock>
+                <supported_graphics_clock>435 MHz</supported_graphics_clock>
+                <supported_graphics_clock>420 MHz</supported_graphics_clock>
+                <supported_graphics_clock>405 MHz</supported_graphics_clock>
+                <supported_graphics_clock>390 MHz</supported_graphics_clock>
+                <supported_graphics_clock>375 MHz</supported_graphics_clock>
+                <supported_graphics_clock>360 MHz</supported_graphics_clock>
+                <supported_graphics_clock>345 MHz</supported_graphics_clock>
+                <supported_graphics_clock>330 MHz</supported_graphics_clock>
+                <supported_graphics_clock>315 MHz</supported_graphics_clock>
+                <supported_graphics_clock>300 MHz</supported_graphics_clock>
+            </supported_mem_clock>
+            <supported_mem_clock>
+                <value>405 MHz</value>
+                <supported_graphics_clock>645 MHz</supported_graphics_clock>
+                <supported_graphics_clock>630 MHz</supported_graphics_clock>
+                <supported_graphics_clock>615 MHz</supported_graphics_clock>
+                <supported_graphics_clock>600 MHz</supported_graphics_clock>
+                <supported_graphics_clock>585 MHz</supported_graphics_clock>
+                <supported_graphics_clock>570 MHz</supported_graphics_clock>
+                <supported_graphics_clock>555 MHz</supported_graphics_clock>
+                <supported_graphics_clock>540 MHz</supported_graphics_clock>
+                <supported_graphics_clock>525 MHz</supported_graphics_clock>
+                <supported_graphics_clock>510 MHz</supported_graphics_clock>
+                <supported_graphics_clock>495 MHz</supported_graphics_clock>
+                <supported_graphics_clock>480 MHz</supported_graphics_clock>
+                <supported_graphics_clock>465 MHz</supported_graphics_clock>
+                <supported_graphics_clock>450 MHz</supported_graphics_clock>
+                <supported_graphics_clock>435 MHz</supported_graphics_clock>
+                <supported_graphics_clock>420 MHz</supported_graphics_clock>
+                <supported_graphics_clock>405 MHz</supported_graphics_clock>
+                <supported_graphics_clock>390 MHz</supported_graphics_clock>
+                <supported_graphics_clock>375 MHz</supported_graphics_clock>
+                <supported_graphics_clock>360 MHz</supported_graphics_clock>
+                <supported_graphics_clock>345 MHz</supported_graphics_clock>
+                <supported_graphics_clock>330 MHz</supported_graphics_clock>
+                <supported_graphics_clock>315 MHz</supported_graphics_clock>
+                <supported_graphics_clock>300 MHz</supported_graphics_clock>
+            </supported_mem_clock>
+        </supported_clocks>
+        <processes>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>7724</pid>
+                <type>C+G</type>
+                <process_name>C:\Program Files\WindowsApps\Microsoft.YourPhone_1.22062.543.0_x64__8wekyb3d8bbwe\PhoneExperienceHost.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>10808</pid>
+                <type>C+G</type>
+                <process_name></process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>11556</pid>
+                <type>C+G</type>
+                <process_name>C:\Windows\SystemApps\ShellExperienceHost_cw5n1h2txyewy\ShellExperienceHost.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>12452</pid>
+                <type>C+G</type>
+                <process_name>C:\Program Files\WindowsApps\Microsoft.SkypeApp_15.88.3401.0_x86__kzf8qxf38zg5c\Skype\Skype.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>12636</pid>
+                <type>C+G</type>
+                <process_name></process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>13120</pid>
+                <type>C+G</type>
+                <process_name></process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>14296</pid>
+                <type>C+G</type>
+                <process_name>C:\Windows\explorer.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>16508</pid>
+                <type>C+G</type>
+                <process_name>C:\Program Files\WindowsApps\Microsoft.549981C3F5F10_4.2204.13303.0_x64__8wekyb3d8bbwe\Cortana.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>16592</pid>
+                <type>C+G</type>
+                <process_name>C:\ProgramData\Logishrd\LogiOptions\Software\Current\LogiOptionsMgr.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>20920</pid>
+                <type>C+G</type>
+                <process_name>C:\Windows\SystemApps\Microsoft.LockApp_cw5n1h2txyewy\LockApp.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>21004</pid>
+                <type>C+G</type>
+                <process_name>C:\Program Files\WindowsApps\Microsoft.Windows.Photos_2022.31070.26005.0_x64__8wekyb3d8bbwe\Microsoft.Photos.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>21036</pid>
+                <type>C+G</type>
+                <process_name>C:\Program Files (x86)\Garmin\Express\CefSharp.BrowserSubprocess.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>21048</pid>
+                <type>C+G</type>
+                <process_name>C:\Program Files\WindowsApps\91750D7E.Slack_4.28.171.0_x64__8she8kybcnzg4\app\Slack.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>21104</pid>
+                <type>C+G</type>
+                <process_name>C:\Windows\SystemApps\MicrosoftWindows.Client.CBS_cw5n1h2txyewy\TextInputHost.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>21292</pid>
+                <type>C+G</type>
+                <process_name>C:\Program Files\WindowsApps\Microsoft.ZuneVideo_10.22041.10091.0_x64__8wekyb3d8bbwe\Video.UI.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>21472</pid>
+                <type>C+G</type>
+                <process_name>C:\Program Files (x86)\Google\Chrome\Application\chrome.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>21852</pid>
+                <type>C+G</type>
+                <process_name>C:\ProgramData\Logishrd\LogiOptions\Software\Current\LogiOverlay.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>22600</pid>
+                <type>C+G</type>
+                <process_name></process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>23652</pid>
+                <type>C+G</type>
+                <process_name>C:\Program Files\WindowsApps\microsoft.windowscommunicationsapps_16005.14326.20970.0_x64__8wekyb3d8bbwe\HxOutlook.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>25436</pid>
+                <type>C+G</type>
+                <process_name>C:\Windows\SystemApps\MicrosoftWindows.Client.CBS_cw5n1h2txyewy\SearchHost.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>25520</pid>
+                <type>C+G</type>
+                <process_name></process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>25696</pid>
+                <type>C+G</type>
+                <process_name>C:\Users\Vlad\AppData\Local\Viber\Viber.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>26972</pid>
+                <type>C+G</type>
+                <process_name>C:\Windows\SystemApps\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\StartMenuExperienceHost.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>27148</pid>
+                <type>C+G</type>
+                <process_name>C:\Program Files\WindowsApps\Microsoft.Office.OneNote_16001.14326.21090.0_x64__8wekyb3d8bbwe\onenoteim.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>27628</pid>
+                <type>C+G</type>
+                <process_name>C:\Program Files\WindowsApps\49297T.Partl.ClockOut_2.9.9.0_x64__jr9bq2af9farr\WorkingHours.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>30212</pid>
+                <type>C+G</type>
+                <process_name>C:\Program Files (x86)\Microsoft\EdgeWebView\Application\105.0.1343.42\msedgewebview2.exe</process_name>
+                <used_memory>N/A</used_memory>
+            </process_info>
+        </processes>
+        <accounted_processes>
+        </accounted_processes>
+    </gpu>
+
+</nvidia_smi_log>

--- a/modules/nvidia_smi/testdata/rtx-3060.xml
+++ b/modules/nvidia_smi/testdata/rtx-3060.xml
@@ -1,0 +1,917 @@
+<?xml version="1.0" ?>
+<!DOCTYPE nvidia_smi_log SYSTEM "nvsmi_device_v11.dtd">
+<nvidia_smi_log>
+    <timestamp>Tue Sep 20 15:21:01 2022</timestamp>
+    <driver_version>515.65.01</driver_version>
+    <cuda_version>11.7</cuda_version>
+    <attached_gpus>1</attached_gpus>
+    <gpu id="00000000:01:00.0">
+        <product_name>NVIDIA GeForce RTX 3060 Laptop GPU</product_name>
+        <product_brand>GeForce</product_brand>
+        <product_architecture>Ampere</product_architecture>
+        <display_mode>Disabled</display_mode>
+        <display_active>Disabled</display_active>
+        <persistence_mode>Disabled</persistence_mode>
+        <mig_mode>
+            <current_mig>N/A</current_mig>
+            <pending_mig>N/A</pending_mig>
+        </mig_mode>
+        <mig_devices>
+            None
+        </mig_devices>
+        <accounting_mode>Disabled</accounting_mode>
+        <accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+        <driver_model>
+            <current_dm>N/A</current_dm>
+            <pending_dm>N/A</pending_dm>
+        </driver_model>
+        <serial>N/A</serial>
+        <uuid>GPU-473d8d0f-d462-185c-6b36-6fc23e23e571</uuid>
+        <minor_number>0</minor_number>
+        <vbios_version>94.06.19.00.51</vbios_version>
+        <multigpu_board>No</multigpu_board>
+        <board_id>0x100</board_id>
+        <gpu_part_number>N/A</gpu_part_number>
+        <gpu_module_id>0</gpu_module_id>
+        <inforom_version>
+            <img_version>G001.0000.03.03</img_version>
+            <oem_object>2.0</oem_object>
+            <ecc_object>N/A</ecc_object>
+            <pwr_object>N/A</pwr_object>
+        </inforom_version>
+        <gpu_operation_mode>
+            <current_gom>N/A</current_gom>
+            <pending_gom>N/A</pending_gom>
+        </gpu_operation_mode>
+        <gsp_firmware_version>N/A</gsp_firmware_version>
+        <gpu_virtualization_mode>
+            <virtualization_mode>None</virtualization_mode>
+            <host_vgpu_mode>N/A</host_vgpu_mode>
+        </gpu_virtualization_mode>
+        <ibmnpu>
+            <relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+        </ibmnpu>
+        <pci>
+            <pci_bus>01</pci_bus>
+            <pci_device>00</pci_device>
+            <pci_domain>0000</pci_domain>
+            <pci_device_id>252010DE</pci_device_id>
+            <pci_bus_id>00000000:01:00.0</pci_bus_id>
+            <pci_sub_system_id>0A831028</pci_sub_system_id>
+            <pci_gpu_link_info>
+                <pcie_gen>
+                    <max_link_gen>4</max_link_gen>
+                    <current_link_gen>1</current_link_gen>
+                </pcie_gen>
+                <link_widths>
+                    <max_link_width>16x</max_link_width>
+                    <current_link_width>8x</current_link_width>
+                </link_widths>
+            </pci_gpu_link_info>
+            <pci_bridge_chip>
+                <bridge_chip_type>N/A</bridge_chip_type>
+                <bridge_chip_fw>N/A</bridge_chip_fw>
+            </pci_bridge_chip>
+            <replay_counter>0</replay_counter>
+            <replay_rollover_counter>0</replay_rollover_counter>
+            <tx_util>0 KB/s</tx_util>
+            <rx_util>0 KB/s</rx_util>
+        </pci>
+        <fan_speed>N/A</fan_speed>
+        <performance_state>P8</performance_state>
+        <clocks_throttle_reasons>
+            <clocks_throttle_reason_gpu_idle>Active</clocks_throttle_reason_gpu_idle>
+            <clocks_throttle_reason_applications_clocks_setting>Not Active</clocks_throttle_reason_applications_clocks_setting>
+            <clocks_throttle_reason_sw_power_cap>Not Active</clocks_throttle_reason_sw_power_cap>
+            <clocks_throttle_reason_hw_slowdown>Not Active</clocks_throttle_reason_hw_slowdown>
+            <clocks_throttle_reason_hw_thermal_slowdown>Not Active</clocks_throttle_reason_hw_thermal_slowdown>
+            <clocks_throttle_reason_hw_power_brake_slowdown>Not Active</clocks_throttle_reason_hw_power_brake_slowdown>
+            <clocks_throttle_reason_sync_boost>Not Active</clocks_throttle_reason_sync_boost>
+            <clocks_throttle_reason_sw_thermal_slowdown>Not Active</clocks_throttle_reason_sw_thermal_slowdown>
+            <clocks_throttle_reason_display_clocks_setting>Not Active</clocks_throttle_reason_display_clocks_setting>
+        </clocks_throttle_reasons>
+        <fb_memory_usage>
+            <total>6144 MiB</total>
+            <reserved>197 MiB</reserved>
+            <used>5 MiB</used>
+            <free>5940 MiB</free>
+        </fb_memory_usage>
+        <bar1_memory_usage>
+            <total>8192 MiB</total>
+            <used>3 MiB</used>
+            <free>8189 MiB</free>
+        </bar1_memory_usage>
+        <compute_mode>Default</compute_mode>
+        <utilization>
+            <gpu_util>0 %</gpu_util>
+            <memory_util>0 %</memory_util>
+            <encoder_util>0 %</encoder_util>
+            <decoder_util>0 %</decoder_util>
+        </utilization>
+        <encoder_stats>
+            <session_count>0</session_count>
+            <average_fps>0</average_fps>
+            <average_latency>0</average_latency>
+        </encoder_stats>
+        <fbc_stats>
+            <session_count>0</session_count>
+            <average_fps>0</average_fps>
+            <average_latency>0</average_latency>
+        </fbc_stats>
+        <ecc_mode>
+            <current_ecc>N/A</current_ecc>
+            <pending_ecc>N/A</pending_ecc>
+        </ecc_mode>
+        <ecc_errors>
+            <volatile>
+                <sram_correctable>N/A</sram_correctable>
+                <sram_uncorrectable>N/A</sram_uncorrectable>
+                <dram_correctable>N/A</dram_correctable>
+                <dram_uncorrectable>N/A</dram_uncorrectable>
+            </volatile>
+            <aggregate>
+                <sram_correctable>N/A</sram_correctable>
+                <sram_uncorrectable>N/A</sram_uncorrectable>
+                <dram_correctable>N/A</dram_correctable>
+                <dram_uncorrectable>N/A</dram_uncorrectable>
+            </aggregate>
+        </ecc_errors>
+        <retired_pages>
+            <multiple_single_bit_retirement>
+                <retired_count>N/A</retired_count>
+                <retired_pagelist>N/A</retired_pagelist>
+            </multiple_single_bit_retirement>
+            <double_bit_retirement>
+                <retired_count>N/A</retired_count>
+                <retired_pagelist>N/A</retired_pagelist>
+            </double_bit_retirement>
+            <pending_blacklist>N/A</pending_blacklist>
+            <pending_retirement>N/A</pending_retirement>
+        </retired_pages>
+        <remapped_rows>N/A</remapped_rows>
+        <temperature>
+            <gpu_temp>45 C</gpu_temp>
+            <gpu_temp_max_threshold>105 C</gpu_temp_max_threshold>
+            <gpu_temp_slow_threshold>102 C</gpu_temp_slow_threshold>
+            <gpu_temp_max_gpu_threshold>75 C</gpu_temp_max_gpu_threshold>
+            <gpu_target_temperature>N/A</gpu_target_temperature>
+            <memory_temp>N/A</memory_temp>
+            <gpu_temp_max_mem_threshold>N/A</gpu_temp_max_mem_threshold>
+        </temperature>
+        <supported_gpu_target_temp>
+            <gpu_target_temp_min>N/A</gpu_target_temp_min>
+            <gpu_target_temp_max>N/A</gpu_target_temp_max>
+        </supported_gpu_target_temp>
+        <power_readings>
+            <power_state>P8</power_state>
+            <power_management>N/A</power_management>
+            <power_draw>8.70 W</power_draw>
+            <power_limit>N/A</power_limit>
+            <default_power_limit>N/A</default_power_limit>
+            <enforced_power_limit>N/A</enforced_power_limit>
+            <min_power_limit>N/A</min_power_limit>
+            <max_power_limit>N/A</max_power_limit>
+        </power_readings>
+        <clocks>
+            <graphics_clock>210 MHz</graphics_clock>
+            <sm_clock>210 MHz</sm_clock>
+            <mem_clock>405 MHz</mem_clock>
+            <video_clock>555 MHz</video_clock>
+        </clocks>
+        <applications_clocks>
+            <graphics_clock>N/A</graphics_clock>
+            <mem_clock>N/A</mem_clock>
+        </applications_clocks>
+        <default_applications_clocks>
+            <graphics_clock>N/A</graphics_clock>
+            <mem_clock>N/A</mem_clock>
+        </default_applications_clocks>
+        <max_clocks>
+            <graphics_clock>2100 MHz</graphics_clock>
+            <sm_clock>2100 MHz</sm_clock>
+            <mem_clock>6001 MHz</mem_clock>
+            <video_clock>1950 MHz</video_clock>
+        </max_clocks>
+        <max_customer_boost_clocks>
+            <graphics_clock>N/A</graphics_clock>
+        </max_customer_boost_clocks>
+        <clock_policy>
+            <auto_boost>N/A</auto_boost>
+            <auto_boost_default>N/A</auto_boost_default>
+        </clock_policy>
+        <voltage>
+            <graphics_volt>631.250 mV</graphics_volt>
+        </voltage>
+        <supported_clocks>
+            <supported_mem_clock>
+                <value>6001 MHz</value>
+                <supported_graphics_clock>2100 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2092 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2085 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2077 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2070 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2062 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2055 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2047 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2040 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2032 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2025 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2017 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2010 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2002 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1995 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1987 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1980 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1972 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1965 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1957 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1950 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1942 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1935 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1927 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1920 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1912 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1905 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1897 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1890 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1882 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1875 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1867 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1860 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1852 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1845 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1837 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1830 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1822 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1815 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1807 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1800 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1792 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1785 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1777 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1770 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1762 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1755 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1747 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1740 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1732 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1725 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1717 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1710 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1702 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1695 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1687 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1680 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1672 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1665 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1657 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1650 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1642 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1635 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1627 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1620 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1612 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1605 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1597 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1590 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1582 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1575 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1567 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1560 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1552 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1545 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1537 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1530 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1522 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1515 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1507 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1500 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1492 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1485 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1477 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1470 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1462 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1455 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1447 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1440 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1432 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1425 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1417 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1410 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1402 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1395 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1387 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1380 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1372 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1365 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1357 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1350 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1342 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1335 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1327 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1320 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1312 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1305 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1297 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1290 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1282 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1275 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1267 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1260 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1252 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1245 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1237 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1230 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1222 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1215 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1207 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1200 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1192 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1185 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1177 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1170 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1162 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1155 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1147 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1140 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1132 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1125 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1117 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1110 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1102 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1095 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1087 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1080 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1072 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1065 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1057 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1050 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1042 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1035 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1027 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1020 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1012 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1005 MHz</supported_graphics_clock>
+                <supported_graphics_clock>997 MHz</supported_graphics_clock>
+                <supported_graphics_clock>990 MHz</supported_graphics_clock>
+                <supported_graphics_clock>982 MHz</supported_graphics_clock>
+                <supported_graphics_clock>975 MHz</supported_graphics_clock>
+                <supported_graphics_clock>967 MHz</supported_graphics_clock>
+                <supported_graphics_clock>960 MHz</supported_graphics_clock>
+                <supported_graphics_clock>952 MHz</supported_graphics_clock>
+                <supported_graphics_clock>945 MHz</supported_graphics_clock>
+                <supported_graphics_clock>937 MHz</supported_graphics_clock>
+                <supported_graphics_clock>930 MHz</supported_graphics_clock>
+                <supported_graphics_clock>922 MHz</supported_graphics_clock>
+                <supported_graphics_clock>915 MHz</supported_graphics_clock>
+                <supported_graphics_clock>907 MHz</supported_graphics_clock>
+                <supported_graphics_clock>900 MHz</supported_graphics_clock>
+                <supported_graphics_clock>892 MHz</supported_graphics_clock>
+                <supported_graphics_clock>885 MHz</supported_graphics_clock>
+                <supported_graphics_clock>877 MHz</supported_graphics_clock>
+                <supported_graphics_clock>870 MHz</supported_graphics_clock>
+                <supported_graphics_clock>862 MHz</supported_graphics_clock>
+                <supported_graphics_clock>855 MHz</supported_graphics_clock>
+                <supported_graphics_clock>847 MHz</supported_graphics_clock>
+                <supported_graphics_clock>840 MHz</supported_graphics_clock>
+                <supported_graphics_clock>832 MHz</supported_graphics_clock>
+                <supported_graphics_clock>825 MHz</supported_graphics_clock>
+                <supported_graphics_clock>817 MHz</supported_graphics_clock>
+                <supported_graphics_clock>810 MHz</supported_graphics_clock>
+                <supported_graphics_clock>802 MHz</supported_graphics_clock>
+                <supported_graphics_clock>795 MHz</supported_graphics_clock>
+                <supported_graphics_clock>787 MHz</supported_graphics_clock>
+                <supported_graphics_clock>780 MHz</supported_graphics_clock>
+                <supported_graphics_clock>772 MHz</supported_graphics_clock>
+                <supported_graphics_clock>765 MHz</supported_graphics_clock>
+                <supported_graphics_clock>757 MHz</supported_graphics_clock>
+                <supported_graphics_clock>750 MHz</supported_graphics_clock>
+                <supported_graphics_clock>742 MHz</supported_graphics_clock>
+                <supported_graphics_clock>735 MHz</supported_graphics_clock>
+                <supported_graphics_clock>727 MHz</supported_graphics_clock>
+                <supported_graphics_clock>720 MHz</supported_graphics_clock>
+                <supported_graphics_clock>712 MHz</supported_graphics_clock>
+                <supported_graphics_clock>705 MHz</supported_graphics_clock>
+                <supported_graphics_clock>697 MHz</supported_graphics_clock>
+                <supported_graphics_clock>690 MHz</supported_graphics_clock>
+                <supported_graphics_clock>682 MHz</supported_graphics_clock>
+                <supported_graphics_clock>675 MHz</supported_graphics_clock>
+                <supported_graphics_clock>667 MHz</supported_graphics_clock>
+                <supported_graphics_clock>660 MHz</supported_graphics_clock>
+                <supported_graphics_clock>652 MHz</supported_graphics_clock>
+                <supported_graphics_clock>645 MHz</supported_graphics_clock>
+                <supported_graphics_clock>637 MHz</supported_graphics_clock>
+                <supported_graphics_clock>630 MHz</supported_graphics_clock>
+                <supported_graphics_clock>622 MHz</supported_graphics_clock>
+                <supported_graphics_clock>615 MHz</supported_graphics_clock>
+                <supported_graphics_clock>607 MHz</supported_graphics_clock>
+                <supported_graphics_clock>600 MHz</supported_graphics_clock>
+                <supported_graphics_clock>592 MHz</supported_graphics_clock>
+                <supported_graphics_clock>585 MHz</supported_graphics_clock>
+                <supported_graphics_clock>577 MHz</supported_graphics_clock>
+                <supported_graphics_clock>570 MHz</supported_graphics_clock>
+                <supported_graphics_clock>562 MHz</supported_graphics_clock>
+                <supported_graphics_clock>555 MHz</supported_graphics_clock>
+                <supported_graphics_clock>547 MHz</supported_graphics_clock>
+                <supported_graphics_clock>540 MHz</supported_graphics_clock>
+                <supported_graphics_clock>532 MHz</supported_graphics_clock>
+                <supported_graphics_clock>525 MHz</supported_graphics_clock>
+                <supported_graphics_clock>517 MHz</supported_graphics_clock>
+                <supported_graphics_clock>510 MHz</supported_graphics_clock>
+                <supported_graphics_clock>502 MHz</supported_graphics_clock>
+                <supported_graphics_clock>495 MHz</supported_graphics_clock>
+                <supported_graphics_clock>487 MHz</supported_graphics_clock>
+                <supported_graphics_clock>480 MHz</supported_graphics_clock>
+                <supported_graphics_clock>472 MHz</supported_graphics_clock>
+                <supported_graphics_clock>465 MHz</supported_graphics_clock>
+                <supported_graphics_clock>457 MHz</supported_graphics_clock>
+                <supported_graphics_clock>450 MHz</supported_graphics_clock>
+                <supported_graphics_clock>442 MHz</supported_graphics_clock>
+                <supported_graphics_clock>435 MHz</supported_graphics_clock>
+                <supported_graphics_clock>427 MHz</supported_graphics_clock>
+                <supported_graphics_clock>420 MHz</supported_graphics_clock>
+                <supported_graphics_clock>412 MHz</supported_graphics_clock>
+                <supported_graphics_clock>405 MHz</supported_graphics_clock>
+            </supported_mem_clock>
+            <supported_mem_clock>
+                <value>5501 MHz</value>
+                <supported_graphics_clock>2100 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2092 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2085 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2077 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2070 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2062 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2055 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2047 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2040 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2032 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2025 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2017 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2010 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2002 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1995 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1987 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1980 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1972 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1965 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1957 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1950 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1942 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1935 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1927 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1920 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1912 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1905 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1897 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1890 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1882 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1875 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1867 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1860 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1852 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1845 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1837 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1830 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1822 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1815 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1807 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1800 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1792 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1785 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1777 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1770 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1762 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1755 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1747 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1740 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1732 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1725 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1717 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1710 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1702 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1695 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1687 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1680 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1672 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1665 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1657 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1650 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1642 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1635 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1627 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1620 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1612 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1605 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1597 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1590 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1582 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1575 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1567 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1560 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1552 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1545 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1537 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1530 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1522 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1515 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1507 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1500 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1492 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1485 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1477 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1470 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1462 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1455 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1447 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1440 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1432 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1425 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1417 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1410 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1402 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1395 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1387 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1380 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1372 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1365 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1357 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1350 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1342 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1335 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1327 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1320 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1312 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1305 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1297 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1290 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1282 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1275 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1267 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1260 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1252 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1245 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1237 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1230 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1222 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1215 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1207 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1200 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1192 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1185 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1177 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1170 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1162 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1155 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1147 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1140 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1132 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1125 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1117 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1110 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1102 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1095 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1087 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1080 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1072 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1065 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1057 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1050 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1042 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1035 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1027 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1020 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1012 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1005 MHz</supported_graphics_clock>
+                <supported_graphics_clock>997 MHz</supported_graphics_clock>
+                <supported_graphics_clock>990 MHz</supported_graphics_clock>
+                <supported_graphics_clock>982 MHz</supported_graphics_clock>
+                <supported_graphics_clock>975 MHz</supported_graphics_clock>
+                <supported_graphics_clock>967 MHz</supported_graphics_clock>
+                <supported_graphics_clock>960 MHz</supported_graphics_clock>
+                <supported_graphics_clock>952 MHz</supported_graphics_clock>
+                <supported_graphics_clock>945 MHz</supported_graphics_clock>
+                <supported_graphics_clock>937 MHz</supported_graphics_clock>
+                <supported_graphics_clock>930 MHz</supported_graphics_clock>
+                <supported_graphics_clock>922 MHz</supported_graphics_clock>
+                <supported_graphics_clock>915 MHz</supported_graphics_clock>
+                <supported_graphics_clock>907 MHz</supported_graphics_clock>
+                <supported_graphics_clock>900 MHz</supported_graphics_clock>
+                <supported_graphics_clock>892 MHz</supported_graphics_clock>
+                <supported_graphics_clock>885 MHz</supported_graphics_clock>
+                <supported_graphics_clock>877 MHz</supported_graphics_clock>
+                <supported_graphics_clock>870 MHz</supported_graphics_clock>
+                <supported_graphics_clock>862 MHz</supported_graphics_clock>
+                <supported_graphics_clock>855 MHz</supported_graphics_clock>
+                <supported_graphics_clock>847 MHz</supported_graphics_clock>
+                <supported_graphics_clock>840 MHz</supported_graphics_clock>
+                <supported_graphics_clock>832 MHz</supported_graphics_clock>
+                <supported_graphics_clock>825 MHz</supported_graphics_clock>
+                <supported_graphics_clock>817 MHz</supported_graphics_clock>
+                <supported_graphics_clock>810 MHz</supported_graphics_clock>
+                <supported_graphics_clock>802 MHz</supported_graphics_clock>
+                <supported_graphics_clock>795 MHz</supported_graphics_clock>
+                <supported_graphics_clock>787 MHz</supported_graphics_clock>
+                <supported_graphics_clock>780 MHz</supported_graphics_clock>
+                <supported_graphics_clock>772 MHz</supported_graphics_clock>
+                <supported_graphics_clock>765 MHz</supported_graphics_clock>
+                <supported_graphics_clock>757 MHz</supported_graphics_clock>
+                <supported_graphics_clock>750 MHz</supported_graphics_clock>
+                <supported_graphics_clock>742 MHz</supported_graphics_clock>
+                <supported_graphics_clock>735 MHz</supported_graphics_clock>
+                <supported_graphics_clock>727 MHz</supported_graphics_clock>
+                <supported_graphics_clock>720 MHz</supported_graphics_clock>
+                <supported_graphics_clock>712 MHz</supported_graphics_clock>
+                <supported_graphics_clock>705 MHz</supported_graphics_clock>
+                <supported_graphics_clock>697 MHz</supported_graphics_clock>
+                <supported_graphics_clock>690 MHz</supported_graphics_clock>
+                <supported_graphics_clock>682 MHz</supported_graphics_clock>
+                <supported_graphics_clock>675 MHz</supported_graphics_clock>
+                <supported_graphics_clock>667 MHz</supported_graphics_clock>
+                <supported_graphics_clock>660 MHz</supported_graphics_clock>
+                <supported_graphics_clock>652 MHz</supported_graphics_clock>
+                <supported_graphics_clock>645 MHz</supported_graphics_clock>
+                <supported_graphics_clock>637 MHz</supported_graphics_clock>
+                <supported_graphics_clock>630 MHz</supported_graphics_clock>
+                <supported_graphics_clock>622 MHz</supported_graphics_clock>
+                <supported_graphics_clock>615 MHz</supported_graphics_clock>
+                <supported_graphics_clock>607 MHz</supported_graphics_clock>
+                <supported_graphics_clock>600 MHz</supported_graphics_clock>
+                <supported_graphics_clock>592 MHz</supported_graphics_clock>
+                <supported_graphics_clock>585 MHz</supported_graphics_clock>
+                <supported_graphics_clock>577 MHz</supported_graphics_clock>
+                <supported_graphics_clock>570 MHz</supported_graphics_clock>
+                <supported_graphics_clock>562 MHz</supported_graphics_clock>
+                <supported_graphics_clock>555 MHz</supported_graphics_clock>
+                <supported_graphics_clock>547 MHz</supported_graphics_clock>
+                <supported_graphics_clock>540 MHz</supported_graphics_clock>
+                <supported_graphics_clock>532 MHz</supported_graphics_clock>
+                <supported_graphics_clock>525 MHz</supported_graphics_clock>
+                <supported_graphics_clock>517 MHz</supported_graphics_clock>
+                <supported_graphics_clock>510 MHz</supported_graphics_clock>
+                <supported_graphics_clock>502 MHz</supported_graphics_clock>
+                <supported_graphics_clock>495 MHz</supported_graphics_clock>
+                <supported_graphics_clock>487 MHz</supported_graphics_clock>
+                <supported_graphics_clock>480 MHz</supported_graphics_clock>
+                <supported_graphics_clock>472 MHz</supported_graphics_clock>
+                <supported_graphics_clock>465 MHz</supported_graphics_clock>
+                <supported_graphics_clock>457 MHz</supported_graphics_clock>
+                <supported_graphics_clock>450 MHz</supported_graphics_clock>
+                <supported_graphics_clock>442 MHz</supported_graphics_clock>
+                <supported_graphics_clock>435 MHz</supported_graphics_clock>
+                <supported_graphics_clock>427 MHz</supported_graphics_clock>
+                <supported_graphics_clock>420 MHz</supported_graphics_clock>
+                <supported_graphics_clock>412 MHz</supported_graphics_clock>
+                <supported_graphics_clock>405 MHz</supported_graphics_clock>
+            </supported_mem_clock>
+            <supported_mem_clock>
+                <value>810 MHz</value>
+                <supported_graphics_clock>2100 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2092 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2085 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2077 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2070 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2062 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2055 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2047 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2040 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2032 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2025 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2017 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2010 MHz</supported_graphics_clock>
+                <supported_graphics_clock>2002 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1995 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1987 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1980 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1972 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1965 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1957 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1950 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1942 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1935 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1927 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1920 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1912 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1905 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1897 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1890 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1882 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1875 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1867 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1860 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1852 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1845 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1837 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1830 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1822 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1815 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1807 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1800 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1792 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1785 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1777 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1770 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1762 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1755 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1747 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1740 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1732 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1725 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1717 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1710 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1702 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1695 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1687 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1680 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1672 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1665 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1657 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1650 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1642 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1635 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1627 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1620 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1612 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1605 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1597 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1590 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1582 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1575 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1567 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1560 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1552 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1545 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1537 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1530 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1522 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1515 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1507 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1500 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1492 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1485 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1477 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1470 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1462 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1455 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1447 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1440 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1432 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1425 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1417 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1410 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1402 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1395 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1387 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1380 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1372 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1365 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1357 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1350 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1342 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1335 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1327 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1320 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1312 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1305 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1297 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1290 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1282 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1275 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1267 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1260 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1252 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1245 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1237 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1230 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1222 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1215 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1207 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1200 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1192 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1185 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1177 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1170 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1162 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1155 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1147 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1140 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1132 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1125 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1117 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1110 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1102 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1095 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1087 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1080 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1072 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1065 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1057 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1050 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1042 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1035 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1027 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1020 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1012 MHz</supported_graphics_clock>
+                <supported_graphics_clock>1005 MHz</supported_graphics_clock>
+                <supported_graphics_clock>997 MHz</supported_graphics_clock>
+                <supported_graphics_clock>990 MHz</supported_graphics_clock>
+                <supported_graphics_clock>982 MHz</supported_graphics_clock>
+                <supported_graphics_clock>975 MHz</supported_graphics_clock>
+                <supported_graphics_clock>967 MHz</supported_graphics_clock>
+                <supported_graphics_clock>960 MHz</supported_graphics_clock>
+                <supported_graphics_clock>952 MHz</supported_graphics_clock>
+                <supported_graphics_clock>945 MHz</supported_graphics_clock>
+                <supported_graphics_clock>937 MHz</supported_graphics_clock>
+                <supported_graphics_clock>930 MHz</supported_graphics_clock>
+                <supported_graphics_clock>922 MHz</supported_graphics_clock>
+                <supported_graphics_clock>915 MHz</supported_graphics_clock>
+                <supported_graphics_clock>907 MHz</supported_graphics_clock>
+                <supported_graphics_clock>900 MHz</supported_graphics_clock>
+                <supported_graphics_clock>892 MHz</supported_graphics_clock>
+                <supported_graphics_clock>885 MHz</supported_graphics_clock>
+                <supported_graphics_clock>877 MHz</supported_graphics_clock>
+                <supported_graphics_clock>870 MHz</supported_graphics_clock>
+                <supported_graphics_clock>862 MHz</supported_graphics_clock>
+                <supported_graphics_clock>855 MHz</supported_graphics_clock>
+                <supported_graphics_clock>847 MHz</supported_graphics_clock>
+                <supported_graphics_clock>840 MHz</supported_graphics_clock>
+                <supported_graphics_clock>832 MHz</supported_graphics_clock>
+                <supported_graphics_clock>825 MHz</supported_graphics_clock>
+                <supported_graphics_clock>817 MHz</supported_graphics_clock>
+                <supported_graphics_clock>810 MHz</supported_graphics_clock>
+                <supported_graphics_clock>802 MHz</supported_graphics_clock>
+                <supported_graphics_clock>795 MHz</supported_graphics_clock>
+                <supported_graphics_clock>787 MHz</supported_graphics_clock>
+                <supported_graphics_clock>780 MHz</supported_graphics_clock>
+                <supported_graphics_clock>772 MHz</supported_graphics_clock>
+                <supported_graphics_clock>765 MHz</supported_graphics_clock>
+                <supported_graphics_clock>757 MHz</supported_graphics_clock>
+                <supported_graphics_clock>750 MHz</supported_graphics_clock>
+                <supported_graphics_clock>742 MHz</supported_graphics_clock>
+                <supported_graphics_clock>735 MHz</supported_graphics_clock>
+                <supported_graphics_clock>727 MHz</supported_graphics_clock>
+                <supported_graphics_clock>720 MHz</supported_graphics_clock>
+                <supported_graphics_clock>712 MHz</supported_graphics_clock>
+                <supported_graphics_clock>705 MHz</supported_graphics_clock>
+                <supported_graphics_clock>697 MHz</supported_graphics_clock>
+                <supported_graphics_clock>690 MHz</supported_graphics_clock>
+                <supported_graphics_clock>682 MHz</supported_graphics_clock>
+                <supported_graphics_clock>675 MHz</supported_graphics_clock>
+                <supported_graphics_clock>667 MHz</supported_graphics_clock>
+                <supported_graphics_clock>660 MHz</supported_graphics_clock>
+                <supported_graphics_clock>652 MHz</supported_graphics_clock>
+                <supported_graphics_clock>645 MHz</supported_graphics_clock>
+                <supported_graphics_clock>637 MHz</supported_graphics_clock>
+                <supported_graphics_clock>630 MHz</supported_graphics_clock>
+                <supported_graphics_clock>622 MHz</supported_graphics_clock>
+                <supported_graphics_clock>615 MHz</supported_graphics_clock>
+                <supported_graphics_clock>607 MHz</supported_graphics_clock>
+                <supported_graphics_clock>600 MHz</supported_graphics_clock>
+                <supported_graphics_clock>592 MHz</supported_graphics_clock>
+                <supported_graphics_clock>585 MHz</supported_graphics_clock>
+                <supported_graphics_clock>577 MHz</supported_graphics_clock>
+                <supported_graphics_clock>570 MHz</supported_graphics_clock>
+                <supported_graphics_clock>562 MHz</supported_graphics_clock>
+                <supported_graphics_clock>555 MHz</supported_graphics_clock>
+                <supported_graphics_clock>547 MHz</supported_graphics_clock>
+                <supported_graphics_clock>540 MHz</supported_graphics_clock>
+                <supported_graphics_clock>532 MHz</supported_graphics_clock>
+                <supported_graphics_clock>525 MHz</supported_graphics_clock>
+                <supported_graphics_clock>517 MHz</supported_graphics_clock>
+                <supported_graphics_clock>510 MHz</supported_graphics_clock>
+                <supported_graphics_clock>502 MHz</supported_graphics_clock>
+                <supported_graphics_clock>495 MHz</supported_graphics_clock>
+                <supported_graphics_clock>487 MHz</supported_graphics_clock>
+                <supported_graphics_clock>480 MHz</supported_graphics_clock>
+                <supported_graphics_clock>472 MHz</supported_graphics_clock>
+                <supported_graphics_clock>465 MHz</supported_graphics_clock>
+                <supported_graphics_clock>457 MHz</supported_graphics_clock>
+                <supported_graphics_clock>450 MHz</supported_graphics_clock>
+                <supported_graphics_clock>442 MHz</supported_graphics_clock>
+                <supported_graphics_clock>435 MHz</supported_graphics_clock>
+                <supported_graphics_clock>427 MHz</supported_graphics_clock>
+                <supported_graphics_clock>420 MHz</supported_graphics_clock>
+                <supported_graphics_clock>412 MHz</supported_graphics_clock>
+                <supported_graphics_clock>405 MHz</supported_graphics_clock>
+            </supported_mem_clock>
+            <supported_mem_clock>
+                <value>405 MHz</value>
+                <supported_graphics_clock>420 MHz</supported_graphics_clock>
+                <supported_graphics_clock>412 MHz</supported_graphics_clock>
+                <supported_graphics_clock>405 MHz</supported_graphics_clock>
+            </supported_mem_clock>
+        </supported_clocks>
+        <processes>
+            <process_info>
+                <gpu_instance_id>N/A</gpu_instance_id>
+                <compute_instance_id>N/A</compute_instance_id>
+                <pid>28543</pid>
+                <type>G</type>
+                <process_name>/usr/libexec/Xorg</process_name>
+                <used_memory>4 MiB</used_memory>
+            </process_info>
+        </processes>
+        <accounted_processes>
+        </accounted_processes>
+    </gpu>
+
+</nvidia_smi_log>

--- a/modules/nvidia_smi/testdata/tesla-p100.xml
+++ b/modules/nvidia_smi/testdata/tesla-p100.xml
@@ -1,0 +1,313 @@
+<?xml version="1.0" ?>
+<!DOCTYPE nvidia_smi_log SYSTEM "nvsmi_device_v11.dtd">
+<nvidia_smi_log>
+	<timestamp>Sat Sep 17 17:06:50 2022</timestamp>
+	<driver_version>510.47.03</driver_version>
+	<cuda_version>11.6</cuda_version>
+	<attached_gpus>1</attached_gpus>
+	<gpu id="00000000:00:04.0">
+		<product_name>Tesla P100-PCIE-16GB</product_name>
+		<product_brand>Tesla</product_brand>
+		<product_architecture>Pascal</product_architecture>
+		<display_mode>Enabled</display_mode>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Disabled</persistence_mode>
+		<mig_mode>
+			<current_mig>N/A</current_mig>
+			<pending_mig>N/A</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>0324217145110</serial>
+		<uuid>GPU-d3da8716-eaab-75db-efc1-60e88e1cd55e</uuid>
+		<minor_number>0</minor_number>
+		<vbios_version>86.00.52.00.02</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x4</board_id>
+		<gpu_part_number>900-2H400-6300-031</gpu_part_number>
+		<gpu_module_id>0</gpu_module_id>
+		<inforom_version>
+			<img_version>H400.0201.00.08</img_version>
+			<oem_object>1.1</oem_object>
+			<ecc_object>4.1</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<gsp_firmware_version>N/A</gsp_firmware_version>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+		</gpu_virtualization_mode>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>00</pci_bus>
+			<pci_device>04</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_device_id>15F810DE</pci_device_id>
+			<pci_bus_id>00000000:00:04.0</pci_bus_id>
+			<pci_sub_system_id>118F10DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>3</max_link_gen>
+					<current_link_gen>3</current_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>0 KB/s</tx_util>
+			<rx_util>0 KB/s</rx_util>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_throttle_reasons>
+			<clocks_throttle_reason_gpu_idle>Active</clocks_throttle_reason_gpu_idle>
+			<clocks_throttle_reason_applications_clocks_setting>Not Active</clocks_throttle_reason_applications_clocks_setting>
+			<clocks_throttle_reason_sw_power_cap>Not Active</clocks_throttle_reason_sw_power_cap>
+			<clocks_throttle_reason_hw_slowdown>Not Active</clocks_throttle_reason_hw_slowdown>
+			<clocks_throttle_reason_hw_thermal_slowdown>Not Active</clocks_throttle_reason_hw_thermal_slowdown>
+			<clocks_throttle_reason_hw_power_brake_slowdown>Not Active</clocks_throttle_reason_hw_power_brake_slowdown>
+			<clocks_throttle_reason_sync_boost>Not Active</clocks_throttle_reason_sync_boost>
+			<clocks_throttle_reason_sw_thermal_slowdown>Not Active</clocks_throttle_reason_sw_thermal_slowdown>
+			<clocks_throttle_reason_display_clocks_setting>Not Active</clocks_throttle_reason_display_clocks_setting>
+		</clocks_throttle_reasons>
+		<fb_memory_usage>
+			<total>16384 MiB</total>
+			<reserved>103 MiB</reserved>
+			<used>0 MiB</used>
+			<free>16280 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>16384 MiB</total>
+			<used>2 MiB</used>
+			<free>16382 MiB</free>
+		</bar1_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<single_bit>
+					<device_memory>0</device_memory>
+					<register_file>0</register_file>
+					<l1_cache>N/A</l1_cache>
+					<l2_cache>0</l2_cache>
+					<texture_memory>0</texture_memory>
+					<texture_shm>0</texture_shm>
+					<cbu>N/A</cbu>
+					<total>0</total>
+				</single_bit>
+				<double_bit>
+					<device_memory>0</device_memory>
+					<register_file>0</register_file>
+					<l1_cache>N/A</l1_cache>
+					<l2_cache>0</l2_cache>
+					<texture_memory>0</texture_memory>
+					<texture_shm>0</texture_shm>
+					<cbu>N/A</cbu>
+					<total>0</total>
+				</double_bit>
+			</volatile>
+			<aggregate>
+				<single_bit>
+					<device_memory>3</device_memory>
+					<register_file>0</register_file>
+					<l1_cache>N/A</l1_cache>
+					<l2_cache>0</l2_cache>
+					<texture_memory>0</texture_memory>
+					<texture_shm>0</texture_shm>
+					<cbu>N/A</cbu>
+					<total>3</total>
+				</single_bit>
+				<double_bit>
+					<device_memory>0</device_memory>
+					<register_file>0</register_file>
+					<l1_cache>N/A</l1_cache>
+					<l2_cache>0</l2_cache>
+					<texture_memory>0</texture_memory>
+					<texture_shm>0</texture_shm>
+					<cbu>N/A</cbu>
+					<total>0</total>
+				</double_bit>
+			</aggregate>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>0</retired_count>
+				<retired_pagelist>
+				</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>0</retired_count>
+				<retired_pagelist>
+				</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>No</pending_blacklist>
+			<pending_retirement>No</pending_retirement>
+		</retired_pages>
+		<remapped_rows>N/A</remapped_rows>
+		<temperature>
+			<gpu_temp>38 C</gpu_temp>
+			<gpu_temp_max_threshold>85 C</gpu_temp_max_threshold>
+			<gpu_temp_slow_threshold>82 C</gpu_temp_slow_threshold>
+			<gpu_temp_max_gpu_threshold>N/A</gpu_temp_max_gpu_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>N/A</memory_temp>
+			<gpu_temp_max_mem_threshold>N/A</gpu_temp_max_mem_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<power_readings>
+			<power_state>P0</power_state>
+			<power_management>Supported</power_management>
+			<power_draw>26.16 W</power_draw>
+			<power_limit>250.00 W</power_limit>
+			<default_power_limit>250.00 W</default_power_limit>
+			<enforced_power_limit>250.00 W</enforced_power_limit>
+			<min_power_limit>125.00 W</min_power_limit>
+			<max_power_limit>250.00 W</max_power_limit>
+		</power_readings>
+		<clocks>
+			<graphics_clock>405 MHz</graphics_clock>
+			<sm_clock>405 MHz</sm_clock>
+			<mem_clock>715 MHz</mem_clock>
+			<video_clock>835 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>1189 MHz</graphics_clock>
+			<mem_clock>715 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>1189 MHz</graphics_clock>
+			<mem_clock>715 MHz</mem_clock>
+		</default_applications_clocks>
+		<max_clocks>
+			<graphics_clock>1328 MHz</graphics_clock>
+			<sm_clock>1328 MHz</sm_clock>
+			<mem_clock>715 MHz</mem_clock>
+			<video_clock>1328 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>1328 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<voltage>
+			<graphics_volt>N/A</graphics_volt>
+		</voltage>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>715 MHz</value>
+				<supported_graphics_clock>1328 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1316 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1303 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1278 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1265 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1227 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1189 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1164 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1151 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1139 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1126 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1113 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1101 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1088 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1075 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1063 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1037 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1025 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>999 MHz</supported_graphics_clock>
+				<supported_graphics_clock>987 MHz</supported_graphics_clock>
+				<supported_graphics_clock>974 MHz</supported_graphics_clock>
+				<supported_graphics_clock>961 MHz</supported_graphics_clock>
+				<supported_graphics_clock>949 MHz</supported_graphics_clock>
+				<supported_graphics_clock>936 MHz</supported_graphics_clock>
+				<supported_graphics_clock>923 MHz</supported_graphics_clock>
+				<supported_graphics_clock>911 MHz</supported_graphics_clock>
+				<supported_graphics_clock>898 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>873 MHz</supported_graphics_clock>
+				<supported_graphics_clock>860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>835 MHz</supported_graphics_clock>
+				<supported_graphics_clock>822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>797 MHz</supported_graphics_clock>
+				<supported_graphics_clock>784 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>759 MHz</supported_graphics_clock>
+				<supported_graphics_clock>746 MHz</supported_graphics_clock>
+				<supported_graphics_clock>734 MHz</supported_graphics_clock>
+				<supported_graphics_clock>721 MHz</supported_graphics_clock>
+				<supported_graphics_clock>708 MHz</supported_graphics_clock>
+				<supported_graphics_clock>696 MHz</supported_graphics_clock>
+				<supported_graphics_clock>683 MHz</supported_graphics_clock>
+				<supported_graphics_clock>670 MHz</supported_graphics_clock>
+				<supported_graphics_clock>658 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>632 MHz</supported_graphics_clock>
+				<supported_graphics_clock>620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>594 MHz</supported_graphics_clock>
+				<supported_graphics_clock>582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>569 MHz</supported_graphics_clock>
+				<supported_graphics_clock>556 MHz</supported_graphics_clock>
+				<supported_graphics_clock>544 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+	</gpu>
+
+</nvidia_smi_log>


### PR DESCRIPTION
- uses the `nvidia-smi` tool to collect metrics.
- initial version will use XML format only and be disabled by default (needed for deprecating the python version first).
- csv support (much faster, but [fewer metrics](https://github.com/netdata/netdata/issues/10362#issuecomment-1022174067)) will be added later.