### PR TITLE
fix(postgres): add missing schemaname to indexrelname when using pg_relation_size

### DIFF
--- a/modules/postgres/queries.go
+++ b/modules/postgres/queries.go
@@ -608,7 +608,7 @@ SELECT current_database()                                as datname,
        idx_scan,
        idx_tup_read,
        idx_tup_fetch,
-       pg_relation_size(quote_ident(indexrelname)::text) as size
+       pg_relation_size(quote_ident(schemaname) || '.' || quote_ident(indexrelname)::text) as size
 FROM pg_stat_user_indexes;
 `
 }


### PR DESCRIPTION
if the table is not in public or search_path, it can not find the pg_relation_size for the indexrelname