### PR TITLE
chore(wmi): simplify

### DIFF
--- a/modules/wmi/collect_collector.go
+++ b/modules/wmi/collect_collector.go
@@ -12,19 +12,35 @@ const (
 )
 
 func (w *WMI) collectCollector(mx map[string]int64, pms prometheus.Metrics) {
+	seen := make(map[string]bool)
 	px := "collector_"
 	for _, pm := range pms.FindByName(metricCollectorDuration) {
 		if name := pm.Labels.Get("collector"); name != "" {
+			seen[name] = true
 			mx[px+name+"_duration"] = int64(pm.Value * precision)
 		}
 	}
 	for _, pm := range pms.FindByName(metricCollectorSuccess) {
 		if name := pm.Labels.Get("collector"); name != "" {
+			seen[name] = true
 			if pm.Value == 1 {
 				mx[px+name+"_status_success"], mx[px+name+"_status_fail"] = 1, 0
 			} else {
 				mx[px+name+"_status_success"], mx[px+name+"_status_fail"] = 0, 1
 			}
+		}
+	}
+
+	for name := range seen {
+		if !w.cache.collectors[name] {
+			w.cache.collectors[name] = true
+			w.addCollectorCharts(name)
+		}
+	}
+	for name := range w.cache.collectors {
+		if !seen[name] {
+			delete(w.cache.collectors, name)
+			w.removeCollectorCharts(name)
 		}
 	}
 }

--- a/modules/wmi/init.go
+++ b/modules/wmi/init.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"github.com/netdata/go.d.plugin/pkg/prometheus"
-	"github.com/netdata/go.d.plugin/pkg/prometheus/selector"
 	"github.com/netdata/go.d.plugin/pkg/web"
 )
 
@@ -22,11 +21,6 @@ func (w *WMI) initHTTPClient() (*http.Client, error) {
 	return web.NewHTTPClient(w.Client)
 }
 
-func (w *WMI) initPrometheusCheckClient(client *http.Client) (prometheus.Prometheus, error) {
-	sr, err := selector.Parse(metricCollectorSuccess)
-	if err != nil {
-		return nil, err
-	}
-
-	return prometheus.NewWithSelector(client, w.Request, sr), nil
+func (w *WMI) initPrometheusClient(client *http.Client) (prometheus.Prometheus, error) {
+	return prometheus.New(client, w.Request), nil
 }

--- a/modules/wmi/wmi.go
+++ b/modules/wmi/wmi.go
@@ -40,10 +40,7 @@ func New() *WMI {
 			iis:          make(map[string]bool),
 			services:     make(map[string]bool),
 		},
-		charts:      &module.Charts{},
-		doCheck:     true,
-		doSlowEvery: time.Second * 30,
-		slowCache:   make(map[string]int64),
+		charts: &module.Charts{},
 	}
 }
 
@@ -61,13 +58,7 @@ type (
 		doCheck bool
 
 		httpClient *http.Client
-		promCheck  prometheus.Prometheus
-		promFast   prometheus.Prometheus
-		promSlow   prometheus.Prometheus
-
-		doSlowTime  time.Time
-		doSlowEvery time.Duration
-		slowCache   map[string]int64
+		prom       prometheus.Prometheus
 
 		cache cache
 	}
@@ -97,12 +88,12 @@ func (w *WMI) Init() bool {
 	}
 	w.httpClient = httpClient
 
-	prom, err := w.initPrometheusCheckClient(w.httpClient)
+	prom, err := w.initPrometheusClient(w.httpClient)
 	if err != nil {
 		w.Errorf("init prometheus clients: %v", err)
 		return false
 	}
-	w.promCheck = prom
+	w.prom = prom
 
 	return true
 }


### PR DESCRIPTION
For some reason querying service individually is slower than querying everything.

```cmd
go.d.plugin@ilyam8 (simplify_wmi) $ time curl -qs "http://10.10.10.128:9182/metrics" > /dev/null

real	0m0.415s
user	0m0.007s
sys	0m0.013s
go.d.plugin@ilyam8 (simplify_wmi) $ time curl -qs "http://10.10.10.128:9182/metrics?collect[]=service" > /dev/null

real	0m0.631s
user	0m0.008s
sys	0m0.015s
```