### PR TITLE
feat(redis): add ping latency chart

### DIFF
--- a/modules/redis/README.md
+++ b/modules/redis/README.md
@@ -27,6 +27,7 @@ It collects information and statistics about the server executing the following 
 
 ### Performance
 
+- Ping latency in `seconds`
 - Processed commands in `commands/s`
 - Keys lookup hit rate in `percentage`
 

--- a/modules/redis/charts.go
+++ b/modules/redis/charts.go
@@ -8,6 +8,7 @@ const (
 	prioConnections = module.Priority + iota
 	prioClients
 
+	prioPingLatency
 	prioCommands
 	prioKeyLookupHitRate
 
@@ -39,6 +40,7 @@ var redisCharts = module.Charts{
 	chartConnections.Copy(),
 	chartClients.Copy(),
 
+	pingLatencyCommands.Copy(),
 	chartCommands.Copy(),
 	chartKeyLookupHitRate.Copy(),
 
@@ -95,6 +97,20 @@ var (
 )
 
 var (
+	pingLatencyCommands = module.Chart{
+		ID:       "ping_latency",
+		Title:    "Ping latency",
+		Units:    "seconds",
+		Fam:      "performance",
+		Ctx:      "redis.ping_latency",
+		Priority: prioPingLatency,
+		Type:     module.Area,
+		Dims: module.Dims{
+			{ID: "ping_latency_min", Name: "min", Div: 1e6},
+			{ID: "ping_latency_max", Name: "max", Div: 1e6},
+			{ID: "ping_latency_avg", Name: "avg", Div: 1e6},
+		},
+	}
 	chartCommands = module.Chart{
 		ID:       "commands",
 		Title:    "Processed commands",

--- a/modules/redis/init.go
+++ b/modules/redis/init.go
@@ -11,14 +11,14 @@ import (
 	"github.com/go-redis/redis/v8"
 )
 
-func (r Redis) validateConfig() error {
+func (r *Redis) validateConfig() error {
 	if r.Address == "" {
 		return errors.New("'address' not set")
 	}
 	return nil
 }
 
-func (r Redis) initRedisClient() (*redis.Client, error) {
+func (r *Redis) initRedisClient() (*redis.Client, error) {
 	opts, err := redis.ParseURL(r.Address)
 	if err != nil {
 		return nil, err
@@ -42,6 +42,6 @@ func (r Redis) initRedisClient() (*redis.Client, error) {
 	return redis.NewClient(opts), nil
 }
 
-func (r Redis) initCharts() (*module.Charts, error) {
+func (r *Redis) initCharts() (*module.Charts, error) {
 	return redisCharts.Copy(), nil
 }


### PR DESCRIPTION
Part of netdata/netdata#13687

- send 5 [PING](https://redis.io/commands/ping/) commands.
- measure the elapsed time.
- calc min, max, and average.


<img width="1365" alt="Screenshot 2022-09-23 at 13 00 54" src="https://user-images.githubusercontent.com/22274335/191937344-2b030359-cfa1-4f6d-8439-bcc2ea7fcd82.png">

