### PR TITLE
prefer user wmi.conf over windows.conf

### DIFF
--- a/agent/job/discovery/file/parse.go
+++ b/agent/job/discovery/file/parse.go
@@ -44,6 +44,11 @@ func parse(req confgroup.Registry, path string) (*confgroup.Group, error) {
 
 func parseStaticFormat(reg confgroup.Registry, path string, bs []byte) (*confgroup.Group, error) {
 	name := fileName(path)
+	// TODO: properly handle module renaming
+	// See agent/setup.go buildDiscoveryConf() for details
+	if name == "wmi" {
+		name = "windows"
+	}
 	modDef, ok := reg.Lookup(name)
 	if !ok {
 		return nil, nil

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -119,6 +119,22 @@ func (a *Agent) buildDiscoveryConf(enabled module.Registry) discovery.Config {
 	}
 
 	for name := range enabled {
+		// TODO: properly handle module renaming
+		// This is just a quick fix for wmi=>windows. We need to prefer user wmi.conf over windows.conf
+		// 2nd part of this fix is in /agent/job/discovery/file/parse.go parseStaticFormat()
+		if name == "windows" {
+			cfgName := "wmi.conf"
+			a.Infof("looking for '%s' in %v", cfgName, a.ModulesConfDir)
+
+			path, err := a.ModulesConfDir.Find(cfgName)
+
+			if err == nil && strings.Contains(path, "etc/netdata") {
+				a.Infof("found '%s", path)
+				readPaths = append(readPaths, path)
+				continue
+			}
+		}
+
 		cfgName := name + ".conf"
 		a.Infof("looking for '%s' in %v", cfgName, a.ModulesConfDir)
 

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -120,6 +120,7 @@ func (a *Agent) buildDiscoveryConf(enabled module.Registry) discovery.Config {
 
 	for name := range enabled {
 		// TODO: properly handle module renaming
+		// We need to announce this change in Netdata v1.39.0 release notes and then remove this workaround.
 		// This is just a quick fix for wmi=>windows. We need to prefer user wmi.conf over windows.conf
 		// 2nd part of this fix is in /agent/job/discovery/file/parse.go parseStaticFormat()
 		if name == "windows" {


### PR DESCRIPTION
https://github.com/netdata/go.d.plugin/pull/1075 follow-up PR.

We have no logic that handles module renaming. It is the first time we do it, so not sure we need it all. This is just a quick and temporary fix. We need to announce this change in the next Netdata release notes and then remove it.