### PR TITLE
fix(postgres):  protect schema/table names with quote_ident

### DIFF
--- a/modules/postgres/queries.go
+++ b/modules/postgres/queries.go
@@ -573,7 +573,7 @@ SELECT current_database()                                   as datname,
        autovacuum_count,
        analyze_count,
        autoanalyze_count,
-       pg_total_relation_size(schemaname || '.' || relname) as total_relation_size
+       pg_total_relation_size(quote_ident(schemaname) || '.' || quote_ident(relname)) as total_relation_size
 FROM pg_stat_user_tables;
 `
 }


### PR DESCRIPTION
In the case of specific characters in schema or table names, the request failed with: `ERROR:  relation "schemaname.relname" does not exist`