### PR TITLE
fix(whoisquery): handle ExpirationDate with space

### DIFF
--- a/modules/whoisquery/provider.go
+++ b/modules/whoisquery/provider.go
@@ -3,6 +3,7 @@
 package whoisquery
 
 import (
+	"strings"
 	"time"
 
 	"github.com/araddon/dateparse"
@@ -39,6 +40,13 @@ func (f *fromNet) remainingTime() (float64, error) {
 	result, err := whoisparser.Parse(raw)
 	if err != nil {
 		return 0, err
+	}
+
+	// https://community.netdata.cloud/t/whois-query-monitor-cannot-parse-expiration-time/3485
+	if strings.Contains(result.Domain.ExpirationDate, " ") {
+		if v, err := time.Parse("2006.01.02 15:04:05", result.Domain.ExpirationDate); err == nil {
+			return time.Until(v).Seconds(), nil
+		}
 	}
 
 	expire, err := dateparse.ParseAny(result.Domain.ExpirationDate)


### PR DESCRIPTION
Reported in https://community.netdata.cloud/t/whois-query-monitor-cannot-parse-expiration-time/3485