### PR TITLE
Fix broken links in .md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,6 @@ forums. We have a whole [category](https://community.netdata.cloud/c/agent-devel
 ### How to develop a collector
 
 - Take a look at our [contributing guidelines](https://learn.netdata.cloud/contribute/handbook).
-- Read
-  the [How to develop a collector in Go](https://github.com/netdata/go.d.plugin/tree/master/docs/how-to-write-a-module.md)
-  guide.
 - [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) this repository to your personal
   GitHub account.
 - [Clone](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository#:~:text=to%20GitHub%20Desktop-,On%20GitHub%2C%20navigate%20to%20the%20main%20page%20of%20the%20repository,Desktop%20to%20complete%20the%20clone.)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ custom_edit_url: https://github.com/netdata/go.d.plugin/edit/master/README.md
 sidebar_label: "go.d.plugin"
 learn_status: "Published"
 learn_topic_type: "Tasks"
-learn_rel_path: "Developers/External plugins"
+learn_rel_path: "Developers/External plugins/go.d.plugin"
 sidebar_position: 1
 -->
 

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -1,15 +1,22 @@
+<!--
+title: "Helper Packages"
+custom_edit_url: "https://github.com/netdata/go.d.plugin/edit/master/pkg/README.md"
+sidebar_label: "Helper Packages"
+learn_status: "Published"
+learn_rel_path: "Developers/External plugins/go.d.plugin"
+-->
+
 # Helper Packages
 
 - if you need IP ranges consider to
-  use [`iprange`](https://github.com/netdata/go.d.plugin/tree/master/pkg/iprange#iprange).
+  use [`iprange`](https://github.com/netdata/go.d.plugin/blob/master/modules/pulsar/README.md).
 - if you parse an application log files, then [`log`](https://github.com/netdata/go.d.plugin/tree/master/pkg/logs) is
   handy.
 - if you need filtering
-  check [`matcher`](https://github.com/netdata/go.d.plugin/tree/master/pkg/matcher#supported-format).
+  check [`matcher`](https://github.com/netdata/go.d.plugin/blob/master/pkg/matcher/README.md).
 - if you collect metrics from an HTTP endpoint use [`web`](https://github.com/netdata/go.d.plugin/tree/master/pkg/web).
 - if you collect metrics from a prometheus endpoint,
   then [`prometheus`](https://github.com/netdata/go.d.plugin/tree/master/pkg/prometheus)
-  and [`web`](https://github.com/netdata/go.d.plugin/tree/master/pkg/web) is what you need.
-- [`tlscfg`](https://github.com/netdata/go.d.plugin/tree/master/pkg/tlscfg) provides TLS support.
-- [`stm`](https://github.com/netdata/go.d.plugin/tree/master/pkg/stm) helps you to convert any struct to
-  a `map[string]int64`.
+  and [`web`](https://github.com/netdata/go.d.plugin/blob/master/pkg/web/README.md) is what you need.
+- [`tlscfg`](https://github.com/netdata/go.d.plugin/blob/master/pkg/tlscfg/README.md) provides TLS support.
+- [`stm`](https://github.com/netdata/go.d.plugin/blob/master/pkg/stm/README.md) helps you to convert any struct to a `map[string]int64`.

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -3,7 +3,7 @@ title: "Helper Packages"
 custom_edit_url: "https://github.com/netdata/go.d.plugin/edit/master/pkg/README.md"
 sidebar_label: "Helper Packages"
 learn_status: "Published"
-learn_rel_path: "Developers/External plugins/go.d.plugin"
+learn_rel_path: "Developers/External plugins/go.d.plugin/Helper Packages"
 -->
 
 # Helper Packages

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -9,7 +9,7 @@ learn_rel_path: "Developers/External plugins/go.d.plugin/Helper Packages"
 # Helper Packages
 
 - if you need IP ranges consider to
-  use [`iprange`](https://github.com/netdata/go.d.plugin/blob/master/modules/pulsar/README.md).
+  use [`iprange`](https://github.com/netdata/go.d.plugin/blob/master/pkg/iprange/README.md).
 - if you parse an application log files, then [`log`](https://github.com/netdata/go.d.plugin/tree/master/pkg/logs) is
   handy.
 - if you need filtering

--- a/pkg/iprange/README.md
+++ b/pkg/iprange/README.md
@@ -1,3 +1,11 @@
+<!--
+title: "iprange"
+custom_edit_url: "https://github.com/netdata/go.d.plugin/edit/master/pkg/iprange/README.md"
+sidebar_label: "iprange"
+learn_status: "Published"
+learn_rel_path: "Developers/External plugins/go.d.plugin/Helper Packages"
+-->
+
 # iprange
 
 This package helps you to work with IP ranges.

--- a/pkg/matcher/README.md
+++ b/pkg/matcher/README.md
@@ -1,4 +1,13 @@
-# Supported Format
+<!--
+title: "matcher"
+custom_edit_url: "https://github.com/netdata/go.d.plugin/edit/master/pkg/matcher/README.md"
+sidebar_label: "matcher"
+learn_status: "Published"
+learn_rel_path: "Developers/External plugins/go.d.plugin/Helper Packages"
+-->
+
+# matcher
+## Supported Format
 
 * string
 * glob

--- a/pkg/prometheus/selector/README.md
+++ b/pkg/prometheus/selector/README.md
@@ -1,3 +1,11 @@
+<!--
+title: "Time series selector"
+custom_edit_url: "https://github.com/netdata/go.d.plugin/edit/master/pkg/prometheus/selector/README.md"
+sidebar_label: "Time series selector"
+learn_status: "Published"
+learn_rel_path: "Developers/External plugins/go.d.plugin/Helper Packages"
+-->
+
 # Time Series Selector
 
 Selectors allow selecting and filtering of a set of time series.

--- a/pkg/stm/README.md
+++ b/pkg/stm/README.md
@@ -1,3 +1,11 @@
+<!--
+title: "stm"
+custom_edit_url: "https://github.com/netdata/go.d.plugin/edit/master/pkg/stm/README.md"
+sidebar_label: "stm"
+learn_status: "Published"
+learn_rel_path: "Developers/External plugins/go.d.plugin/Helper Packages"
+-->
+
 # stm
 
 This package helps you to convert a struct to `map[string]int64`.

--- a/pkg/tlscfg/README.md
+++ b/pkg/tlscfg/README.md
@@ -1,3 +1,11 @@
+<!--
+title: "tlscfg"
+custom_edit_url: "https://github.com/netdata/go.d.plugin/edit/master/pkg/tlscfg/README.md"
+sidebar_label: "tlscfg"
+learn_status: "Published"
+learn_rel_path: "Developers/External plugins/go.d.plugin/Helper Packages"
+-->
+
 # tlscfg
 
 This package contains client TLS configuration and function to create `tls.Config` from it.

--- a/pkg/web/README.md
+++ b/pkg/web/README.md
@@ -1,3 +1,11 @@
+<!--
+title: "web"
+custom_edit_url: "https://github.com/netdata/go.d.plugin/edit/master/pkg/web/README.md"
+sidebar_label: "web"
+learn_status: "Published"
+learn_rel_path: "Developers/External plugins/go.d.plugin/Helper Packages"
+-->
+
 # web
 
 This package contains HTTP related configurations (`Request`, `Client` and `HTTP` structs) and functions to


### PR DESCRIPTION
Related to netdata/learn#1349 
This is a WIP PR intended to fix broken links in markdown files, if there are any issues, where the missing link's info didn't get moved, but deleted, I will add checkbox items to decide what we should do about it.

- The [Contributing](https://github.com/netdata/go.d.plugin/blob/master/README.md?plain=1#:~:text=%23%23%20Contributing,done%20with%20testing.) section in the `README.md` has some old Learn links, and I removed a link that referred to a missing document.
- [The pulsar README](https://github.com/netdata/go.d.plugin/blob/master/modules/pulsar/README.md?plain=1#:~:text=To%20check%20matcher,matcher/README.md).) has a link to [`/pkg/matcher/README.md`](https://github.com/netdata/go.d.plugin/blob/master/pkg/matcher/README.md?plain=1) which we don't include in Learn. I will add it in a new section, to not confuse the current ordering effort, and we can decide then where it should go. (EDIT, this is the case for all the READMEs under `/pkg`)
