### PR TITLE
Change call for proper function

### DIFF
--- a/modules/wmi/collect_process.go
+++ b/modules/wmi/collect_process.go
@@ -85,7 +85,7 @@ func (w *WMI) collectProcess(mx map[string]int64, pms prometheus.Metrics) {
 	for proc := range w.cache.processes {
 		if !seen[proc] {
 			delete(w.cache.processes, proc)
-			w.removeServiceCharts(proc)
+			w.removeProcessFromCharts(proc)
 		}
 	}
 }


### PR DESCRIPTION
During the development of IIS module I observed that we inverted the caller to remove charts.