### PR TITLE
fix(cassandra): don't collect and blacklist table metric for now

### DIFF
--- a/modules/cassandra/README.md
+++ b/modules/cassandra/README.md
@@ -42,7 +42,6 @@ All metrics have "cassandra." prefix.
 | cache_hit_rate                    | global | hits, misses |   events/s   |
 | cache_size                        | global |     size     |    bytes     |
 | storage_live_disk_space_used      | global |     used     |    bytes     |
-| storage_total_disk_space_used     | global |     used     |    bytes     |
 | compaction_completed_tasks_rate   | global |  completed   |   tasks/s    |
 | compaction_pending_tasks_count    | global |   pending    |    tasks     |
 | compaction_compacted_rate         | global |  compacted   |   bytes/s    |

--- a/modules/cassandra/cassandra_test.go
+++ b/modules/cassandra/cassandra_test.go
@@ -15,12 +15,12 @@ import (
 )
 
 var (
-	vMetrics, _ = os.ReadFile("testdata/metrics.txt")
+	dataMetrics, _ = os.ReadFile("testdata/metrics.txt")
 )
 
 func Test_TestData(t *testing.T) {
 	for name, data := range map[string][]byte{
-		"vMetrics": vMetrics,
+		"dataMetrics": dataMetrics,
 	} {
 		assert.NotNilf(t, data, name)
 	}
@@ -137,7 +137,6 @@ func TestCassandra_Collect(t *testing.T) {
 				"jvm_gc_parnew_time":                   937,
 				"storage_exceptions":                   0,
 				"storage_load":                         145838019,
-				"tables_total_disk_space_used":         145838019,
 				"thread_pools_active_tasks":            0,
 				"thread_pools_currently_blocked_tasks": 0,
 				"thread_pools_pending_tasks":           0,
@@ -172,7 +171,7 @@ func TestCassandra_Collect(t *testing.T) {
 func prepareCassandra() (c *Cassandra, cleanup func()) {
 	ts := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write(vMetrics)
+			_, _ = w.Write(dataMetrics)
 		}))
 
 	c = New()

--- a/modules/cassandra/charts.go
+++ b/modules/cassandra/charts.go
@@ -14,7 +14,6 @@ const (
 	prioCacheSize
 
 	prioStorageLiveDiskSpaceUsed
-	prioStorageTotalDiskSpaceUsed
 
 	prioCompactionCompletedTasksRate
 	prioCompactionPendingTasksCount
@@ -45,7 +44,6 @@ var baseCharts = module.Charts{
 	chartCacheSize.Copy(),
 
 	chartStorageLiveDiskSpaceUsed.Copy(),
-	chartStorageTotalDiskSpaceUsed.Copy(),
 
 	chartCompactionCompletedTasksRate.Copy(),
 	chartCompactionPendingTasksCount.Copy(),
@@ -144,17 +142,6 @@ var (
 		Priority: prioStorageLiveDiskSpaceUsed,
 		Dims: module.Dims{
 			{ID: "storage_load", Name: "used"},
-		},
-	}
-	chartStorageTotalDiskSpaceUsed = module.Chart{
-		ID:       "storage_total_disk_space_used",
-		Title:    "Total disk space used",
-		Units:    "bytes",
-		Fam:      "disk usage",
-		Ctx:      "cassandra.storage_total_disk_space_used",
-		Priority: prioStorageTotalDiskSpaceUsed,
-		Dims: module.Dims{
-			{ID: "tables_total_disk_space_used", Name: "used"},
 		},
 	}
 )

--- a/modules/cassandra/collect.go
+++ b/modules/cassandra/collect.go
@@ -48,7 +48,6 @@ func (c *Cassandra) collectMetrics(mx *cassandraMetrics, pms prometheus.Metrics)
 	c.collectDroppedMessagesMetrics(mx, pms)
 	c.collectThreadPoolsMetrics(mx, pms)
 	c.collectStorageMetrics(mx, pms)
-	c.collectTableMetrics(mx, pms)
 	c.collectCacheMetrics(mx, pms)
 	c.collectJVMMetrics(mx, pms)
 	c.collectCompactionMetrics(mx, pms)
@@ -147,19 +146,6 @@ func (c *Cassandra) collectStorageMetrics(mx *cassandraMetrics, pms prometheus.M
 			addValue(&mx.storageLoad, pm.Value)
 		case "Exceptions":
 			addValue(&mx.storageExceptions, pm.Value)
-		}
-	}
-}
-
-func (c *Cassandra) collectTableMetrics(mx *cassandraMetrics, pms prometheus.Metrics) {
-	const metric = "org_apache_cassandra_metrics_table"
-
-	for _, pm := range pms.FindByName(metric + suffixCount) {
-		name := pm.Labels.Get("name")
-
-		switch name {
-		case "TotalDiskSpaceUsed":
-			addValue(&mx.tablesTotalDiskSpaceUsed, pm.Value)
 		}
 	}
 }

--- a/modules/cassandra/metrics.go
+++ b/modules/cassandra/metrics.go
@@ -28,9 +28,6 @@ type cassandraMetrics struct {
 	threadPoolsTotalBlockedTasks     *float64 `stm:"thread_pools_total_blocked_tasks"`
 	threadPoolsCurrentlyBlockedTasks *float64 `stm:"thread_pools_currently_blocked_tasks"`
 
-	// https://cassandra.apache.org/doc/latest/cassandra/operating/metrics.html#table-metrics
-	tablesTotalDiskSpaceUsed *float64 `stm:"tables_total_disk_space_used"`
-
 	// https://cassandra.apache.org/doc/latest/cassandra/operating/metrics.html#dropped-metrics
 	droppedMsgsOneMinute *float64 `stm:"dropped_messages_one_minute,1000,1"`
 

--- a/modules/cassandra/testdata/jmx_exporter.yaml
+++ b/modules/cassandra/testdata/jmx_exporter.yaml
@@ -1,8 +1,9 @@
 lowercaseOutputLabelNames: true
 lowercaseOutputName: true
 whitelistObjectNames: ["org.apache.cassandra.metrics:*"]
-# ColumnFamily is an alias for Table metrics
-#blacklistObjectNames: ["org.apache.cassandra.metrics:type=ColumnFamily,*"]
+blacklistObjectNames:
+  - "org.apache.cassandra.metrics:type=ColumnFamily,*"
+  - "org.apache.cassandra.metrics:type=Table,*"
 rules:
   # Throughput and Latency
   - pattern: org.apache.cassandra.metrics<type=(ClientRequest), scope=(Write|Read), name=(TotalLatency|Latency|Timeouts|Unavailables|Failures)><>(Count)
@@ -18,7 +19,7 @@ rules:
   - pattern: org.apache.cassandra.metrics<type=(Storage), name=(Load|Exceptions)><>(Count)
 
   # Tables
-  - pattern: org.apache.cassandra.metrics<type=(Table), keyspace=(\S*), scope=(\S*), name=(TotalDiskSpaceUsed)><>(Count)
+  #  - pattern: org.apache.cassandra.metrics<type=(Table), keyspace=(\S*), scope=(\S*), name=(TotalDiskSpaceUsed)><>(Count)
 
   # Compaction
   - pattern: org.apache.cassandra.metrics<type=(Compaction), name=(CompletedTasks|PendingTasks)><>(Value)


### PR DESCRIPTION
querying table metrics (seems) puts a lot of pressure on Cassandra, not needed because we don't really use them.