### PR TITLE
add commented example to pull from node exporter demo

### DIFF
--- a/config/go.d/prometheus.conf
+++ b/config/go.d/prometheus.conf
@@ -207,6 +207,9 @@ jobs:
   # https://github.com/prometheus/prometheus/wiki/Default-port-allocations
   #  - name: node_exporter_local
   #    url: 'http://127.0.0.1:9100/metrics'
+  # example to pull from node exporter demo
+  #  - name: node_exporter_demo
+  #    url: 'https://node.demo.do.prometheus.io/metrics'
   - name: wireguard_local
     url: 'http://127.0.0.1:9586/metrics'
     expected_prefix: 'wireguard_'


### PR DESCRIPTION
Make it easy for users to get started with a working remote prometheus demo node exporter so they can see how it looks in netdata without having to set up a localhost prometheus which is what all the default examples and configs assume. 

https://node.demo.do.prometheus.io/metrics