### PR TITLE
add k8s service discovery

### DIFF
--- a/agent/job/discovery/file/discovery.go
+++ b/agent/job/discovery/file/discovery.go
@@ -52,7 +52,7 @@ func NewDiscovery(cfg Config) (*Discovery, error) {
 	return &d, nil
 }
 
-func (d Discovery) String() string {
+func (d *Discovery) String() string {
 	return fmt.Sprintf("file discovery: %v", d.discoverers)
 }
 
@@ -84,6 +84,7 @@ func (d *Discovery) Run(ctx context.Context, in chan<- []*confgroup.Group) {
 	}
 
 	wg.Wait()
+
 	<-ctx.Done()
 }
 

--- a/agent/job/discovery/manager.go
+++ b/agent/job/discovery/manager.go
@@ -63,7 +63,7 @@ func NewManager(cfg Config) (*Manager, error) {
 	return mgr, nil
 }
 
-func (m Manager) String() string {
+func (m *Manager) String() string {
 	return fmt.Sprintf("discovery manager: %v", m.discoverers)
 }
 

--- a/agent/job/discovery/sd/discovery.go
+++ b/agent/job/discovery/sd/discovery.go
@@ -1,0 +1,168 @@
+package sd
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/netdata/go.d.plugin/agent/job/discovery/sd/kubernetes"
+	"github.com/netdata/go.d.plugin/agent/job/discovery/sd/model"
+	"github.com/netdata/go.d.plugin/logger"
+)
+
+func NewDiscoveryManager(cfg DiscoveryManagerConfig) (*DiscoveryManager, error) {
+	if err := validateDiscoveryManagerConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	d := &DiscoveryManager{
+		send:        make(chan struct{}, 1),
+		sendEvery:   5 * time.Second,
+		discoverers: make([]Discoverer, 0),
+		mux:         sync.RWMutex{},
+		groups:      make(map[string]model.TargetGroup),
+		Logger:      logger.New("discovery", "manager"),
+	}
+
+	if err := d.registerDiscoverers(cfg); err != nil {
+		return nil, err
+	}
+
+	d.Infof("registered: %v", d.discoverers)
+	return d, nil
+}
+
+type (
+	DiscoveryManagerConfig struct {
+		K8S []kubernetes.DiscoveryConfig `yaml:"k8s"`
+	}
+	DiscoveryManager struct {
+		*logger.Logger
+
+		discoverers []Discoverer
+		send        chan struct{}
+		sendEvery   time.Duration
+
+		mux    sync.RWMutex
+		groups map[string]model.TargetGroup
+	}
+)
+
+func (dm *DiscoveryManager) registerDiscoverers(cfg DiscoveryManagerConfig) error {
+	for _, cfg := range cfg.K8S {
+		d, err := kubernetes.NewDiscovery(cfg)
+		if err != nil {
+			return err
+		}
+		dm.discoverers = append(dm.discoverers, d)
+	}
+	return nil
+}
+
+func (dm *DiscoveryManager) Discover(ctx context.Context, in chan<- []model.TargetGroup) {
+	dm.Info("instance is started")
+	defer dm.Info("instance is stopped")
+
+	var wg sync.WaitGroup
+
+	for _, d := range dm.discoverers {
+		wg.Add(1)
+		go func(d Discoverer) { defer wg.Done(); dm.runDiscoverer(ctx, d) }(d)
+	}
+
+	wg.Add(1)
+	go func() { defer wg.Done(); dm.run(ctx, in) }()
+	wg.Wait()
+
+	<-ctx.Done()
+}
+
+func (dm *DiscoveryManager) runDiscoverer(ctx context.Context, d Discoverer) {
+	updates := make(chan []model.TargetGroup)
+	go d.Discover(ctx, updates)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case groups, ok := <-updates:
+			if !ok {
+				return
+			}
+			func() {
+				dm.mux.Lock()
+				defer dm.mux.Unlock()
+
+				dm.addTargetGroups(groups)
+				dm.triggerSend()
+			}()
+		}
+	}
+}
+
+func (dm *DiscoveryManager) run(ctx context.Context, in chan<- []model.TargetGroup) {
+	tk := time.NewTicker(dm.sendEvery)
+	defer tk.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tk.C:
+			select {
+			case <-dm.send:
+				dm.trySend(in)
+			default:
+			}
+		}
+	}
+}
+
+func (dm *DiscoveryManager) trySend(in chan<- []model.TargetGroup) {
+	dm.mux.Lock()
+	defer dm.mux.Unlock()
+
+	select {
+	case in <- dm.listTargetGroups():
+		dm.resetTargetGroups()
+	default:
+		dm.triggerSend()
+	}
+}
+
+func (dm *DiscoveryManager) triggerSend() {
+	select {
+	case dm.send <- struct{}{}:
+	default:
+	}
+}
+
+func (dm *DiscoveryManager) addTargetGroups(groups []model.TargetGroup) {
+	for _, group := range groups {
+		if group != nil {
+			dm.groups[group.Source()] = group
+		}
+	}
+}
+
+func (dm *DiscoveryManager) resetTargetGroups() {
+	for key := range dm.groups {
+		delete(dm.groups, key)
+	}
+}
+
+func (dm *DiscoveryManager) listTargetGroups() []model.TargetGroup {
+	groups := make([]model.TargetGroup, 0, len(dm.groups))
+	for _, group := range dm.groups {
+		groups = append(groups, group)
+	}
+	return groups
+}
+
+func validateDiscoveryManagerConfig(cfg DiscoveryManagerConfig) error {
+	if len(cfg.K8S) == 0 {
+		return errors.New("empty config")
+	}
+	return nil
+}

--- a/agent/job/discovery/sd/discovery_test.go
+++ b/agent/job/discovery/sd/discovery_test.go
@@ -1,0 +1,203 @@
+package sd
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/netdata/go.d.plugin/agent/job/discovery/sd/model"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoveryManager_Discover(t *testing.T) {
+	tests := map[string]func() kubernetesDiscoverySim{
+		"2 discoverers unique groups with delayed collect": func() kubernetesDiscoverySim {
+			const numGroups, numTargets = 2, 2
+			d1 := prepareMockDiscoverer("test1", numGroups, numTargets)
+			d2 := prepareMockDiscoverer("test2", numGroups, numTargets)
+			mgr := prepareKubernetesDiscoverer(d1, d2)
+			expected := combineGroups(d1.groups, d2.groups)
+
+			sim := kubernetesDiscoverySim{
+				mgr:            mgr,
+				collectDelay:   mgr.sendEvery + time.Second,
+				expectedGroups: expected,
+			}
+			return sim
+		},
+		"2 discoverers unique groups": func() kubernetesDiscoverySim {
+			const numGroups, numTargets = 2, 2
+			d1 := prepareMockDiscoverer("test1", numGroups, numTargets)
+			d2 := prepareMockDiscoverer("test2", numGroups, numTargets)
+			mgr := prepareKubernetesDiscoverer(d1, d2)
+			expected := combineGroups(d1.groups, d2.groups)
+
+			sim := kubernetesDiscoverySim{
+				mgr:            mgr,
+				expectedGroups: expected,
+			}
+			return sim
+		},
+		"2 discoverers same groups": func() kubernetesDiscoverySim {
+			const numGroups, numTargets = 2, 2
+			d1 := prepareMockDiscoverer("test1", numGroups, numTargets)
+			mgr := prepareKubernetesDiscoverer(d1, d1)
+			expected := combineGroups(d1.groups)
+
+			sim := kubernetesDiscoverySim{
+				mgr:            mgr,
+				expectedGroups: expected,
+			}
+			return sim
+		},
+		"2 discoverers empty groups": func() kubernetesDiscoverySim {
+			const numGroups, numTargets = 1, 0
+			d1 := prepareMockDiscoverer("test1", numGroups, numTargets)
+			d2 := prepareMockDiscoverer("test2", numGroups, numTargets)
+			mgr := prepareKubernetesDiscoverer(d1, d2)
+			expected := combineGroups(d1.groups, d2.groups)
+
+			sim := kubernetesDiscoverySim{
+				mgr:            mgr,
+				expectedGroups: expected,
+			}
+			return sim
+		},
+		"2 discoverers nil groups": func() kubernetesDiscoverySim {
+			const numGroups, numTargets = 0, 0
+			d1 := prepareMockDiscoverer("test1", numGroups, numTargets)
+			d2 := prepareMockDiscoverer("test2", numGroups, numTargets)
+			mgr := prepareKubernetesDiscoverer(d1, d2)
+
+			sim := kubernetesDiscoverySim{
+				mgr:            mgr,
+				expectedGroups: nil,
+			}
+			return sim
+		},
+	}
+
+	for name, sim := range tests {
+		t.Run(name, func(t *testing.T) { sim().run(t) })
+	}
+}
+
+func prepareMockDiscoverer(source string, groups, targets int) mockDiscoverer {
+	d := mockDiscoverer{}
+
+	for i := 0; i < groups; i++ {
+		group := mockGroup{
+			source: fmt.Sprintf("%s_group_%d", source, i+1),
+		}
+		for j := 0; j < targets; j++ {
+			group.targets = append(group.targets,
+				mockTarget{Name: fmt.Sprintf("%s_group_%d_target_%d", source, i+1, j+1)})
+		}
+		d.groups = append(d.groups, group)
+	}
+	return d
+}
+
+func prepareKubernetesDiscoverer(discoverers ...Discoverer) *DiscoveryManager {
+	mgr := &DiscoveryManager{
+		send:        make(chan struct{}, 1),
+		sendEvery:   2 * time.Second,
+		discoverers: discoverers,
+		mux:         sync.RWMutex{},
+		groups:      make(map[string]model.TargetGroup),
+	}
+	return mgr
+}
+
+type mockDiscoverer struct {
+	groups []model.TargetGroup
+}
+
+func (md mockDiscoverer) Discover(ctx context.Context, out chan<- []model.TargetGroup) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case out <- md.groups:
+			return
+		}
+	}
+}
+
+type mockGroup struct {
+	targets []model.Target
+	source  string
+}
+
+func (mg mockGroup) Targets() []model.Target { return mg.targets }
+func (mg mockGroup) Source() string          { return mg.source }
+
+type mockTarget struct {
+	Name string
+}
+
+func (mt mockTarget) Tags() model.Tags { return model.Tags{} }
+func (mt mockTarget) TUID() string     { return "" }
+func (mt mockTarget) Hash() uint64     { return 0 }
+
+func combineGroups(groups ...[]model.TargetGroup) (combined []model.TargetGroup) {
+	for _, set := range groups {
+		combined = append(combined, set...)
+	}
+	return combined
+}
+
+type kubernetesDiscoverySim struct {
+	mgr            *DiscoveryManager
+	collectDelay   time.Duration
+	expectedGroups []model.TargetGroup
+}
+
+func (sim kubernetesDiscoverySim) run(t *testing.T) {
+	t.Helper()
+	require.NotNil(t, sim.mgr)
+
+	in, out := make(chan []model.TargetGroup), make(chan []model.TargetGroup)
+	go sim.collectGroups(t, in, out)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sim.mgr.Discover(ctx, in)
+
+	actualGroups := <-out
+
+	sortGroups(sim.expectedGroups)
+	sortGroups(actualGroups)
+
+	assert.Equal(t, sim.expectedGroups, actualGroups)
+}
+
+func (sim kubernetesDiscoverySim) collectGroups(t *testing.T, in, out chan []model.TargetGroup) {
+	time.Sleep(sim.collectDelay)
+
+	timeout := sim.mgr.sendEvery + time.Second*2
+	var groups []model.TargetGroup
+loop:
+	for {
+		select {
+		case inGroups := <-in:
+			if groups = append(groups, inGroups...); len(groups) >= len(sim.expectedGroups) {
+				break loop
+			}
+		case <-time.After(timeout):
+			t.Logf("discovery %s timed out after %s, got %d groups, expected %d, some events are skipped",
+				sim.mgr.discoverers, timeout, len(groups), len(sim.expectedGroups))
+			break loop
+		}
+	}
+	out <- groups
+}
+
+func sortGroups(groups []model.TargetGroup) {
+	sort.Slice(groups, func(i, j int) bool { return groups[i].Source() < groups[j].Source() })
+}

--- a/agent/job/discovery/sd/funcmap.go
+++ b/agent/job/discovery/sd/funcmap.go
@@ -1,0 +1,105 @@
+package sd
+
+import (
+	"regexp"
+	"sync"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+	"github.com/gobwas/glob"
+)
+
+var funcMap = func() template.FuncMap {
+	fm := sprig.HermeticTxtFuncMap()
+
+	custom := map[string]any{
+		"glob": globAny,
+		"re":   regexpAny,
+	}
+
+	for name, fn := range custom {
+		fm[name] = fn
+	}
+
+	return fm
+}()
+
+func globAny(value, pattern string, rest ...string) bool {
+	switch len(rest) {
+	case 0:
+		return globOnce(value, pattern)
+	default:
+		return globOnce(value, pattern) || globAny(value, rest[0], rest[1:]...)
+	}
+}
+
+func regexpAny(value, pattern string, rest ...string) bool {
+	switch len(rest) {
+	case 0:
+		return regexpOnce(value, pattern)
+	default:
+		return regexpOnce(value, pattern) || regexpAny(value, rest[0], rest[1:]...)
+	}
+}
+
+func globOnce(value, pattern string) bool {
+	g, _ := globStore(pattern)
+	return g != nil && g.Match(value)
+}
+
+func regexpOnce(value, pattern string) bool {
+	r, _ := regexpStore(pattern)
+	return r != nil && r.MatchString(value)
+}
+
+// TODO: cleanup?
+var globStore = func() func(pattern string) (glob.Glob, error) {
+	var l sync.RWMutex
+	store := make(map[string]struct {
+		g   glob.Glob
+		err error
+	})
+
+	return func(pattern string) (glob.Glob, error) {
+		if pattern == "" {
+			return nil, nil
+		}
+
+		l.Lock()
+		defer l.Unlock()
+
+		entry, ok := store[pattern]
+		if !ok {
+			entry.g, entry.err = glob.Compile(pattern, '/')
+			store[pattern] = entry
+		}
+
+		return entry.g, entry.err
+	}
+}()
+
+// TODO: cleanup?
+var regexpStore = func() func(pattern string) (*regexp.Regexp, error) {
+	var l sync.RWMutex
+	store := make(map[string]struct {
+		r   *regexp.Regexp
+		err error
+	})
+
+	return func(pattern string) (*regexp.Regexp, error) {
+		if pattern == "" {
+			return nil, nil
+		}
+
+		l.Lock()
+		defer l.Unlock()
+
+		entry, ok := store[pattern]
+		if !ok {
+			entry.r, entry.err = regexp.Compile(pattern)
+			store[pattern] = entry
+		}
+
+		return entry.r, entry.err
+	}
+}()

--- a/agent/job/discovery/sd/funcmap_test.go
+++ b/agent/job/discovery/sd/funcmap_test.go
@@ -1,0 +1,86 @@
+package sd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_globAny(t *testing.T) {
+	tests := map[string]struct {
+		patterns  []string
+		value     string
+		wantFalse bool
+	}{
+		"one param, matches": {
+			patterns: []string{"*"},
+			value:    "value",
+		},
+		"one param, matches with *": {
+			patterns: []string{"**/value"},
+			value:    "/one/two/three/value",
+		},
+		"one param, not matches": {
+			patterns:  []string{"Value"},
+			value:     "value",
+			wantFalse: true,
+		},
+		"several params, last one matches": {
+			patterns: []string{"not", "matches", "*"},
+			value:    "value",
+		},
+		"several params, no matches": {
+			patterns:  []string{"not", "matches", "really"},
+			value:     "value",
+			wantFalse: true,
+		},
+	}
+
+	for name, test := range tests {
+		name := fmt.Sprintf("name: %s, patterns: '%v', value: '%s'", name, test.patterns, test.value)
+
+		if test.wantFalse {
+			assert.Falsef(t, globAny(test.value, test.patterns[0], test.patterns[1:]...), name)
+		} else {
+			assert.Truef(t, globAny(test.value, test.patterns[0], test.patterns[1:]...), name)
+		}
+	}
+}
+
+func Test_regexpAny(t *testing.T) {
+	tests := map[string]struct {
+		patterns  []string
+		value     string
+		wantFalse bool
+	}{
+		"one param, matches": {
+			patterns: []string{"^value$"},
+			value:    "value",
+		},
+		"one param, not matches": {
+			patterns:  []string{"^Value$"},
+			value:     "value",
+			wantFalse: true,
+		},
+		"several params, last one matches": {
+			patterns: []string{"not", "matches", "va[lue]{3}"},
+			value:    "value",
+		},
+		"several params, no matches": {
+			patterns:  []string{"not", "matches", "val[^l]ue"},
+			value:     "value",
+			wantFalse: true,
+		},
+	}
+
+	for name, test := range tests {
+		name := fmt.Sprintf("name: %s, patterns: '%v', value: '%s'", name, test.patterns, test.value)
+
+		if test.wantFalse {
+			assert.Falsef(t, regexpAny(test.value, test.patterns[0], test.patterns[1:]...), name)
+		} else {
+			assert.Truef(t, regexpAny(test.value, test.patterns[0], test.patterns[1:]...), name)
+		}
+	}
+}

--- a/agent/job/discovery/sd/kubernetes/clientset.go
+++ b/agent/job/discovery/sd/kubernetes/clientset.go
@@ -1,0 +1,62 @@
+package kubernetes
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+)
+
+const envFakeClient = "KUBERNETES_FAKE_CLIENTSET"
+
+func newClientset() (kubernetes.Interface, error) {
+	switch {
+	case os.Getenv(envFakeClient) != "":
+		return fake.NewSimpleClientset(), nil
+	case os.Getenv("KUBERNETES_SERVICE_HOST") != "" && os.Getenv("KUBERNETES_SERVICE_PORT") != "":
+		return newClientsetInCluster()
+	default:
+		return newClientsetOutOfCluster()
+	}
+}
+
+func newClientsetInCluster() (*kubernetes.Clientset, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	config.UserAgent = "Netdata/auto-discovery"
+
+	return kubernetes.NewForConfig(config)
+}
+
+func newClientsetOutOfCluster() (*kubernetes.Clientset, error) {
+	home := homeDir()
+	if home == "" {
+		return nil, errors.New("couldn't find home directory")
+	}
+
+	configPath := filepath.Join(home, ".kube", "config")
+	config, err := clientcmd.BuildConfigFromFlags("", configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	config.UserAgent = "Netdata/auto-discovery"
+
+	return kubernetes.NewForConfig(config)
+}
+
+func homeDir() string {
+	if h := os.Getenv("HOME"); h != "" {
+		return h
+	}
+	return os.Getenv("USERPROFILE") // windows
+}

--- a/agent/job/discovery/sd/kubernetes/kubernetes.go
+++ b/agent/job/discovery/sd/kubernetes/kubernetes.go
@@ -1,0 +1,292 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/netdata/go.d.plugin/agent/job/discovery/sd/model"
+	"github.com/netdata/go.d.plugin/logger"
+
+	"github.com/ilyam8/hashstructure"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const (
+	RolePod     = "pod"
+	RoleService = "service"
+)
+
+const (
+	envNodeName = "MY_NODE_NAME"
+)
+
+func NewDiscovery(cfg DiscoveryConfig) (*Discovery, error) {
+	if err := validateConfig(cfg); err != nil {
+		return nil, fmt.Errorf("k8s discovery config validation: %v", err)
+	}
+
+	d, err := initDiscovery(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("k8s discovery initialization ('%s'): %v", cfg.Role, err)
+	}
+
+	return d, nil
+}
+
+type DiscoveryConfig struct {
+	APIServer  string   `yaml:"api_server"`
+	Tags       string   `yaml:"tags"`
+	Namespaces []string `yaml:"namespaces"`
+	Role       string   `yaml:"role"`
+	LocalMode  bool     `yaml:"local_mode"`
+	Selector   struct {
+		Label string `yaml:"label"`
+		Field string `yaml:"field"`
+	} `yaml:"selector"`
+}
+
+type (
+	Discovery struct {
+		*logger.Logger
+
+		tags          model.Tags
+		namespaces    []string
+		role          string
+		selectorLabel string
+		selectorField string
+		client        kubernetes.Interface
+		discoverers   []discoverer
+		started       chan struct{}
+	}
+
+	discoverer interface {
+		Discover(ctx context.Context, ch chan<- []model.TargetGroup)
+	}
+)
+
+func (d *Discovery) String() string {
+	return "k8s discovery manager"
+}
+
+const resyncPeriod = 10 * time.Minute
+
+func (d *Discovery) Discover(ctx context.Context, in chan<- []model.TargetGroup) {
+	if err := d.setupDiscoverers(ctx); err != nil {
+		// TODO: no panic pls
+		panic(err)
+	}
+
+	var wg sync.WaitGroup
+	updates := make(chan []model.TargetGroup)
+
+	for _, dd := range d.discoverers {
+		wg.Add(1)
+		go func(dd discoverer) { defer wg.Done(); dd.Discover(ctx, updates) }(dd)
+	}
+
+	wg.Add(1)
+	go func() { defer wg.Done(); d.run(ctx, updates, in) }()
+
+	close(d.started)
+
+	wg.Wait()
+
+	<-ctx.Done()
+}
+
+func (d *Discovery) run(ctx context.Context, updates chan []model.TargetGroup, in chan<- []model.TargetGroup) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case groups := <-updates:
+			for _, group := range groups {
+				for _, target := range group.Targets() {
+					target.Tags().Merge(d.tags)
+				}
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case in <- groups:
+			}
+		}
+	}
+}
+
+func (d *Discovery) setupDiscoverers(ctx context.Context) error {
+	for _, namespace := range d.namespaces {
+		var dd discoverer
+		switch d.role {
+		case RolePod:
+			dd = d.setupPodDiscovery(ctx, namespace)
+		case RoleService:
+			dd = d.setupServiceDiscovery(ctx, namespace)
+		default:
+			return fmt.Errorf("unknown k8 discovery role: '%s'", d.role)
+		}
+		d.discoverers = append(d.discoverers, dd)
+	}
+
+	if len(d.discoverers) == 0 {
+		return errors.New("k8s cant run discovery: zero discoverers")
+	}
+
+	d.Infof("registered: %v", d.discoverers)
+	return nil
+}
+
+func (d *Discovery) setupPodDiscovery(ctx context.Context, namespace string) *PodDiscovery {
+	pod := d.client.CoreV1().Pods(namespace)
+	podLW := &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			opts.FieldSelector = d.selectorField
+			opts.LabelSelector = d.selectorLabel
+			return pod.List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			opts.FieldSelector = d.selectorField
+			opts.LabelSelector = d.selectorLabel
+			return pod.Watch(ctx, opts)
+		},
+	}
+
+	cmap := d.client.CoreV1().ConfigMaps(namespace)
+	cmapLW := &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return cmap.List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return cmap.Watch(ctx, opts)
+		},
+	}
+
+	secret := d.client.CoreV1().Secrets(namespace)
+	secretLW := &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return secret.List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return secret.Watch(ctx, opts)
+		},
+	}
+
+	return NewPodDiscovery(
+		cache.NewSharedInformer(podLW, &corev1.Pod{}, resyncPeriod),
+		cache.NewSharedInformer(cmapLW, &corev1.ConfigMap{}, resyncPeriod),
+		cache.NewSharedInformer(secretLW, &corev1.Secret{}, resyncPeriod),
+	)
+}
+
+func (d *Discovery) setupServiceDiscovery(ctx context.Context, namespace string) *ServiceDiscovery {
+	svc := d.client.CoreV1().Services(namespace)
+	clw := &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			opts.FieldSelector = d.selectorField
+			opts.LabelSelector = d.selectorLabel
+			return svc.List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			opts.FieldSelector = d.selectorField
+			opts.LabelSelector = d.selectorLabel
+			return svc.Watch(ctx, opts)
+		},
+	}
+	inf := cache.NewSharedInformer(clw, &corev1.Service{}, resyncPeriod)
+
+	return NewServiceDiscovery(inf)
+}
+
+func validateConfig(cfg DiscoveryConfig) error {
+	if !(cfg.Role == RolePod || cfg.Role == RoleService) {
+		return fmt.Errorf("invalid role '%s', valid roles: '%s', '%s'", cfg.Role, RolePod, RoleService)
+	}
+	if cfg.Tags == "" {
+		return fmt.Errorf("no tags set for '%s' role", cfg.Role)
+	}
+	return nil
+}
+
+func initDiscovery(cfg DiscoveryConfig) (*Discovery, error) {
+	tags, err := model.ParseTags(cfg.Tags)
+	if err != nil {
+		return nil, fmt.Errorf("parse config->tags: %v", err)
+	}
+
+	client, err := newClientset()
+	if err != nil {
+		return nil, fmt.Errorf("create clientset: %v", err)
+	}
+
+	namespaces := cfg.Namespaces
+	if len(namespaces) == 0 {
+		namespaces = []string{corev1.NamespaceAll}
+	}
+
+	if cfg.LocalMode && cfg.Role == RolePod {
+		name := os.Getenv(envNodeName)
+		if name == "" {
+			return nil, fmt.Errorf("local_mode is enabled, but env '%s' not set", envNodeName)
+		}
+
+		cfg.Selector.Field = joinSelectors(cfg.Selector.Field, "spec.nodeName="+name)
+	}
+
+	d := &Discovery{
+		tags:          tags,
+		namespaces:    namespaces,
+		role:          cfg.Role,
+		selectorLabel: cfg.Selector.Label,
+		selectorField: cfg.Selector.Field,
+		client:        client,
+		discoverers:   make([]discoverer, 0, len(namespaces)),
+		started:       make(chan struct{}),
+		Logger:        logger.New("k8s discovery", "kube"),
+	}
+
+	return d, nil
+}
+
+func enqueue(queue *workqueue.Type, obj any) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+	queue.Add(key)
+}
+
+func send(ctx context.Context, in chan<- []model.TargetGroup, group model.TargetGroup) {
+	if group == nil {
+		return
+	}
+	select {
+	case <-ctx.Done():
+	case in <- []model.TargetGroup{group}:
+	}
+}
+
+func calcHash(obj any) (uint64, error) {
+	return hashstructure.Hash(obj, nil)
+}
+
+func joinSelectors(srs ...string) string {
+	var i int
+	for _, v := range srs {
+		if v != "" {
+			srs[i] = v
+			i++
+		}
+	}
+	return strings.Join(srs[:i], ",")
+}

--- a/agent/job/discovery/sd/kubernetes/kubernetes_test.go
+++ b/agent/job/discovery/sd/kubernetes/kubernetes_test.go
@@ -1,0 +1,170 @@
+package kubernetes
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/netdata/go.d.plugin/agent/job/discovery/sd/model"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestMain(m *testing.M) {
+	_ = os.Setenv(envNodeName, "m01")
+	_ = os.Setenv(envFakeClient, "true")
+	code := m.Run()
+	_ = os.Unsetenv(envNodeName)
+	_ = os.Unsetenv(envFakeClient)
+	os.Exit(code)
+}
+
+func TestNew(t *testing.T) {
+	tests := map[string]struct {
+		cfg     DiscoveryConfig
+		wantErr bool
+	}{
+		"role pod and local mode": {
+			wantErr: false,
+			cfg:     DiscoveryConfig{Role: RolePod, Tags: "k8s", LocalMode: true},
+		},
+		"role service and local mode": {
+			wantErr: false,
+			cfg:     DiscoveryConfig{Role: RoleService, Tags: "k8s", LocalMode: true},
+		},
+		"empty config": {
+			wantErr: true,
+		},
+		"invalid role": {
+			wantErr: true,
+			cfg:     DiscoveryConfig{Role: "invalid"},
+		},
+		"lack of tags": {
+			wantErr: true,
+			cfg:     DiscoveryConfig{Role: RolePod},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			discovery, err := NewDiscovery(test.cfg)
+
+			if test.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, discovery)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, discovery)
+				if test.cfg.LocalMode && test.cfg.Role == RolePod {
+					assert.Contains(t, discovery.selectorField, "spec.nodeName=m01")
+				}
+				if test.cfg.LocalMode && test.cfg.Role != RolePod {
+					assert.Empty(t, discovery.selectorField)
+				}
+			}
+		})
+	}
+}
+
+func TestDiscovery_Discover(t *testing.T) {
+	const prod = "prod"
+	const dev = "dev"
+	prodNamespace := prepareNamespace(prod)
+	devNamespace := prepareNamespace(dev)
+
+	tests := map[string]func() discoverySim{
+		"multiple namespaces pod discovery": func() discoverySim {
+			httpdProd, nginxProd := prepareHTTPDPod(), prepareNGINXPod()
+			httpdProd.Namespace = prod
+			nginxProd.Namespace = prod
+
+			httpdDev, nginxDev := prepareHTTPDPod(), prepareNGINXPod()
+			httpdDev.Namespace = dev
+			nginxDev.Namespace = dev
+
+			discovery, _ := prepareDiscovery(
+				RolePod,
+				[]string{prod, dev},
+				prodNamespace, devNamespace, httpdProd, nginxProd, httpdDev, nginxDev)
+
+			sim := discoverySim{
+				discovery:        discovery,
+				sortBeforeVerify: true,
+				expectedGroups: []model.TargetGroup{
+					preparePodGroup(httpdDev),
+					preparePodGroup(nginxDev),
+					preparePodGroup(httpdProd),
+					preparePodGroup(nginxProd),
+				},
+			}
+			return sim
+		},
+		"multiple namespaces ClusterIP service discovery": func() discoverySim {
+			httpdProd, nginxProd := prepareHTTPDClusterIPService(), prepareNGINXClusterIPService()
+			httpdProd.Namespace = prod
+			nginxProd.Namespace = prod
+
+			httpdDev, nginxDev := prepareHTTPDClusterIPService(), prepareNGINXClusterIPService()
+			httpdDev.Namespace = dev
+			nginxDev.Namespace = dev
+
+			discovery, _ := prepareDiscovery(
+				RoleService,
+				[]string{prod, dev},
+				prodNamespace, devNamespace, httpdProd, nginxProd, httpdDev, nginxDev)
+
+			sim := discoverySim{
+				discovery:        discovery,
+				sortBeforeVerify: true,
+				expectedGroups: []model.TargetGroup{
+					prepareSvcGroup(httpdDev),
+					prepareSvcGroup(nginxDev),
+					prepareSvcGroup(httpdProd),
+					prepareSvcGroup(nginxProd),
+				},
+			}
+			return sim
+		},
+	}
+
+	for name, sim := range tests {
+		t.Run(name, func(t *testing.T) { sim().run(t) })
+	}
+}
+
+var discoveryTags model.Tags = map[string]struct{}{"k8s": {}}
+
+func prepareNamespaceAllDiscovery(role string, objects ...runtime.Object) (*Discovery, kubernetes.Interface) {
+	return prepareDiscovery(role, []string{corev1.NamespaceAll}, objects...)
+}
+
+func prepareDiscovery(role string, namespaces []string, objects ...runtime.Object) (*Discovery, kubernetes.Interface) {
+	clientset := fake.NewSimpleClientset(objects...)
+	discovery := &Discovery{
+		tags:          discoveryTags,
+		namespaces:    namespaces,
+		role:          role,
+		selectorLabel: "",
+		selectorField: "",
+		client:        clientset,
+		discoverers:   nil,
+		started:       make(chan struct{}),
+	}
+	return discovery, clientset
+}
+
+func prepareNamespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+func mustCalcHash(target any) uint64 {
+	hash, err := calcHash(target)
+	if err != nil {
+		panic(fmt.Sprintf("hash calculation: %v", err))
+	}
+	return hash
+}

--- a/agent/job/discovery/sd/kubernetes/pod.go
+++ b/agent/job/discovery/sd/kubernetes/pod.go
@@ -1,0 +1,407 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/netdata/go.d.plugin/agent/job/discovery/sd/model"
+	"github.com/netdata/go.d.plugin/logger"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+type (
+	podTargetGroup struct {
+		targets []model.Target
+		source  string
+	}
+	PodTarget struct {
+		model.Base `hash:"ignore"`
+		hash       uint64
+		tuid       string
+		Address    string
+
+		Namespace   string
+		Name        string
+		Annotations map[string]any
+		Labels      map[string]any
+		NodeName    string
+		PodIP       string
+
+		ContName     string
+		Image        string
+		Env          map[string]any
+		Port         string
+		PortName     string
+		PortProtocol string
+	}
+)
+
+func (p *PodTarget) Hash() uint64 { return p.hash }
+func (p *PodTarget) TUID() string { return p.tuid }
+
+func (p *podTargetGroup) Source() string          { return p.source }
+func (p *podTargetGroup) Targets() []model.Target { return p.targets }
+
+func NewPodDiscovery(pod, cmap, secret cache.SharedInformer) *PodDiscovery {
+	if cmap == nil || secret == nil {
+		panic("nil cmap or secret informer")
+	}
+
+	queue := workqueue.NewNamed("pod")
+
+	_, _ = pod.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { enqueue(queue, obj) },
+		UpdateFunc: func(_, obj any) { enqueue(queue, obj) },
+		DeleteFunc: func(obj any) { enqueue(queue, obj) },
+	})
+
+	return &PodDiscovery{
+		podInformer:    pod,
+		cmapInformer:   cmap,
+		secretInformer: secret,
+		queue:          queue,
+		Logger:         logger.New("k8s discovery", "pod"),
+	}
+}
+
+type PodDiscovery struct {
+	*logger.Logger
+
+	podInformer    cache.SharedInformer
+	cmapInformer   cache.SharedInformer
+	secretInformer cache.SharedInformer
+	queue          *workqueue.Type
+}
+
+func (pd *PodDiscovery) String() string {
+	return fmt.Sprintf("k8s %s discovery", RolePod)
+}
+
+func (pd *PodDiscovery) Discover(ctx context.Context, in chan<- []model.TargetGroup) {
+	pd.Info("instance is started")
+	defer pd.Info("instance is stopped")
+	defer pd.queue.ShutDown()
+
+	go pd.podInformer.Run(ctx.Done())
+	go pd.cmapInformer.Run(ctx.Done())
+	go pd.secretInformer.Run(ctx.Done())
+
+	if !cache.WaitForCacheSync(ctx.Done(),
+		pd.podInformer.HasSynced, pd.cmapInformer.HasSynced, pd.secretInformer.HasSynced) {
+		pd.Error("failed to sync caches")
+		return
+	}
+
+	go pd.run(ctx, in)
+
+	<-ctx.Done()
+}
+
+func (pd *PodDiscovery) run(ctx context.Context, in chan<- []model.TargetGroup) {
+	for {
+		item, shutdown := pd.queue.Get()
+		if shutdown {
+			return
+		}
+
+		func() {
+			defer pd.queue.Done(item)
+
+			key := item.(string)
+			namespace, name, err := cache.SplitMetaNamespaceKey(key)
+			if err != nil {
+				return
+			}
+
+			item, exists, err := pd.podInformer.GetStore().GetByKey(key)
+			if err != nil {
+				return
+			}
+
+			if !exists {
+				group := &podTargetGroup{source: podSourceFromNsName(namespace, name)}
+				send(ctx, in, group)
+				return
+			}
+
+			pod, err := toPod(item)
+			if err != nil {
+				return
+			}
+
+			group := pd.buildGroup(pod)
+			send(ctx, in, group)
+		}()
+	}
+}
+
+func (pd *PodDiscovery) buildGroup(pod *corev1.Pod) model.TargetGroup {
+	if pod.Status.PodIP == "" || len(pod.Spec.Containers) == 0 {
+		return &podTargetGroup{
+			source: podSource(pod),
+		}
+	}
+	return &podTargetGroup{
+		source:  podSource(pod),
+		targets: pd.buildTargets(pod),
+	}
+}
+
+func (pd *PodDiscovery) buildTargets(pod *corev1.Pod) (targets []model.Target) {
+	for _, container := range pod.Spec.Containers {
+		env := pd.collectEnv(pod.Namespace, container)
+
+		if len(container.Ports) == 0 {
+			target := &PodTarget{
+				tuid:        podTUID(pod, container),
+				Address:     pod.Status.PodIP,
+				Namespace:   pod.Namespace,
+				Name:        pod.Name,
+				Annotations: toMapAny(pod.Annotations),
+				Labels:      toMapAny(pod.Labels),
+				NodeName:    pod.Spec.NodeName,
+				PodIP:       pod.Status.PodIP,
+				ContName:    container.Name,
+				Image:       container.Image,
+				Env:         toMapAny(env),
+			}
+			hash, err := calcHash(target)
+			if err != nil {
+				continue
+			}
+			target.hash = hash
+
+			targets = append(targets, target)
+		} else {
+			for _, port := range container.Ports {
+				portNum := strconv.FormatUint(uint64(port.ContainerPort), 10)
+				target := &PodTarget{
+					tuid:         podTUIDWithPort(pod, container, port),
+					Address:      net.JoinHostPort(pod.Status.PodIP, portNum),
+					Namespace:    pod.Namespace,
+					Name:         pod.Name,
+					Annotations:  toMapAny(pod.Annotations),
+					Labels:       toMapAny(pod.Labels),
+					NodeName:     pod.Spec.NodeName,
+					PodIP:        pod.Status.PodIP,
+					ContName:     container.Name,
+					Image:        container.Image,
+					Env:          toMapAny(env),
+					Port:         portNum,
+					PortName:     port.Name,
+					PortProtocol: string(port.Protocol),
+				}
+				hash, err := calcHash(target)
+				if err != nil {
+					continue
+				}
+				target.hash = hash
+
+				targets = append(targets, target)
+			}
+		}
+	}
+	return targets
+}
+
+func (pd *PodDiscovery) collectEnv(ns string, container corev1.Container) map[string]string {
+	vars := make(map[string]string)
+
+	// When a key exists in multiple sources,
+	// the value associated with the last source will take precedence.
+	// Values defined by an Env with a duplicate key will take precedence.
+	//
+	// Order (https://github.com/kubernetes/kubectl/blob/master/pkg/describe/describe.go)
+	// - envFrom: configMapRef, secretRef
+	// - env: value || valueFrom: fieldRef, resourceFieldRef, secretRef, configMap
+
+	for _, src := range container.EnvFrom {
+		switch {
+		case src.ConfigMapRef != nil:
+			pd.envFromConfigMap(vars, ns, src)
+		case src.SecretRef != nil:
+			pd.envFromSecret(vars, ns, src)
+		}
+	}
+
+	for _, env := range container.Env {
+		if env.Name == "" || isVar(env.Name) {
+			continue
+		}
+		switch {
+		case env.Value != "":
+			vars[env.Name] = env.Value
+		case env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil:
+			pd.valueFromSecret(vars, ns, env)
+		case env.ValueFrom != nil && env.ValueFrom.ConfigMapKeyRef != nil:
+			pd.valueFromConfigMap(vars, ns, env)
+		}
+	}
+
+	if len(vars) == 0 {
+		return nil
+	}
+	return vars
+}
+
+func (pd *PodDiscovery) valueFromConfigMap(vars map[string]string, ns string, env corev1.EnvVar) {
+	if env.ValueFrom.ConfigMapKeyRef.Name == "" || env.ValueFrom.ConfigMapKeyRef.Key == "" {
+		return
+	}
+
+	sr := env.ValueFrom.ConfigMapKeyRef
+	key := ns + "/" + sr.Name
+	item, exist, err := pd.cmapInformer.GetStore().GetByKey(key)
+	if err != nil || !exist {
+		return
+	}
+
+	cmap, err := toConfigMap(item)
+	if err != nil {
+		return
+	}
+
+	if v, ok := cmap.Data[sr.Key]; ok {
+		vars[env.Name] = v
+	}
+}
+
+func (pd *PodDiscovery) valueFromSecret(vars map[string]string, ns string, env corev1.EnvVar) {
+	if env.ValueFrom.SecretKeyRef.Name == "" || env.ValueFrom.SecretKeyRef.Key == "" {
+		return
+	}
+
+	keyRef := env.ValueFrom.SecretKeyRef
+	key := ns + "/" + keyRef.Name
+	item, exist, err := pd.secretInformer.GetStore().GetByKey(key)
+	if err != nil || !exist {
+		return
+	}
+
+	secret, err := toSecret(item)
+	if err != nil {
+		return
+	}
+
+	if v, ok := secret.Data[keyRef.Key]; ok {
+		vars[env.Name] = string(v)
+	}
+}
+
+func (pd *PodDiscovery) envFromConfigMap(vars map[string]string, ns string, src corev1.EnvFromSource) {
+	if src.ConfigMapRef.Name == "" {
+		return
+	}
+
+	key := ns + "/" + src.ConfigMapRef.Name
+	item, exist, err := pd.cmapInformer.GetStore().GetByKey(key)
+	if err != nil || !exist {
+		return
+	}
+
+	cmap, err := toConfigMap(item)
+	if err != nil {
+		return
+	}
+
+	for k, v := range cmap.Data {
+		vars[src.Prefix+k] = v
+	}
+}
+
+func (pd *PodDiscovery) envFromSecret(vars map[string]string, ns string, src corev1.EnvFromSource) {
+	if src.SecretRef.Name == "" {
+		return
+	}
+
+	key := ns + "/" + src.SecretRef.Name
+	item, exist, err := pd.secretInformer.GetStore().GetByKey(key)
+	if err != nil || !exist {
+		return
+	}
+
+	secret, err := toSecret(item)
+	if err != nil {
+		return
+	}
+
+	for k, v := range secret.Data {
+		vars[src.Prefix+k] = string(v)
+	}
+}
+
+func podTUID(pod *corev1.Pod, container corev1.Container) string {
+	return fmt.Sprintf("%s_%s_%s",
+		pod.Namespace,
+		pod.Name,
+		container.Name,
+	)
+}
+
+func podTUIDWithPort(pod *corev1.Pod, container corev1.Container, port corev1.ContainerPort) string {
+	return fmt.Sprintf("%s_%s_%s_%s_%s",
+		pod.Namespace,
+		pod.Name,
+		container.Name,
+		strings.ToLower(string(port.Protocol)),
+		strconv.FormatInt(int64(port.ContainerPort), 10),
+	)
+}
+
+func podSourceFromNsName(namespace, name string) string {
+	return "k8s/pod/" + namespace + "/" + name
+}
+
+func podSource(pod *corev1.Pod) string {
+	return podSourceFromNsName(pod.Namespace, pod.Name)
+}
+
+func toPod(item any) (*corev1.Pod, error) {
+	pod, ok := item.(*corev1.Pod)
+	if !ok {
+		return nil, fmt.Errorf("received unexpected object type: %T", item)
+	}
+	return pod, nil
+}
+
+func toConfigMap(item any) (*corev1.ConfigMap, error) {
+	cmap, ok := item.(*corev1.ConfigMap)
+	if !ok {
+		return nil, fmt.Errorf("received unexpected object type: %T", item)
+	}
+	return cmap, nil
+}
+
+func toSecret(item any) (*corev1.Secret, error) {
+	secret, ok := item.(*corev1.Secret)
+	if !ok {
+		return nil, fmt.Errorf("received unexpected object type: %T", item)
+	}
+	return secret, nil
+}
+
+func isVar(name string) bool {
+	// Variable references $(VAR_NAME) are expanded using the previous defined
+	// environment variables in the container and any service environment
+	// variables.
+	return strings.IndexByte(name, '$') != -1
+}
+
+func toMapAny(src map[string]string) map[string]any {
+	if src == nil {
+		return nil
+	}
+
+	m := make(map[string]any, len(src))
+	for k, v := range src {
+		m[k] = v
+	}
+
+	return m
+}

--- a/agent/job/discovery/sd/kubernetes/pod_test.go
+++ b/agent/job/discovery/sd/kubernetes/pod_test.go
@@ -1,0 +1,594 @@
+package kubernetes
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/netdata/go.d.plugin/agent/job/discovery/sd/model"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestPodTargetGroup_Source(t *testing.T) {
+	tests := map[string]struct {
+		sim            func() discoverySim
+		expectedSource []string
+	}{
+		"pods with multiple ports": {
+			sim: func() discoverySim {
+				httpd, nginx := prepareHTTPDPod(), prepareNGINXPod()
+				discovery, _ := prepareNamespaceAllDiscovery(RolePod, httpd, nginx)
+
+				sim := discoverySim{
+					discovery: discovery,
+					expectedGroups: []model.TargetGroup{
+						preparePodGroup(httpd),
+						preparePodGroup(nginx),
+					},
+				}
+				return sim
+			},
+			expectedSource: []string{
+				"k8s/pod/default/httpd-dd95c4d68-5bkwl",
+				"k8s/pod/default/nginx-7cfd77469b-q6kxj",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			sim := test.sim()
+			var actual []string
+			for _, group := range sim.run(t) {
+				actual = append(actual, group.Source())
+			}
+
+			assert.Equal(t, test.expectedSource, actual)
+		})
+	}
+}
+
+func TestPodTargetGroup_Targets(t *testing.T) {
+	tests := map[string]struct {
+		sim                func() discoverySim
+		expectedNumTargets int
+	}{
+		"pods with multiple ports": {
+			sim: func() discoverySim {
+				httpd, nginx := prepareHTTPDPod(), prepareNGINXPod()
+				discovery, _ := prepareNamespaceAllDiscovery(RolePod, httpd, nginx)
+
+				sim := discoverySim{
+					discovery: discovery,
+					expectedGroups: []model.TargetGroup{
+						preparePodGroup(httpd),
+						preparePodGroup(nginx),
+					},
+				}
+				return sim
+			},
+			expectedNumTargets: 4,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			sim := test.sim()
+			var actual int
+			for _, group := range sim.run(t) {
+				actual += len(group.Targets())
+			}
+
+			assert.Equal(t, test.expectedNumTargets, actual)
+		})
+	}
+}
+
+func TestPodTargetGroup_Hash(t *testing.T) {
+	tests := map[string]struct {
+		sim          func() discoverySim
+		expectedHash []uint64
+	}{
+		"pods with multiple ports": {
+			sim: func() discoverySim {
+				httpd, nginx := prepareHTTPDPod(), prepareNGINXPod()
+				discovery, _ := prepareNamespaceAllDiscovery(RolePod, httpd, nginx)
+
+				sim := discoverySim{
+					discovery: discovery,
+					expectedGroups: []model.TargetGroup{
+						preparePodGroup(httpd),
+						preparePodGroup(nginx),
+					},
+				}
+				return sim
+			},
+			expectedHash: []uint64{
+				10984584459239076244,
+				10480294460002508451,
+				6511065520956605596,
+				9821662463142050012,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			sim := test.sim()
+			var actual []uint64
+			for _, group := range sim.run(t) {
+				for _, tg := range group.Targets() {
+					actual = append(actual, tg.Hash())
+				}
+			}
+
+			assert.Equal(t, test.expectedHash, actual)
+		})
+	}
+}
+
+func TestPodTargetGroup_TUID(t *testing.T) {
+	tests := map[string]struct {
+		sim          func() discoverySim
+		expectedTUID []string
+	}{
+		"pods with multiple ports": {
+			sim: func() discoverySim {
+				httpd, nginx := prepareHTTPDPod(), prepareNGINXPod()
+				discovery, _ := prepareNamespaceAllDiscovery(RolePod, httpd, nginx)
+
+				sim := discoverySim{
+					discovery: discovery,
+					expectedGroups: []model.TargetGroup{
+						preparePodGroup(httpd),
+						preparePodGroup(nginx),
+					},
+				}
+				return sim
+			},
+			expectedTUID: []string{
+				"default_httpd-dd95c4d68-5bkwl_httpd_tcp_80",
+				"default_httpd-dd95c4d68-5bkwl_httpd_tcp_443",
+				"default_nginx-7cfd77469b-q6kxj_nginx_tcp_80",
+				"default_nginx-7cfd77469b-q6kxj_nginx_tcp_443",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			sim := test.sim()
+			var actual []string
+			for _, group := range sim.run(t) {
+				for _, tg := range group.Targets() {
+					actual = append(actual, tg.TUID())
+				}
+			}
+
+			assert.Equal(t, test.expectedTUID, actual)
+		})
+	}
+}
+
+func TestNewPodDiscovery(t *testing.T) {
+	tests := map[string]struct {
+		podInf    cache.SharedInformer
+		cmapInf   cache.SharedInformer
+		secretInf cache.SharedInformer
+		wantPanic bool
+	}{
+		"valid informers": {
+			podInf:    cache.NewSharedInformer(nil, &corev1.Pod{}, resyncPeriod),
+			cmapInf:   cache.NewSharedInformer(nil, &corev1.ConfigMap{}, resyncPeriod),
+			secretInf: cache.NewSharedInformer(nil, &corev1.Secret{}, resyncPeriod),
+		},
+		"nil informers": {wantPanic: true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if test.wantPanic {
+				assert.Panics(t, func() { NewPodDiscovery(nil, nil, nil) })
+			} else {
+				assert.IsType(t, &PodDiscovery{}, NewPodDiscovery(test.podInf, test.cmapInf, test.secretInf))
+			}
+		})
+	}
+}
+
+func TestPodDiscovery_String(t *testing.T) {
+	p := PodDiscovery{}
+	assert.NotEmpty(t, p.String())
+}
+
+func TestPodDiscovery_Discover(t *testing.T) {
+	tests := map[string]func() discoverySim{
+		"ADD: pods exist before run": func() discoverySim {
+			httpd, nginx := prepareHTTPDPod(), prepareNGINXPod()
+			discovery, _ := prepareNamespaceAllDiscovery(RolePod, httpd, nginx)
+
+			sim := discoverySim{
+				discovery: discovery,
+				expectedGroups: []model.TargetGroup{
+					preparePodGroup(httpd),
+					preparePodGroup(nginx),
+				},
+			}
+			return sim
+		},
+		"ADD: pods exist before run and add after sync": func() discoverySim {
+			httpd, nginx := prepareHTTPDPod(), prepareNGINXPod()
+			discovery, clientset := prepareNamespaceAllDiscovery(RolePod, httpd)
+			podClient := clientset.CoreV1().Pods("default")
+
+			sim := discoverySim{
+				discovery: discovery,
+				runAfterSync: func(ctx context.Context) {
+					_, _ = podClient.Create(ctx, nginx, metav1.CreateOptions{})
+				},
+				expectedGroups: []model.TargetGroup{
+					preparePodGroup(httpd),
+					preparePodGroup(nginx),
+				},
+			}
+			return sim
+		},
+		"DELETE: remove pods after sync": func() discoverySim {
+			httpd, nginx := prepareHTTPDPod(), prepareNGINXPod()
+			discovery, clientset := prepareNamespaceAllDiscovery(RolePod, httpd, nginx)
+			podClient := clientset.CoreV1().Pods("default")
+
+			sim := discoverySim{
+				discovery: discovery,
+				runAfterSync: func(ctx context.Context) {
+					time.Sleep(time.Millisecond * 50)
+					_ = podClient.Delete(ctx, httpd.Name, metav1.DeleteOptions{})
+					_ = podClient.Delete(ctx, nginx.Name, metav1.DeleteOptions{})
+				},
+				expectedGroups: []model.TargetGroup{
+					preparePodGroup(httpd),
+					preparePodGroup(nginx),
+					prepareEmptyPodGroup(httpd),
+					prepareEmptyPodGroup(nginx),
+				},
+			}
+			return sim
+		},
+		"DELETE,ADD: remove and add pods after sync": func() discoverySim {
+			httpd, nginx := prepareHTTPDPod(), prepareNGINXPod()
+			discovery, clientset := prepareNamespaceAllDiscovery(RolePod, httpd)
+			podClient := clientset.CoreV1().Pods("default")
+
+			sim := discoverySim{
+				discovery: discovery,
+				runAfterSync: func(ctx context.Context) {
+					time.Sleep(time.Millisecond * 50)
+					_ = podClient.Delete(ctx, httpd.Name, metav1.DeleteOptions{})
+					_, _ = podClient.Create(ctx, nginx, metav1.CreateOptions{})
+				},
+				expectedGroups: []model.TargetGroup{
+					preparePodGroup(httpd),
+					prepareEmptyPodGroup(httpd),
+					preparePodGroup(nginx),
+				},
+			}
+			return sim
+		},
+		"ADD: pods with empty PodIP": func() discoverySim {
+			httpd, nginx := prepareHTTPDPod(), prepareNGINXPod()
+			httpd.Status.PodIP = ""
+			nginx.Status.PodIP = ""
+			discovery, _ := prepareNamespaceAllDiscovery(RolePod, httpd, nginx)
+
+			sim := discoverySim{
+				discovery: discovery,
+				expectedGroups: []model.TargetGroup{
+					prepareEmptyPodGroup(httpd),
+					prepareEmptyPodGroup(nginx),
+				},
+			}
+			return sim
+		},
+		"UPDATE: set pods PodIP after sync": func() discoverySim {
+			httpd, nginx := prepareHTTPDPod(), prepareNGINXPod()
+			httpd.Status.PodIP = ""
+			nginx.Status.PodIP = ""
+			discovery, clientset := prepareNamespaceAllDiscovery(RolePod, httpd, nginx)
+			podClient := clientset.CoreV1().Pods("default")
+
+			sim := discoverySim{
+				discovery: discovery,
+				runAfterSync: func(ctx context.Context) {
+					time.Sleep(time.Millisecond * 50)
+					_, _ = podClient.Update(ctx, prepareHTTPDPod(), metav1.UpdateOptions{})
+					_, _ = podClient.Update(ctx, prepareNGINXPod(), metav1.UpdateOptions{})
+				},
+				expectedGroups: []model.TargetGroup{
+					prepareEmptyPodGroup(httpd),
+					prepareEmptyPodGroup(nginx),
+					preparePodGroup(prepareHTTPDPod()),
+					preparePodGroup(prepareNGINXPod()),
+				},
+			}
+			return sim
+		},
+		"ADD: pods without containers": func() discoverySim {
+			httpd, nginx := prepareHTTPDPod(), prepareNGINXPod()
+			httpd.Spec.Containers = httpd.Spec.Containers[:0]
+			nginx.Spec.Containers = httpd.Spec.Containers[:0]
+			discovery, _ := prepareNamespaceAllDiscovery(RolePod, httpd, nginx)
+
+			sim := discoverySim{
+				discovery: discovery,
+				expectedGroups: []model.TargetGroup{
+					prepareEmptyPodGroup(httpd),
+					prepareEmptyPodGroup(nginx),
+				},
+			}
+			return sim
+		},
+		"Env: from value": func() discoverySim {
+			httpd := prepareHTTPDPod()
+			mangle := func(c *corev1.Container) {
+				c.Env = []corev1.EnvVar{
+					{Name: "key1", Value: "value1"},
+				}
+			}
+			mangleContainers(httpd.Spec.Containers, mangle)
+			data := map[string]string{"key1": "value1"}
+
+			discovery, _ := prepareNamespaceAllDiscovery(RolePod, httpd)
+
+			sim := discoverySim{
+				discovery: discovery,
+				expectedGroups: []model.TargetGroup{
+					preparePodGroupWithEnv(httpd, data),
+				},
+			}
+			return sim
+		},
+		"Env: from Secret": func() discoverySim {
+			httpd := prepareHTTPDPod()
+			mangle := func(c *corev1.Container) {
+				c.Env = []corev1.EnvVar{
+					{
+						Name: "key1",
+						ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+							Key:                  "key1",
+						}},
+					},
+				}
+			}
+			mangleContainers(httpd.Spec.Containers, mangle)
+			data := map[string]string{"key1": "value1"}
+			secret := prepareSecret("my-secret", data)
+
+			discovery, _ := prepareNamespaceAllDiscovery(RolePod, httpd, secret)
+
+			sim := discoverySim{
+				discovery: discovery,
+				expectedGroups: []model.TargetGroup{
+					preparePodGroupWithEnv(httpd, data),
+				},
+			}
+			return sim
+		},
+		"Env: from ConfigMap": func() discoverySim {
+			httpd := prepareHTTPDPod()
+			mangle := func(c *corev1.Container) {
+				c.Env = []corev1.EnvVar{
+					{
+						Name: "key1",
+						ValueFrom: &corev1.EnvVarSource{ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "my-cmap"},
+							Key:                  "key1",
+						}},
+					},
+				}
+			}
+			mangleContainers(httpd.Spec.Containers, mangle)
+			data := map[string]string{"key1": "value1"}
+			cmap := prepareConfigMap("my-cmap", data)
+
+			discovery, _ := prepareNamespaceAllDiscovery(RolePod, httpd, cmap)
+
+			sim := discoverySim{
+				discovery: discovery,
+				expectedGroups: []model.TargetGroup{
+					preparePodGroupWithEnv(httpd, data),
+				},
+			}
+			return sim
+		},
+		"EnvFrom: from ConfigMap": func() discoverySim {
+			httpd := prepareHTTPDPod()
+			mangle := func(c *corev1.Container) {
+				c.EnvFrom = []corev1.EnvFromSource{
+					{
+						ConfigMapRef: &corev1.ConfigMapEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "my-cmap"}},
+					},
+				}
+			}
+			mangleContainers(httpd.Spec.Containers, mangle)
+			data := map[string]string{"key1": "value1", "key2": "value2"}
+			cmap := prepareConfigMap("my-cmap", data)
+
+			discovery, _ := prepareNamespaceAllDiscovery(RolePod, httpd, cmap)
+
+			sim := discoverySim{
+				discovery: discovery,
+				expectedGroups: []model.TargetGroup{
+					preparePodGroupWithEnv(httpd, data),
+				},
+			}
+			return sim
+		},
+		"EnvFrom: from Secret": func() discoverySim {
+			httpd := prepareHTTPDPod()
+			mangle := func(c *corev1.Container) {
+				c.EnvFrom = []corev1.EnvFromSource{
+					{
+						SecretRef: &corev1.SecretEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"}},
+					},
+				}
+			}
+			mangleContainers(httpd.Spec.Containers, mangle)
+			data := map[string]string{"key1": "value1", "key2": "value2"}
+			secret := prepareSecret("my-secret", data)
+
+			discovery, _ := prepareNamespaceAllDiscovery(RolePod, httpd, secret)
+
+			sim := discoverySim{
+				discovery: discovery,
+				expectedGroups: []model.TargetGroup{
+					preparePodGroupWithEnv(httpd, data),
+				},
+			}
+			return sim
+		},
+	}
+
+	for name, sim := range tests {
+		t.Run(name, func(t *testing.T) { sim().run(t) })
+	}
+}
+
+func mangleContainers(containers []corev1.Container, mangle func(container *corev1.Container)) {
+	for i := range containers {
+		mangle(&containers[i])
+	}
+}
+
+func prepareHTTPDPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "httpd-dd95c4d68-5bkwl",
+			Namespace:   "default",
+			UID:         "1cebb6eb-0c1e-495b-8131-8fa3e6668dc8",
+			Annotations: map[string]string{"phase": "prod"},
+			Labels:      map[string]string{"app": "httpd", "tier": "frontend"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "m01",
+			Containers: []corev1.Container{
+				{
+					Name:  "httpd",
+					Image: "httpd",
+					Ports: []corev1.ContainerPort{
+						{Name: "http", Protocol: corev1.ProtocolTCP, ContainerPort: 80},
+						{Name: "https", Protocol: corev1.ProtocolTCP, ContainerPort: 443},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "172.17.0.1",
+		},
+	}
+}
+
+func prepareNGINXPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "nginx-7cfd77469b-q6kxj",
+			Namespace:   "default",
+			UID:         "09e883f2-d740-4c5f-970d-02cf02876522",
+			Annotations: map[string]string{"phase": "prod"},
+			Labels:      map[string]string{"app": "nginx", "tier": "frontend"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "m01",
+			Containers: []corev1.Container{
+				{
+					Name:  "nginx",
+					Image: "nginx",
+					Ports: []corev1.ContainerPort{
+						{Name: "http", Protocol: corev1.ProtocolTCP, ContainerPort: 80},
+						{Name: "https", Protocol: corev1.ProtocolTCP, ContainerPort: 443},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "172.17.0.2",
+		},
+	}
+}
+
+func prepareConfigMap(name string, data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       types.UID("a03b8dc6-dc40-46dc-b571-5030e69d8167" + name),
+		},
+		Data: data,
+	}
+}
+
+func prepareSecret(name string, data map[string]string) *corev1.Secret {
+	secretData := make(map[string][]byte, len(data))
+	for k, v := range data {
+		secretData[k] = []byte(v)
+	}
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       types.UID("a03b8dc6-dc40-46dc-b571-5030e69d8161" + name),
+		},
+		Data: secretData,
+	}
+}
+
+func prepareEmptyPodGroup(pod *corev1.Pod) *podTargetGroup {
+	return &podTargetGroup{source: podSource(pod)}
+}
+
+func preparePodGroup(pod *corev1.Pod) *podTargetGroup {
+	group := prepareEmptyPodGroup(pod)
+	for _, container := range pod.Spec.Containers {
+		for _, port := range container.Ports {
+			portNum := strconv.FormatUint(uint64(port.ContainerPort), 10)
+			target := &PodTarget{
+				tuid:         podTUIDWithPort(pod, container, port),
+				Address:      net.JoinHostPort(pod.Status.PodIP, portNum),
+				Namespace:    pod.Namespace,
+				Name:         pod.Name,
+				Annotations:  toMapAny(pod.Annotations),
+				Labels:       toMapAny(pod.Labels),
+				NodeName:     pod.Spec.NodeName,
+				PodIP:        pod.Status.PodIP,
+				ContName:     container.Name,
+				Image:        container.Image,
+				Env:          nil,
+				Port:         portNum,
+				PortName:     port.Name,
+				PortProtocol: string(port.Protocol),
+			}
+			target.hash = mustCalcHash(target)
+			target.Tags().Merge(discoveryTags)
+			group.targets = append(group.targets, target)
+		}
+	}
+	return group
+}
+
+func preparePodGroupWithEnv(pod *corev1.Pod, env map[string]string) *podTargetGroup {
+	group := preparePodGroup(pod)
+	for _, target := range group.Targets() {
+		target.(*PodTarget).Env = toMapAny(env)
+		target.(*PodTarget).hash = mustCalcHash(target)
+	}
+	return group
+}

--- a/agent/job/discovery/sd/kubernetes/service.go
+++ b/agent/job/discovery/sd/kubernetes/service.go
@@ -1,0 +1,194 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/netdata/go.d.plugin/agent/job/discovery/sd/model"
+	"github.com/netdata/go.d.plugin/logger"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+type (
+	serviceTargetGroup struct {
+		targets []model.Target
+		source  string
+	}
+	ServiceTarget struct {
+		model.Base `hash:"ignore"`
+		hash       uint64
+		tuid       string
+		Address    string
+
+		Namespace   string
+		Name        string
+		Annotations map[string]any
+		Labels      map[string]any
+
+		Port         string
+		PortName     string
+		PortProtocol string
+		ClusterIP    string
+		ExternalName string
+		Type         string
+	}
+)
+
+func (s ServiceTarget) Hash() uint64 { return s.hash }
+func (s ServiceTarget) TUID() string { return s.tuid }
+
+func (s serviceTargetGroup) Source() string          { return s.source }
+func (s serviceTargetGroup) Targets() []model.Target { return s.targets }
+
+func NewServiceDiscovery(inf cache.SharedInformer) *ServiceDiscovery {
+	queue := workqueue.NewNamed("service")
+	_, _ = inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { enqueue(queue, obj) },
+		UpdateFunc: func(_, obj any) { enqueue(queue, obj) },
+		DeleteFunc: func(obj any) { enqueue(queue, obj) },
+	})
+
+	return &ServiceDiscovery{
+		informer: inf,
+		queue:    queue,
+		Logger:   logger.New("k8s discovery", "service"),
+	}
+}
+
+type ServiceDiscovery struct {
+	*logger.Logger
+
+	informer cache.SharedInformer
+	queue    *workqueue.Type
+}
+
+func (sd *ServiceDiscovery) String() string {
+	return fmt.Sprintf("k8s %sd discovery", RoleService)
+}
+
+func (sd *ServiceDiscovery) Discover(ctx context.Context, ch chan<- []model.TargetGroup) {
+	sd.Info("instance is started")
+	defer sd.Info("instance is stopped")
+
+	defer sd.queue.ShutDown()
+
+	go sd.informer.Run(ctx.Done())
+
+	if !cache.WaitForCacheSync(ctx.Done(), sd.informer.HasSynced) {
+		sd.Error("failed to sync caches")
+		return
+	}
+
+	go sd.run(ctx, ch)
+	<-ctx.Done()
+}
+
+func (sd *ServiceDiscovery) run(ctx context.Context, ch chan<- []model.TargetGroup) {
+	for {
+		item, shutdown := sd.queue.Get()
+		if shutdown {
+			return
+		}
+
+		func() {
+			defer sd.queue.Done(item)
+
+			key := item.(string)
+			namespace, name, err := cache.SplitMetaNamespaceKey(key)
+			if err != nil {
+				return
+			}
+
+			item, exists, err := sd.informer.GetStore().GetByKey(key)
+			if err != nil {
+				return
+			}
+
+			if !exists {
+				group := &serviceTargetGroup{source: serviceSourceFromNsName(namespace, name)}
+				send(ctx, ch, group)
+				return
+			}
+
+			svc, err := toService(item)
+			if err != nil {
+				return
+			}
+
+			group := sd.buildGroup(svc)
+			send(ctx, ch, group)
+		}()
+	}
+}
+
+func (sd *ServiceDiscovery) buildGroup(svc *corev1.Service) model.TargetGroup {
+	// TODO: headless service?
+	if svc.Spec.ClusterIP == "" || len(svc.Spec.Ports) == 0 {
+		return &serviceTargetGroup{
+			source: serviceSource(svc),
+		}
+	}
+	return &serviceTargetGroup{
+		source:  serviceSource(svc),
+		targets: sd.buildTargets(svc),
+	}
+}
+
+func (sd *ServiceDiscovery) buildTargets(svc *corev1.Service) (targets []model.Target) {
+	for _, port := range svc.Spec.Ports {
+		portNum := strconv.FormatInt(int64(port.Port), 10)
+		target := &ServiceTarget{
+			tuid:         serviceTUID(svc, port),
+			Address:      net.JoinHostPort(svc.Name+"."+svc.Namespace+".svc", portNum),
+			Namespace:    svc.Namespace,
+			Name:         svc.Name,
+			Annotations:  toMapAny(svc.Annotations),
+			Labels:       toMapAny(svc.Labels),
+			Port:         portNum,
+			PortName:     port.Name,
+			PortProtocol: string(port.Protocol),
+			ClusterIP:    svc.Spec.ClusterIP,
+			ExternalName: svc.Spec.ExternalName,
+			Type:         string(svc.Spec.Type),
+		}
+		hash, err := calcHash(target)
+		if err != nil {
+			continue
+		}
+		target.hash = hash
+
+		targets = append(targets, target)
+	}
+	return targets
+}
+
+func serviceTUID(svc *corev1.Service, port corev1.ServicePort) string {
+	return fmt.Sprintf("%s_%s_%s_%s",
+		svc.Namespace,
+		svc.Name,
+		strings.ToLower(string(port.Protocol)),
+		strconv.FormatInt(int64(port.Port), 10),
+	)
+}
+
+func serviceSourceFromNsName(namespace, name string) string {
+	return "k8s/service/" + namespace + "/" + name
+}
+
+func serviceSource(svc *corev1.Service) string {
+	return serviceSourceFromNsName(svc.Namespace, svc.Name)
+}
+
+func toService(obj any) (*corev1.Service, error) {
+	svc, ok := obj.(*corev1.Service)
+	if !ok {
+		return nil, fmt.Errorf("received unexpected object type: %T", obj)
+	}
+	return svc, nil
+}

--- a/agent/job/discovery/sd/kubernetes/service_test.go
+++ b/agent/job/discovery/sd/kubernetes/service_test.go
@@ -1,0 +1,418 @@
+package kubernetes
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/netdata/go.d.plugin/agent/job/discovery/sd/model"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestServiceTargetGroup_Source(t *testing.T) {
+	tests := map[string]struct {
+		sim            func() discoverySim
+		expectedSource []string
+	}{
+		"ClusterIP svc with multiple ports": {
+			sim: func() discoverySim {
+				httpd, nginx := prepareHTTPDClusterIPService(), prepareNGINXClusterIPService()
+				discovery, _ := prepareNamespaceAllDiscovery(RoleService, httpd, nginx)
+
+				sim := discoverySim{
+					discovery: discovery,
+					expectedGroups: []model.TargetGroup{
+						prepareSvcGroup(httpd),
+						prepareSvcGroup(nginx),
+					},
+				}
+				return sim
+			},
+			expectedSource: []string{
+				"k8s/service/default/httpd-cluster-ip-service",
+				"k8s/service/default/nginx-cluster-ip-service",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			sim := test.sim()
+			var actual []string
+			for _, group := range sim.run(t) {
+				actual = append(actual, group.Source())
+			}
+
+			assert.Equal(t, test.expectedSource, actual)
+		})
+	}
+}
+
+func TestServiceTargetGroup_Targets(t *testing.T) {
+	tests := map[string]struct {
+		sim                func() discoverySim
+		expectedNumTargets int
+	}{
+		"ClusterIP svc with multiple ports": {
+			sim: func() discoverySim {
+				httpd, nginx := prepareHTTPDClusterIPService(), prepareNGINXClusterIPService()
+				discovery, _ := prepareNamespaceAllDiscovery(RoleService, httpd, nginx)
+
+				sim := discoverySim{
+					discovery: discovery,
+					expectedGroups: []model.TargetGroup{
+						prepareSvcGroup(httpd),
+						prepareSvcGroup(nginx),
+					},
+				}
+				return sim
+			},
+			expectedNumTargets: 4,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			sim := test.sim()
+			var actual int
+			for _, group := range sim.run(t) {
+				actual += len(group.Targets())
+			}
+
+			assert.Equal(t, test.expectedNumTargets, actual)
+		})
+	}
+}
+
+func TestServiceTarget_Hash(t *testing.T) {
+	tests := map[string]struct {
+		sim          func() discoverySim
+		expectedHash []uint64
+	}{
+		"ClusterIP svc with multiple ports": {
+			sim: func() discoverySim {
+				httpd, nginx := prepareHTTPDClusterIPService(), prepareNGINXClusterIPService()
+				discovery, _ := prepareNamespaceAllDiscovery(RoleService, httpd, nginx)
+
+				sim := discoverySim{
+					discovery: discovery,
+					expectedGroups: []model.TargetGroup{
+						prepareSvcGroup(httpd),
+						prepareSvcGroup(nginx),
+					},
+				}
+				return sim
+			},
+			expectedHash: []uint64{
+				17611803477081780974,
+				6019985892433421258,
+				4151907287549842238,
+				5757608926096186119,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			sim := test.sim()
+			var actual []uint64
+			for _, group := range sim.run(t) {
+				for _, tg := range group.Targets() {
+					actual = append(actual, tg.Hash())
+				}
+			}
+
+			assert.Equal(t, test.expectedHash, actual)
+		})
+	}
+}
+
+func TestServiceTarget_TUID(t *testing.T) {
+	tests := map[string]struct {
+		sim          func() discoverySim
+		expectedTUID []string
+	}{
+		"ClusterIP svc with multiple ports": {
+			sim: func() discoverySim {
+				httpd, nginx := prepareHTTPDClusterIPService(), prepareNGINXClusterIPService()
+				discovery, _ := prepareNamespaceAllDiscovery(RoleService, httpd, nginx)
+
+				sim := discoverySim{
+					discovery: discovery,
+					expectedGroups: []model.TargetGroup{
+						prepareSvcGroup(httpd),
+						prepareSvcGroup(nginx),
+					},
+				}
+				return sim
+			},
+			expectedTUID: []string{
+				"default_httpd-cluster-ip-service_tcp_80",
+				"default_httpd-cluster-ip-service_tcp_443",
+				"default_nginx-cluster-ip-service_tcp_80",
+				"default_nginx-cluster-ip-service_tcp_443",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			sim := test.sim()
+			var actual []string
+			for _, group := range sim.run(t) {
+				for _, tg := range group.Targets() {
+					actual = append(actual, tg.TUID())
+				}
+			}
+
+			assert.Equal(t, test.expectedTUID, actual)
+		})
+	}
+}
+
+func Test_newServiceDiscoverer(t *testing.T) {
+	tests := map[string]struct {
+		informer  cache.SharedInformer
+		wantPanic bool
+	}{
+		"valid informer": {informer: cache.NewSharedInformer(nil, &corev1.Service{}, resyncPeriod)},
+		"nil informer":   {wantPanic: true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if test.wantPanic {
+				assert.Panics(t, func() { NewServiceDiscovery(nil) })
+			} else {
+				assert.IsType(t, &ServiceDiscovery{}, NewServiceDiscovery(test.informer))
+			}
+		})
+	}
+}
+
+func TestServiceDiscovery_String(t *testing.T) {
+	s := ServiceDiscovery{}
+	assert.NotEmpty(t, s.String())
+}
+
+func TestServiceDiscovery_Discover(t *testing.T) {
+	tests := map[string]func() discoverySim{
+		"ADD: ClusterIP svc exist before run": func() discoverySim {
+			httpd, nginx := prepareHTTPDClusterIPService(), prepareNGINXClusterIPService()
+			discovery, _ := prepareNamespaceAllDiscovery(RoleService, httpd, nginx)
+
+			sim := discoverySim{
+				discovery: discovery,
+				expectedGroups: []model.TargetGroup{
+					prepareSvcGroup(httpd),
+					prepareSvcGroup(nginx),
+				},
+			}
+			return sim
+		},
+		"ADD: ClusterIP svc exist before run and add after sync": func() discoverySim {
+			httpd, nginx := prepareHTTPDClusterIPService(), prepareNGINXClusterIPService()
+			discovery, clientset := prepareNamespaceAllDiscovery(RoleService, httpd)
+			svcClient := clientset.CoreV1().Services("default")
+
+			sim := discoverySim{
+				discovery: discovery,
+				runAfterSync: func(ctx context.Context) {
+					_, _ = svcClient.Create(ctx, nginx, metav1.CreateOptions{})
+				},
+				expectedGroups: []model.TargetGroup{
+					prepareSvcGroup(httpd),
+					prepareSvcGroup(nginx),
+				},
+			}
+			return sim
+		},
+		"DELETE: ClusterIP svc remove after sync": func() discoverySim {
+			httpd, nginx := prepareHTTPDClusterIPService(), prepareNGINXClusterIPService()
+			discovery, clientset := prepareNamespaceAllDiscovery(RoleService, httpd, nginx)
+			svcClient := clientset.CoreV1().Services("default")
+
+			sim := discoverySim{
+				discovery: discovery,
+				runAfterSync: func(ctx context.Context) {
+					time.Sleep(time.Millisecond * 50)
+					_ = svcClient.Delete(ctx, httpd.Name, metav1.DeleteOptions{})
+					_ = svcClient.Delete(ctx, nginx.Name, metav1.DeleteOptions{})
+				},
+				expectedGroups: []model.TargetGroup{
+					prepareSvcGroup(httpd),
+					prepareSvcGroup(nginx),
+					prepareEmptySvcGroup(httpd),
+					prepareEmptySvcGroup(nginx),
+				},
+			}
+			return sim
+		},
+		"ADD,DELETE: ClusterIP svc remove and add after sync": func() discoverySim {
+			httpd, nginx := prepareHTTPDClusterIPService(), prepareNGINXClusterIPService()
+			discovery, clientset := prepareNamespaceAllDiscovery(RoleService, httpd)
+			svcClient := clientset.CoreV1().Services("default")
+
+			sim := discoverySim{
+				discovery: discovery,
+				runAfterSync: func(ctx context.Context) {
+					time.Sleep(time.Millisecond * 50)
+					_ = svcClient.Delete(ctx, httpd.Name, metav1.DeleteOptions{})
+					_, _ = svcClient.Create(ctx, nginx, metav1.CreateOptions{})
+				},
+				expectedGroups: []model.TargetGroup{
+					prepareSvcGroup(httpd),
+					prepareEmptySvcGroup(httpd),
+					prepareSvcGroup(nginx),
+				},
+			}
+			return sim
+		},
+		"ADD: Headless svc exist before run": func() discoverySim {
+			httpd, nginx := prepareHTTPDHeadlessService(), prepareNGINXHeadlessService()
+			discovery, _ := prepareNamespaceAllDiscovery(RoleService, httpd, nginx)
+
+			sim := discoverySim{
+				discovery: discovery,
+				expectedGroups: []model.TargetGroup{
+					prepareEmptySvcGroup(httpd),
+					prepareEmptySvcGroup(nginx),
+				},
+			}
+			return sim
+		},
+		"UPDATE: Headless => ClusterIP svc after sync": func() discoverySim {
+			httpd, nginx := prepareHTTPDHeadlessService(), prepareNGINXHeadlessService()
+			httpdUpd, nginxUpd := *httpd, *nginx
+			httpdUpd.Spec.ClusterIP = "10.100.0.1"
+			nginxUpd.Spec.ClusterIP = "10.100.0.2"
+			discovery, clientset := prepareNamespaceAllDiscovery(RoleService, httpd, nginx)
+			svcClient := clientset.CoreV1().Services("default")
+
+			sim := discoverySim{
+				discovery: discovery,
+				runAfterSync: func(ctx context.Context) {
+					time.Sleep(time.Millisecond * 50)
+					_, _ = svcClient.Update(ctx, &httpdUpd, metav1.UpdateOptions{})
+					_, _ = svcClient.Update(ctx, &nginxUpd, metav1.UpdateOptions{})
+				},
+				expectedGroups: []model.TargetGroup{
+					prepareEmptySvcGroup(httpd),
+					prepareEmptySvcGroup(nginx),
+					prepareSvcGroup(&httpdUpd),
+					prepareSvcGroup(&nginxUpd),
+				},
+			}
+			return sim
+		},
+		"ADD: ClusterIP svc with zero exposed ports": func() discoverySim {
+			httpd, nginx := prepareHTTPDClusterIPService(), prepareNGINXClusterIPService()
+			httpd.Spec.Ports = httpd.Spec.Ports[:0]
+			nginx.Spec.Ports = httpd.Spec.Ports[:0]
+			discovery, _ := prepareNamespaceAllDiscovery(RoleService, httpd, nginx)
+
+			sim := discoverySim{
+				discovery: discovery,
+				expectedGroups: []model.TargetGroup{
+					prepareEmptySvcGroup(httpd),
+					prepareEmptySvcGroup(nginx),
+				},
+			}
+			return sim
+		},
+	}
+
+	for name, sim := range tests {
+		t.Run(name, func(t *testing.T) { sim().run(t) })
+	}
+
+}
+
+func prepareHTTPDClusterIPService() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "httpd-cluster-ip-service",
+			Namespace:   "default",
+			Annotations: map[string]string{"phase": "prod"},
+			Labels:      map[string]string{"app": "httpd", "tier": "frontend"},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "http", Protocol: corev1.ProtocolTCP, Port: 80},
+				{Name: "https", Protocol: corev1.ProtocolTCP, Port: 443},
+			},
+			Type:      corev1.ServiceTypeClusterIP,
+			ClusterIP: "10.100.0.1",
+			Selector:  map[string]string{"app": "httpd", "tier": "frontend"},
+		},
+	}
+}
+
+func prepareNGINXClusterIPService() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "nginx-cluster-ip-service",
+			Namespace:   "default",
+			Annotations: map[string]string{"phase": "prod"},
+			Labels:      map[string]string{"app": "nginx", "tier": "frontend"},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "http", Protocol: corev1.ProtocolTCP, Port: 80},
+				{Name: "https", Protocol: corev1.ProtocolTCP, Port: 443},
+			},
+			Type:      corev1.ServiceTypeClusterIP,
+			ClusterIP: "10.100.0.2",
+			Selector:  map[string]string{"app": "nginx", "tier": "frontend"},
+		},
+	}
+}
+
+func prepareHTTPDHeadlessService() *corev1.Service {
+	svc := prepareHTTPDClusterIPService()
+	svc.Name = "httpd-headless-service"
+	svc.Spec.ClusterIP = ""
+	return svc
+}
+
+func prepareNGINXHeadlessService() *corev1.Service {
+	svc := prepareNGINXClusterIPService()
+	svc.Name = "nginx-headless-service"
+	svc.Spec.ClusterIP = ""
+	return svc
+}
+
+func prepareEmptySvcGroup(svc *corev1.Service) *serviceTargetGroup {
+	return &serviceTargetGroup{source: serviceSource(svc)}
+}
+
+func prepareSvcGroup(svc *corev1.Service) *serviceTargetGroup {
+	group := prepareEmptySvcGroup(svc)
+	for _, port := range svc.Spec.Ports {
+		portNum := strconv.FormatInt(int64(port.Port), 10)
+		target := &ServiceTarget{
+			tuid:         serviceTUID(svc, port),
+			Address:      net.JoinHostPort(svc.Name+"."+svc.Namespace+".svc", portNum),
+			Namespace:    svc.Namespace,
+			Name:         svc.Name,
+			Annotations:  toMapAny(svc.Annotations),
+			Labels:       toMapAny(svc.Labels),
+			Port:         portNum,
+			PortName:     port.Name,
+			PortProtocol: string(port.Protocol),
+			ClusterIP:    svc.Spec.ClusterIP,
+			ExternalName: svc.Spec.ExternalName,
+			Type:         string(svc.Spec.Type),
+		}
+		target.hash = mustCalcHash(target)
+		target.Tags().Merge(discoveryTags)
+		group.targets = append(group.targets, target)
+	}
+	return group
+}

--- a/agent/job/discovery/sd/kubernetes/sim_test.go
+++ b/agent/job/discovery/sd/kubernetes/sim_test.go
@@ -1,0 +1,132 @@
+package kubernetes
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/netdata/go.d.plugin/agent/job/discovery/sd/model"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	startWaitTimeout  = time.Second * 3
+	finishWaitTimeout = time.Second * 5
+)
+
+type discoverySim struct {
+	discovery        *Discovery
+	runAfterSync     func(ctx context.Context)
+	sortBeforeVerify bool
+	expectedGroups   []model.TargetGroup
+}
+
+func (sim discoverySim) run(t *testing.T) []model.TargetGroup {
+	t.Helper()
+	require.NotNil(t, sim.discovery)
+	require.NotEmpty(t, sim.expectedGroups)
+
+	in, out := make(chan []model.TargetGroup), make(chan []model.TargetGroup)
+	go sim.collectGroups(t, in, out)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	go sim.discovery.Discover(ctx, in)
+
+	select {
+	case <-sim.discovery.started:
+	case <-time.After(startWaitTimeout):
+		t.Fatalf("discovery %s filed to start in %s", sim.discovery.discoverers, startWaitTimeout)
+	}
+
+	synced := cache.WaitForCacheSync(ctx.Done(), sim.discovery.hasSynced)
+	require.Truef(t, synced, "discovery %s failed to sync", sim.discovery.discoverers)
+
+	if sim.runAfterSync != nil {
+		sim.runAfterSync(ctx)
+	}
+
+	groups := <-out
+
+	if sim.sortBeforeVerify {
+		sortGroups(groups)
+	}
+
+	sim.verifyResult(t, groups)
+	return groups
+}
+
+func (sim discoverySim) collectGroups(t *testing.T, in, out chan []model.TargetGroup) {
+	var groups []model.TargetGroup
+loop:
+	for {
+		select {
+		case inGroups := <-in:
+			if groups = append(groups, inGroups...); len(groups) >= len(sim.expectedGroups) {
+				break loop
+			}
+		case <-time.After(finishWaitTimeout):
+			t.Logf("discovery %s timed out after %s, got %d groups, expected %d, some events are skipped",
+				sim.discovery.discoverers, finishWaitTimeout, len(groups), len(sim.expectedGroups))
+			break loop
+		}
+	}
+	out <- groups
+}
+
+func (sim discoverySim) verifyResult(t *testing.T, result []model.TargetGroup) {
+	var expected, actual any
+
+	if len(sim.expectedGroups) == len(result) {
+		expected = sim.expectedGroups
+		actual = result
+	} else {
+		want := make(map[string]model.TargetGroup)
+		for _, group := range sim.expectedGroups {
+			want[group.Source()] = group
+		}
+		got := make(map[string]model.TargetGroup)
+		for _, group := range result {
+			got[group.Source()] = group
+		}
+		expected, actual = want, got
+	}
+
+	assert.Equal(t, expected, actual)
+}
+
+type hasSynced interface {
+	hasSynced() bool
+}
+
+var (
+	_ hasSynced = &Discovery{}
+	_ hasSynced = &PodDiscovery{}
+	_ hasSynced = &ServiceDiscovery{}
+)
+
+func (d *Discovery) hasSynced() bool {
+	for _, dd := range d.discoverers {
+		v, ok := dd.(hasSynced)
+		if !ok || !v.hasSynced() {
+			return false
+		}
+	}
+	return true
+}
+
+func (pd *PodDiscovery) hasSynced() bool {
+	return pd.podInformer.HasSynced() && pd.cmapInformer.HasSynced() && pd.secretInformer.HasSynced()
+}
+
+func (sd *ServiceDiscovery) hasSynced() bool {
+	return sd.informer.HasSynced()
+}
+
+func sortGroups(groups []model.TargetGroup) {
+	sort.Slice(groups, func(i, j int) bool { return groups[i].Source() < groups[j].Source() })
+}

--- a/agent/job/discovery/sd/model/tags.go
+++ b/agent/job/discovery/sd/model/tags.go
@@ -1,0 +1,79 @@
+package model
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type Base struct {
+	tags Tags
+}
+
+func (b *Base) Tags() Tags {
+	if b.tags == nil {
+		b.tags = NewTags()
+	}
+	return b.tags
+}
+
+type Tags map[string]struct{}
+
+func NewTags() Tags {
+	return Tags{}
+}
+
+func (t Tags) Merge(tags Tags) {
+	for tag := range tags {
+		if strings.HasPrefix(tag, "-") {
+			delete(t, tag[1:])
+		} else {
+			t[tag] = struct{}{}
+		}
+	}
+}
+
+func (t Tags) String() string {
+	ts := make([]string, 0, len(t))
+	for key := range t {
+		ts = append(ts, key)
+	}
+	sort.Strings(ts)
+	return fmt.Sprintf("{%s}", strings.Join(ts, ", "))
+}
+
+func ParseTags(line string) (Tags, error) {
+	words := strings.Fields(line)
+	if len(words) == 0 {
+		return NewTags(), nil
+	}
+
+	tags := NewTags()
+	for _, tag := range words {
+		if !isTagWordValid(tag) {
+			return nil, fmt.Errorf("tags '%s' contains tag '%s' with forbidden symbol", line, tag)
+		}
+		tags[tag] = struct{}{}
+	}
+	return tags, nil
+}
+
+func isTagWordValid(word string) bool {
+	// valid:
+	// ^[a-zA-Z][a-zA-Z0-9=_.]*$
+	word = strings.TrimPrefix(word, "-")
+	if len(word) == 0 {
+		return false
+	}
+	for i, b := range word {
+		switch {
+		default:
+			return false
+		case b >= 'a' && b <= 'z':
+		case b >= 'A' && b <= 'Z':
+		case b >= '0' && b <= '9' && i > 0:
+		case (b == '=' || b == '_' || b == '.') && i > 0:
+		}
+	}
+	return true
+}

--- a/agent/job/discovery/sd/model/tags_test.go
+++ b/agent/job/discovery/sd/model/tags_test.go
@@ -1,0 +1,1 @@
+package model

--- a/agent/job/discovery/sd/model/target.go
+++ b/agent/job/discovery/sd/model/target.go
@@ -1,0 +1,18 @@
+package model
+
+type Target interface {
+	Hash() uint64
+	Tags() Tags
+	TUID() string
+}
+
+type TargetGroup interface {
+	Targets() []Target
+	Source() string
+}
+
+type Config struct {
+	Tags  Tags
+	Conf  string
+	Stale bool
+}

--- a/agent/job/discovery/sd/pipeline.go
+++ b/agent/job/discovery/sd/pipeline.go
@@ -1,0 +1,170 @@
+package sd
+
+import (
+	"context"
+	"github.com/netdata/go.d.plugin/agent/job/discovery/sd/model"
+	"sync"
+
+	"github.com/netdata/go.d.plugin/logger"
+)
+
+type Discoverer interface {
+	Discover(ctx context.Context, in chan<- []model.TargetGroup)
+}
+
+type Tagger interface {
+	Tag(model.Target)
+}
+
+type Builder interface {
+	Build(model.Target) []model.Config
+}
+
+type Exporter interface {
+	Export(ctx context.Context, out <-chan []model.Config)
+}
+
+type (
+	Pipeline struct {
+		*logger.Logger
+		Discoverer
+		Tagger
+		Builder
+		Exporter
+
+		cache pipelineCache
+	}
+	pipelineCache map[string]groupCache // source:hash:configs
+	groupCache    map[uint64][]model.Config
+)
+
+func NewPipeline(discoverer Discoverer, tagger Tagger, builder Builder, exporter Exporter) *Pipeline {
+	return &Pipeline{
+		Discoverer: discoverer,
+		Tagger:     tagger,
+		Builder:    builder,
+		Exporter:   exporter,
+		cache:      make(pipelineCache),
+		Logger:     logger.New("discovery", "pipeline"),
+	}
+}
+
+func (p *Pipeline) Run(ctx context.Context) {
+	p.Info("instance is started")
+	defer p.Info("instance is stopped")
+
+	var wg sync.WaitGroup
+	disc := make(chan []model.TargetGroup)
+	exp := make(chan []model.Config)
+
+	wg.Add(1)
+	go func() { defer wg.Done(); p.Discover(ctx, disc) }()
+
+	wg.Add(1)
+	go func() { defer wg.Done(); p.run(ctx, disc, exp) }()
+
+	wg.Add(1)
+	go func() { defer wg.Done(); p.Export(ctx, exp) }()
+
+	wg.Wait()
+	<-ctx.Done()
+}
+
+func (p *Pipeline) run(ctx context.Context, disc chan []model.TargetGroup, export chan []model.Config) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case groups := <-disc:
+			if configs := p.process(groups); len(configs) > 0 {
+				select {
+				case <-ctx.Done():
+				case export <- configs:
+				}
+			}
+		}
+	}
+}
+
+func (p *Pipeline) process(groups []model.TargetGroup) (configs []model.Config) {
+	p.Infof("received '%d' group(s)", len(groups))
+
+	for _, group := range groups {
+		p.Infof("processing group '%s' with %d target(s)", group.Source(), len(group.Targets()))
+
+		if len(group.Targets()) == 0 {
+			if remove := p.handleEmpty(group); len(remove) > 0 {
+				p.Infof("group '%s': stale config(s) %d", group.Source(), len(remove))
+
+				configs = append(configs, remove...)
+			}
+		} else {
+			if add, remove := p.handleNotEmpty(group); len(add) > 0 || len(remove) > 0 {
+				p.Infof("group '%s': new/stale config(s) %d/%d", group.Source(), len(add), len(remove))
+
+				configs = append(configs, append(add, remove...)...)
+			}
+		}
+	}
+	return configs
+}
+
+func (p *Pipeline) handleEmpty(group model.TargetGroup) (remove []model.Config) {
+	grpCache, exist := p.cache[group.Source()]
+	if !exist {
+		return
+	}
+	delete(p.cache, group.Source())
+
+	for hash, cfgs := range grpCache {
+		delete(grpCache, hash)
+		remove = append(remove, cfgs...)
+	}
+
+	return stale(remove)
+}
+
+func (p *Pipeline) handleNotEmpty(group model.TargetGroup) (add, remove []model.Config) {
+	grpCache, exist := p.cache[group.Source()]
+	if !exist {
+		grpCache = make(map[uint64][]model.Config)
+		p.cache[group.Source()] = grpCache
+	}
+
+	seen := make(map[uint64]bool)
+	for _, target := range group.Targets() {
+		if target == nil {
+			continue
+		}
+		seen[target.Hash()] = true
+
+		if _, ok := grpCache[target.Hash()]; ok {
+			continue
+		}
+
+		p.Tag(target)
+		cfgs := p.Build(target)
+
+		grpCache[target.Hash()] = cfgs
+		add = append(add, cfgs...)
+	}
+
+	if !exist {
+		return
+	}
+
+	for hash, cfgs := range grpCache {
+		if !seen[hash] {
+			delete(grpCache, hash)
+			remove = append(remove, stale(cfgs)...)
+		}
+	}
+	return add, remove
+}
+
+func stale(configs []model.Config) []model.Config {
+	for i := range configs {
+		configs[i].Stale = true
+	}
+	return configs
+}

--- a/agent/job/discovery/sd/pipeline_test.go
+++ b/agent/job/discovery/sd/pipeline_test.go
@@ -1,0 +1,215 @@
+package sd
+
+import (
+	"context"
+	"github.com/netdata/go.d.plugin/agent/job/discovery/sd/model"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ilyam8/hashstructure"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPipeline_Run(t *testing.T) {
+	tests := map[string]func() pipelineSim{
+		"new group with no targets": func() pipelineSim {
+			g1 := mockPipelineGroup{source: "s1"}
+
+			sim := pipelineSim{
+				discoveredGroups:   []model.TargetGroup{g1},
+				expectedCacheItems: 0,
+			}
+			return sim
+		},
+		"new group with targets": func() pipelineSim {
+			t1 := mockPipelineTarget{Name: "t1"}
+			t2 := mockPipelineTarget{Name: "t2"}
+			g1 := mockPipelineGroup{targets: []model.Target{t1, t2}, source: "s1"}
+
+			sim := pipelineSim{
+				discoveredGroups:   []model.TargetGroup{g1},
+				expectedTag:        []model.Target{t1, t2},
+				expectedBuild:      []model.Target{t1, t2},
+				expectedExport:     []model.Config{{Conf: "t1"}, {Conf: "t2"}},
+				expectedCacheItems: 1,
+			}
+			return sim
+		},
+		"existing group with same targets": func() pipelineSim {
+			t1 := mockPipelineTarget{Name: "t1"}
+			t2 := mockPipelineTarget{Name: "t2"}
+			g1 := mockPipelineGroup{targets: []model.Target{t1, t2}, source: "s1"}
+
+			sim := pipelineSim{
+				discoveredGroups:   []model.TargetGroup{g1, g1},
+				expectedTag:        []model.Target{t1, t2},
+				expectedBuild:      []model.Target{t1, t2},
+				expectedExport:     []model.Config{{Conf: "t1"}, {Conf: "t2"}},
+				expectedCacheItems: 1,
+			}
+			return sim
+		},
+		"existing group with no targets": func() pipelineSim {
+			t1 := mockPipelineTarget{Name: "t1"}
+			t2 := mockPipelineTarget{Name: "t2"}
+			g1 := mockPipelineGroup{targets: []model.Target{t1, t2}, source: "s1"}
+			g2 := mockPipelineGroup{source: "s1"}
+
+			sim := pipelineSim{
+				discoveredGroups: []model.TargetGroup{g1, g2},
+				expectedTag:      []model.Target{t1, t2},
+				expectedBuild:    []model.Target{t1, t2},
+				expectedExport: []model.Config{
+					{Conf: "t1"}, {Conf: "t2"}, {Conf: "t1", Stale: true}, {Conf: "t2", Stale: true},
+				},
+				expectedCacheItems: 0,
+			}
+			return sim
+		},
+		"existing group with old and new targets": func() pipelineSim {
+			t1 := mockPipelineTarget{Name: "t1"}
+			t2 := mockPipelineTarget{Name: "t2"}
+			t3 := mockPipelineTarget{Name: "t3"}
+			g1 := mockPipelineGroup{targets: []model.Target{t1, t2}, source: "s1"}
+			g2 := mockPipelineGroup{targets: []model.Target{t1, t3}, source: "s1"}
+
+			sim := pipelineSim{
+				discoveredGroups: []model.TargetGroup{g1, g2},
+				expectedTag:      []model.Target{t1, t2, t3},
+				expectedBuild:    []model.Target{t1, t2, t3},
+				expectedExport: []model.Config{
+					{Conf: "t1"}, {Conf: "t2"}, {Conf: "t3"}, {Conf: "t2", Stale: true}},
+				expectedCacheItems: 1,
+			}
+			return sim
+		},
+		"existing group with new targets only": func() pipelineSim {
+			t1 := mockPipelineTarget{Name: "t1"}
+			t2 := mockPipelineTarget{Name: "t2"}
+			t3 := mockPipelineTarget{Name: "t3"}
+			g1 := mockPipelineGroup{targets: []model.Target{t1, t2}, source: "s1"}
+			g2 := mockPipelineGroup{targets: []model.Target{t3}, source: "s1"}
+
+			sim := pipelineSim{
+				discoveredGroups: []model.TargetGroup{g1, g2},
+				expectedTag:      []model.Target{t1, t2, t3},
+				expectedBuild:    []model.Target{t1, t2, t3},
+				expectedExport: []model.Config{
+					{Conf: "t1"}, {Conf: "t2"}, {Conf: "t3"},
+					{Conf: "t1", Stale: true}, {Conf: "t2", Stale: true}},
+				expectedCacheItems: 1,
+			}
+			return sim
+		},
+	}
+
+	for name, sim := range tests {
+		t.Run(name, func(t *testing.T) { sim().run(t) })
+	}
+}
+
+type (
+	mockPipelineDiscoverer struct {
+		send []model.TargetGroup
+	}
+	mockTagger struct {
+		seen []model.Target
+	}
+	mockBuilder struct {
+		seen []model.Target
+	}
+	mockExporter struct {
+		seen []model.Config
+	}
+)
+
+func (d mockPipelineDiscoverer) Discover(ctx context.Context, in chan<- []model.TargetGroup) {
+	select {
+	case <-ctx.Done():
+	case in <- d.send:
+	}
+	<-ctx.Done()
+}
+
+func (t *mockTagger) Tag(target model.Target) {
+	t.seen = append(t.seen, target)
+}
+
+func (b *mockBuilder) Build(target model.Target) []model.Config {
+	b.seen = append(b.seen, target)
+	return []model.Config{{Conf: target.TUID()}}
+}
+
+func (e *mockExporter) Export(ctx context.Context, out <-chan []model.Config) {
+	select {
+	case <-ctx.Done():
+	case cfgs := <-out:
+		e.seen = append(e.seen, cfgs...)
+	}
+	<-ctx.Done()
+}
+
+type (
+	mockPipelineGroup struct {
+		targets []model.Target
+		source  string
+	}
+	mockPipelineTarget struct {
+		Name string
+	}
+)
+
+func (mg mockPipelineGroup) Targets() []model.Target { return mg.targets }
+func (mg mockPipelineGroup) Source() string          { return mg.source }
+
+func (mt mockPipelineTarget) Tags() model.Tags { return nil }
+func (mt mockPipelineTarget) TUID() string     { return mt.Name }
+func (mt mockPipelineTarget) Hash() uint64     { h, _ := hashstructure.Hash(mt, nil); return h }
+
+type pipelineSim struct {
+	discoveredGroups   []model.TargetGroup
+	expectedTag        []model.Target
+	expectedBuild      []model.Target
+	expectedExport     []model.Config
+	expectedCacheItems int
+}
+
+func (sim pipelineSim) run(t *testing.T) {
+	require.NotEmpty(t, sim.discoveredGroups)
+
+	discoverer := &mockPipelineDiscoverer{send: sim.discoveredGroups}
+	tagger := &mockTagger{}
+	builder := &mockBuilder{}
+	exporter := &mockExporter{}
+
+	p := NewPipeline(discoverer, tagger, builder, exporter)
+
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(context.Background())
+
+	wg.Add(1)
+	go func() { defer wg.Done(); p.Run(ctx) }()
+
+	time.Sleep(time.Second)
+	cancel()
+	wg.Wait()
+
+	sortStaleConfigs(sim.expectedExport)
+	sortStaleConfigs(exporter.seen)
+
+	assert.Equal(t, sim.expectedTag, tagger.seen)
+	assert.Equal(t, sim.expectedBuild, builder.seen)
+	assert.Equal(t, sim.expectedExport, exporter.seen)
+	if sim.expectedCacheItems >= 0 {
+		assert.Equal(t, sim.expectedCacheItems, len(p.cache))
+	}
+}
+
+func sortStaleConfigs(cfgs []model.Config) {
+	sort.Slice(cfgs, func(i, j int) bool {
+		return cfgs[i].Stale && cfgs[j].Stale && cfgs[i].Conf < cfgs[j].Conf
+	})
+}

--- a/agent/job/discovery/sd/selector.go
+++ b/agent/job/discovery/sd/selector.go
@@ -1,0 +1,159 @@
+package sd
+
+import (
+	"errors"
+	"fmt"
+	"github.com/netdata/go.d.plugin/agent/job/discovery/sd/model"
+	"strings"
+)
+
+type selector interface {
+	matches(model.Tags) bool
+}
+
+type (
+	exactSelector string
+	trueSelector  struct{}
+	negSelector   struct{ selector }
+	orSelector    struct{ lhs, rhs selector }
+	andSelector   struct{ lhs, rhs selector }
+)
+
+func (s exactSelector) matches(tags model.Tags) bool { _, ok := tags[string(s)]; return ok }
+func (s trueSelector) matches(_ model.Tags) bool     { return true }
+func (s negSelector) matches(tags model.Tags) bool   { return !s.selector.matches(tags) }
+func (s orSelector) matches(tags model.Tags) bool    { return s.lhs.matches(tags) || s.rhs.matches(tags) }
+func (s andSelector) matches(tags model.Tags) bool   { return s.lhs.matches(tags) && s.rhs.matches(tags) }
+
+func (s exactSelector) String() string { return "{" + string(s) + "}" }
+func (s negSelector) String() string   { return "{!" + stringify(s.selector) + "}" }
+func (s trueSelector) String() string  { return "{*}" }
+func (s orSelector) String() string    { return "{" + stringify(s.lhs) + "|" + stringify(s.rhs) + "}" }
+func (s andSelector) String() string   { return "{" + stringify(s.lhs) + ", " + stringify(s.rhs) + "}" }
+func stringify(sr selector) string     { return strings.Trim(fmt.Sprintf("%s", sr), "{}") }
+
+func parseSelector(line string) (sr selector, err error) {
+	words := strings.Fields(line)
+	if len(words) == 0 {
+		return trueSelector{}, nil
+	}
+
+	var srs []selector
+	for _, word := range words {
+		if idx := strings.IndexByte(word, '|'); idx > 0 {
+			sr, err = parseOrSelectorWord(word)
+		} else {
+			sr, err = parseSingleSelectorWord(word)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("selector '%s' contains selector '%s' with forbidden symbol", line, word)
+		}
+		srs = append(srs, sr)
+	}
+
+	switch len(srs) {
+	case 0:
+		return trueSelector{}, nil
+	case 1:
+		return srs[0], nil
+	default:
+		return newAndSelector(srs[0], srs[1], srs[2:]...), nil
+	}
+}
+
+func mustParseSelector(line string) selector {
+	sr, err := parseSelector(line)
+	if err != nil {
+		panic(fmt.Sprintf("selector '%s' parse error: %v", line, err))
+	}
+	return sr
+}
+
+func parseOrSelectorWord(orWord string) (sr selector, err error) {
+	var srs []selector
+	for _, word := range strings.Split(orWord, "|") {
+		if sr, err = parseSingleSelectorWord(word); err != nil {
+			return nil, err
+		}
+		srs = append(srs, sr)
+	}
+	switch len(srs) {
+	case 0:
+		return trueSelector{}, nil
+	case 1:
+		return srs[0], nil
+	default:
+		return newOrSelector(srs[0], srs[1], srs[2:]...), nil
+	}
+}
+
+func parseSingleSelectorWord(word string) (selector, error) {
+	if len(word) == 0 {
+		return nil, errors.New("empty word")
+	}
+	neg := word[0] == '!'
+	if neg {
+		word = word[1:]
+	}
+	if len(word) == 0 {
+		return nil, errors.New("empty word")
+	}
+	if word != "*" && !isSelectorWordValid(word) {
+		return nil, errors.New("forbidden symbol")
+	}
+
+	var sr selector
+	switch word {
+	case "*":
+		sr = trueSelector{}
+	default:
+		sr = exactSelector(word)
+	}
+	if neg {
+		return negSelector{sr}, nil
+	}
+	return sr, nil
+}
+
+func newAndSelector(lhs, rhs selector, others ...selector) selector {
+	m := andSelector{lhs: lhs, rhs: rhs}
+	switch len(others) {
+	case 0:
+		return m
+	default:
+		return newAndSelector(m, others[0], others[1:]...)
+	}
+}
+
+func newOrSelector(lhs, rhs selector, others ...selector) selector {
+	m := orSelector{lhs: lhs, rhs: rhs}
+	switch len(others) {
+	case 0:
+		return m
+	default:
+		return newOrSelector(m, others[0], others[1:]...)
+	}
+}
+
+func isSelectorWordValid(word string) bool {
+	// valid:
+	// *
+	// ^[a-zA-Z][a-zA-Z0-9=_.]*$
+	if len(word) == 0 {
+		return false
+	}
+	if word == "*" {
+		return true
+	}
+	for i, b := range word {
+		switch {
+		default:
+			return false
+		case b >= 'a' && b <= 'z':
+		case b >= 'A' && b <= 'Z':
+		case b >= '0' && b <= '9' && i > 0:
+		case (b == '=' || b == '_' || b == '.') && i > 0:
+		}
+	}
+	return true
+}

--- a/agent/job/discovery/sd/selector_test.go
+++ b/agent/job/discovery/sd/selector_test.go
@@ -1,0 +1,259 @@
+package sd
+
+import (
+	"github.com/netdata/go.d.plugin/agent/job/discovery/sd/model"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var reSrString = regexp.MustCompile(`^{[^{}]+}$`)
+
+func TestExactSelector_String(t *testing.T) {
+	sr := exactSelector("selector")
+
+	assert.True(t, reSrString.MatchString(sr.String()))
+}
+
+func TestNegSelector_String(t *testing.T) {
+	srs := []selector{
+		exactSelector("selector"),
+		negSelector{exactSelector("selector")},
+		orSelector{
+			lhs: exactSelector("selector"),
+			rhs: exactSelector("selector")},
+		orSelector{
+			lhs: orSelector{lhs: exactSelector("selector"), rhs: negSelector{exactSelector("selector")}},
+			rhs: orSelector{lhs: exactSelector("selector"), rhs: negSelector{exactSelector("selector")}},
+		},
+		andSelector{
+			lhs: andSelector{lhs: exactSelector("selector"), rhs: negSelector{exactSelector("selector")}},
+			rhs: andSelector{lhs: exactSelector("selector"), rhs: negSelector{exactSelector("selector")}},
+		},
+	}
+
+	for i, sr := range srs {
+		neg := negSelector{sr}
+		assert.True(t, reSrString.MatchString(neg.String()), "selector num %d", i+1)
+	}
+}
+
+func TestOrSelector_String(t *testing.T) {
+	sr := orSelector{
+		lhs: orSelector{lhs: exactSelector("selector"), rhs: negSelector{exactSelector("selector")}},
+		rhs: orSelector{lhs: exactSelector("selector"), rhs: negSelector{exactSelector("selector")}},
+	}
+
+	assert.True(t, reSrString.MatchString(sr.String()))
+}
+
+func TestAndSelector_String(t *testing.T) {
+	sr := andSelector{
+		lhs: andSelector{lhs: exactSelector("selector"), rhs: negSelector{exactSelector("selector")}},
+		rhs: andSelector{lhs: exactSelector("selector"), rhs: negSelector{exactSelector("selector")}},
+	}
+
+	assert.True(t, reSrString.MatchString(sr.String()))
+}
+
+func TestExactSelector_Match(t *testing.T) {
+	matchTests := struct {
+		tags model.Tags
+		srs  []exactSelector
+	}{
+		tags: model.Tags{"a": {}, "b": {}},
+		srs: []exactSelector{
+			"a",
+			"b",
+		},
+	}
+	notMatchTests := struct {
+		tags model.Tags
+		srs  []exactSelector
+	}{
+		tags: model.Tags{"a": {}, "b": {}},
+		srs: []exactSelector{
+			"c",
+			"d",
+		},
+	}
+
+	for i, sr := range matchTests.srs {
+		assert.Truef(t, sr.matches(matchTests.tags), "match selector num %d", i+1)
+	}
+	for i, sr := range notMatchTests.srs {
+		assert.Falsef(t, sr.matches(notMatchTests.tags), "not match selector num %d", i+1)
+	}
+}
+
+func TestNegSelector_Match(t *testing.T) {
+	matchTests := struct {
+		tags model.Tags
+		srs  []negSelector
+	}{
+		tags: model.Tags{"a": {}, "b": {}},
+		srs: []negSelector{
+			{exactSelector("c")},
+			{exactSelector("d")},
+		},
+	}
+	notMatchTests := struct {
+		tags model.Tags
+		srs  []negSelector
+	}{
+		tags: model.Tags{"a": {}, "b": {}},
+		srs: []negSelector{
+			{exactSelector("a")},
+			{exactSelector("b")},
+		},
+	}
+
+	for i, sr := range matchTests.srs {
+		assert.Truef(t, sr.matches(matchTests.tags), "match selector num %d", i+1)
+	}
+	for i, sr := range notMatchTests.srs {
+		assert.Falsef(t, sr.matches(notMatchTests.tags), "not match selector num %d", i+1)
+	}
+}
+
+func TestOrSelector_Match(t *testing.T) {
+	matchTests := struct {
+		tags model.Tags
+		srs  []orSelector
+	}{
+		tags: model.Tags{"a": {}, "b": {}},
+		srs: []orSelector{
+			{
+				lhs: orSelector{lhs: exactSelector("c"), rhs: exactSelector("d")},
+				rhs: orSelector{lhs: exactSelector("e"), rhs: exactSelector("b")},
+			},
+		},
+	}
+	notMatchTests := struct {
+		tags model.Tags
+		srs  []orSelector
+	}{
+		tags: model.Tags{"a": {}, "b": {}},
+		srs: []orSelector{
+			{
+				lhs: orSelector{lhs: exactSelector("c"), rhs: exactSelector("d")},
+				rhs: orSelector{lhs: exactSelector("e"), rhs: exactSelector("f")},
+			},
+		},
+	}
+
+	for i, sr := range matchTests.srs {
+		assert.Truef(t, sr.matches(matchTests.tags), "match selector num %d", i+1)
+	}
+	for i, sr := range notMatchTests.srs {
+		assert.Falsef(t, sr.matches(notMatchTests.tags), "not match selector num %d", i+1)
+	}
+}
+
+func TestAndSelector_Match(t *testing.T) {
+	matchTests := struct {
+		tags model.Tags
+		srs  []andSelector
+	}{
+		tags: model.Tags{"a": {}, "b": {}, "c": {}, "d": {}},
+		srs: []andSelector{
+			{
+				lhs: andSelector{lhs: exactSelector("a"), rhs: exactSelector("b")},
+				rhs: andSelector{lhs: exactSelector("c"), rhs: exactSelector("d")},
+			},
+		},
+	}
+	notMatchTests := struct {
+		tags model.Tags
+		srs  []andSelector
+	}{
+		tags: model.Tags{"a": {}, "b": {}, "c": {}, "d": {}},
+		srs: []andSelector{
+			{
+				lhs: andSelector{lhs: exactSelector("a"), rhs: exactSelector("b")},
+				rhs: andSelector{lhs: exactSelector("c"), rhs: exactSelector("z")},
+			},
+		},
+	}
+
+	for i, sr := range matchTests.srs {
+		assert.Truef(t, sr.matches(matchTests.tags), "match selector num %d", i+1)
+	}
+	for i, sr := range notMatchTests.srs {
+		assert.Falsef(t, sr.matches(notMatchTests.tags), "not match selector num %d", i+1)
+	}
+}
+
+func TestParseSelector(t *testing.T) {
+	tests := map[string]struct {
+		wantSelector selector
+		wantErr      bool
+	}{
+		"":    {wantSelector: trueSelector{}},
+		"a":   {wantSelector: exactSelector("a")},
+		"Z":   {wantSelector: exactSelector("Z")},
+		"a_b": {wantSelector: exactSelector("a_b")},
+		"a=b": {wantSelector: exactSelector("a=b")},
+		"!a":  {wantSelector: negSelector{exactSelector("a")}},
+		"a b": {wantSelector: andSelector{lhs: exactSelector("a"), rhs: exactSelector("b")}},
+		"a|b": {wantSelector: orSelector{lhs: exactSelector("a"), rhs: exactSelector("b")}},
+		"*":   {wantSelector: trueSelector{}},
+		"!*":  {wantSelector: negSelector{trueSelector{}}},
+		"a b !c d|e f": {
+			wantSelector: andSelector{
+				lhs: andSelector{
+					lhs: andSelector{
+						lhs: andSelector{lhs: exactSelector("a"), rhs: exactSelector("b")},
+						rhs: negSelector{exactSelector("c")},
+					},
+					rhs: orSelector{
+						lhs: exactSelector("d"),
+						rhs: exactSelector("e"),
+					},
+				},
+				rhs: exactSelector("f"),
+			},
+		},
+		"!":      {wantErr: true},
+		"a !":    {wantErr: true},
+		"a!b":    {wantErr: true},
+		"0a":     {wantErr: true},
+		"a b c*": {wantErr: true},
+		"__":     {wantErr: true},
+		"a|b|c*": {wantErr: true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			sr, err := parseSelector(name)
+
+			if test.wantErr {
+				assert.Nil(t, sr)
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.wantSelector, sr)
+			}
+		})
+	}
+}
+
+func TestMustParseSelector(t *testing.T) {
+	tests := []string{
+		"!",
+		"a !",
+		"a!b",
+		"0a",
+		"a b c*",
+		"__",
+		"a|b|c*",
+	}
+
+	for _, test := range tests {
+		f := func() {
+			mustParseSelector(test)
+		}
+		assert.Panicsf(t, f, test)
+	}
+}

--- a/agent/job/discovery/sd/target_build.go
+++ b/agent/job/discovery/sd/target_build.go
@@ -1,0 +1,170 @@
+package sd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"github.com/netdata/go.d.plugin/agent/job/discovery/sd/model"
+	"text/template"
+
+	"github.com/netdata/go.d.plugin/logger"
+)
+
+type (
+	BuildConfig     []BuildRuleConfig // mandatory, at least 1
+	BuildRuleConfig struct {
+		Name     string        `yaml:"name"`     // optional
+		Selector string        `yaml:"selector"` // mandatory
+		Tags     string        `yaml:"tags"`     // mandatory
+		Apply    []ApplyConfig `yaml:"apply"`    // mandatory, at least 1
+	}
+	ApplyConfig struct {
+		Selector string `yaml:"selector"` // mandatory
+		Tags     string `yaml:"tags"`     // optional
+		Template string `yaml:"template"` // mandatory
+	}
+)
+
+func validateBuildConfig(cfg BuildConfig) error {
+	if len(cfg) == 0 {
+		return errors.New("empty config, need least 1 rule")
+	}
+	for i, ruleCfg := range cfg {
+		if ruleCfg.Selector == "" {
+			return fmt.Errorf("'rule->selector' not set (rule %s[%d])", ruleCfg.Name, i+1)
+		}
+
+		if ruleCfg.Tags == "" {
+			return fmt.Errorf("'rule->tags' not set (rule %s[%d])", ruleCfg.Name, i+1)
+		}
+		if len(ruleCfg.Apply) == 0 {
+			return fmt.Errorf("'rule->apply' not set (rule %s[%d])", ruleCfg.Name, i+1)
+		}
+
+		for j, applyCfg := range ruleCfg.Apply {
+			if applyCfg.Selector == "" {
+				return fmt.Errorf("'rule->apply->selector' not set (rule %s[%d]/apply [%d])", ruleCfg.Name, i+1, j+1)
+			}
+			if applyCfg.Template == "" {
+				return fmt.Errorf("'rule->apply->template' not set (rule %s[%d]/apply [%d])", ruleCfg.Name, i+1, j+1)
+			}
+		}
+	}
+	return nil
+}
+
+type (
+	BuildManager struct {
+		rules []*buildRule
+		buf   bytes.Buffer
+		*logger.Logger
+	}
+	buildRule struct {
+		name  string
+		id    int
+		sr    selector
+		tags  model.Tags
+		apply []*ruleApply
+	}
+	ruleApply struct {
+		id   int
+		sr   selector
+		tags model.Tags
+		tmpl *template.Template
+	}
+)
+
+func NewBuildManager(cfg BuildConfig) (*BuildManager, error) {
+	if err := validateBuildConfig(cfg); err != nil {
+		return nil, fmt.Errorf("build manager config validation: %v", err)
+	}
+	mgr, err := initBuildManager(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("build manager initialization: %v", err)
+	}
+	return mgr, nil
+}
+
+func (m *BuildManager) Build(target model.Target) (configs []model.Config) {
+	for _, rule := range m.rules {
+		if !rule.sr.matches(target.Tags()) {
+			continue
+		}
+
+		for _, apply := range rule.apply {
+			if !apply.sr.matches(target.Tags()) {
+				continue
+			}
+
+			m.buf.Reset()
+			if err := apply.tmpl.Execute(&m.buf, target); err != nil {
+				m.Warningf("failed to execute rule apply '%d/%d' on target '%s': %v", rule.id, apply.id, target.TUID(), err)
+				continue
+			}
+
+			cfg := model.Config{
+				Tags: model.NewTags(),
+				Conf: m.buf.String(),
+			}
+			cfg.Tags.Merge(rule.tags)
+			cfg.Tags.Merge(apply.tags)
+
+			configs = append(configs, cfg)
+		}
+	}
+
+	if len(configs) > 0 {
+		m.Infof("built %d config(s) for target '%s'", len(configs), target.TUID())
+	}
+	return configs
+}
+
+func initBuildManager(conf BuildConfig) (*BuildManager, error) {
+	if len(conf) == 0 {
+		return nil, errors.New("empty config")
+	}
+	mgr := &BuildManager{
+		Logger: logger.New("build", "manager"),
+	}
+
+	for i, cfg := range conf {
+		rule := buildRule{id: i + 1, name: cfg.Name}
+		if sr, err := parseSelector(cfg.Selector); err != nil {
+			return nil, err
+		} else {
+			rule.sr = sr
+		}
+
+		if tags, err := model.ParseTags(cfg.Tags); err != nil {
+			return nil, err
+		} else {
+			rule.tags = tags
+		}
+
+		for i, cfg := range cfg.Apply {
+			apply := ruleApply{id: i + 1}
+
+			sr, err := parseSelector(cfg.Selector)
+			if err != nil {
+				return nil, err
+			}
+			apply.sr = sr
+
+			tags, err := model.ParseTags(cfg.Tags)
+			if err != nil {
+				return nil, err
+			}
+			apply.tags = tags
+
+			tmpl, err := parseTemplate(cfg.Template)
+			if err != nil {
+				return nil, err
+			}
+			apply.tmpl = tmpl
+
+			rule.apply = append(rule.apply, &apply)
+		}
+		mgr.rules = append(mgr.rules, &rule)
+	}
+	return mgr, nil
+}

--- a/agent/job/discovery/sd/target_build_test.go
+++ b/agent/job/discovery/sd/target_build_test.go
@@ -1,0 +1,320 @@
+package sd
+
+import (
+	"fmt"
+	"github.com/netdata/go.d.plugin/agent/job/discovery/sd/model"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBuildManager(t *testing.T) {
+	tests := map[string]buildSim{
+		"valid config": {
+			cfg: BuildConfig{
+				{
+					Selector: "unknown",
+					Tags:     "-unknown",
+					Apply: []ApplyConfig{
+						{Selector: "wizard", Template: `class {{.Class}}`},
+					},
+				},
+			},
+		},
+		"empty config": {
+			invalid: true,
+			cfg:     BuildConfig{},
+		},
+		"config rule->selector not set": {
+			invalid: true,
+			cfg: BuildConfig{
+				{
+					Selector: "",
+					Tags:     "-unknown",
+					Apply: []ApplyConfig{
+						{Selector: "wizard", Template: `class {{.Class}}`},
+					},
+				},
+			},
+		},
+		"config rule->selector bad syntax": {
+			invalid: true,
+			cfg: BuildConfig{
+				{
+					Selector: "!",
+					Tags:     "-unknown",
+					Apply: []ApplyConfig{
+						{Selector: "wizard", Template: `class {{.Class}}`},
+					},
+				},
+			},
+		},
+		"config rule->tags not set": {
+			invalid: true,
+			cfg: BuildConfig{
+				{
+					Selector: "unknown",
+					Tags:     "",
+					Apply: []ApplyConfig{
+						{Selector: "wizard", Template: `class {{.Class}}`},
+					},
+				},
+			},
+		},
+		"config rule->apply not set": {
+			invalid: true,
+			cfg: BuildConfig{
+				{
+					Selector: "unknown",
+					Tags:     "-unknown",
+				},
+			},
+		},
+		"config rule->apply->selector not set": {
+			invalid: true,
+			cfg: BuildConfig{
+				{
+					Selector: "unknown",
+					Tags:     "-unknown",
+					Apply: []ApplyConfig{
+						{Selector: "", Template: `class {{.Class}}`},
+					},
+				},
+			},
+		},
+		"config rule->apply->selector bad syntax": {
+			invalid: true,
+			cfg: BuildConfig{
+				{
+					Selector: "unknown",
+					Tags:     "-unknown",
+					Apply: []ApplyConfig{
+						{Selector: "!", Template: `class {{.Class}}`},
+					},
+				},
+			},
+		},
+		"config rule->apply->template not set": {
+			invalid: true,
+			cfg: BuildConfig{
+				{
+					Selector: "unknown",
+					Tags:     "-unknown",
+					Apply: []ApplyConfig{
+						{Selector: "wizard", Template: ""},
+					},
+				},
+			},
+		},
+		"config rule->apply->template missingkey (unknown func)": {
+			invalid: true,
+			cfg: BuildConfig{
+				{
+					Selector: "unknown",
+					Tags:     "-unknown",
+					Apply: []ApplyConfig{
+						{Selector: "wizard", Template: `class {{error .Class}}`},
+					},
+				},
+			},
+		},
+	}
+
+	for name, sim := range tests {
+		t.Run(name, func(t *testing.T) { sim.run(t) })
+	}
+}
+
+func TestManager_Build(t *testing.T) {
+	tests := map[string]buildSim{
+		"4 rule service": {
+			cfg: BuildConfig{
+				{
+					Selector: "class",
+					Tags:     "built",
+					Apply: []ApplyConfig{
+						{Selector: "*", Template: `Class: {{.Class}}`},
+					},
+				},
+				{
+					Selector: "race",
+					Tags:     "built",
+					Apply: []ApplyConfig{
+						{Selector: "*", Template: `Race: {{.Race}}`},
+					},
+				},
+				{
+					Selector: "level",
+					Tags:     "built",
+					Apply: []ApplyConfig{
+						{Selector: "*", Template: `Level: {{.Level}}`},
+					},
+				},
+				{
+					Selector: "full",
+					Tags:     "built",
+					Apply: []ApplyConfig{
+						{Selector: "*", Template: `Class: {{.Class}}, Race: {{.Race}}, Level: {{.Level}}`},
+					},
+				},
+			},
+			inputs: []buildSimInput{
+				{
+					desc: "1st rule match",
+					target: mockBuildTarget{
+						tag:   model.Tags{"class": {}},
+						Class: "fighter", Race: "orc", Level: 9001,
+					},
+					expectedCfgs: []model.Config{
+						{Conf: "Class: fighter", Tags: model.Tags{"built": {}}},
+					},
+				},
+				{
+					desc: "1st, 2nd rules match",
+					target: mockBuildTarget{
+						tag:   model.Tags{"class": {}, "race": {}},
+						Class: "fighter", Race: "orc", Level: 9001,
+					},
+					expectedCfgs: []model.Config{
+						{Conf: "Class: fighter", Tags: model.Tags{"built": {}}},
+						{Conf: "Race: orc", Tags: model.Tags{"built": {}}},
+					},
+				},
+				{
+					desc: "1st, 2nd, 3rd rules match",
+					target: mockBuildTarget{
+						tag:   model.Tags{"class": {}, "race": {}, "level": {}},
+						Class: "fighter", Race: "orc", Level: 9001,
+					},
+					expectedCfgs: []model.Config{
+						{Conf: "Class: fighter", Tags: model.Tags{"built": {}}},
+						{Conf: "Race: orc", Tags: model.Tags{"built": {}}},
+						{Conf: "Level: 9001", Tags: model.Tags{"built": {}}},
+					},
+				},
+				{
+					desc: "all rules match",
+					target: mockBuildTarget{
+						tag:   model.Tags{"class": {}, "race": {}, "level": {}, "full": {}},
+						Class: "fighter", Race: "orc", Level: 9001,
+					},
+					expectedCfgs: []model.Config{
+						{Conf: "Class: fighter", Tags: model.Tags{"built": {}}},
+						{Conf: "Race: orc", Tags: model.Tags{"built": {}}},
+						{Conf: "Level: 9001", Tags: model.Tags{"built": {}}},
+						{Conf: "Class: fighter, Race: orc, Level: 9001", Tags: model.Tags{"built": {}}},
+					},
+				},
+			},
+		},
+	}
+
+	for name, sim := range tests {
+		t.Run(name, func(t *testing.T) { sim.run(t) })
+	}
+}
+
+func TestRule_Build(t *testing.T) {
+	tests := map[string]buildSim{
+		"simple rule": {
+			cfg: BuildConfig{
+				{
+					Selector: "build",
+					Tags:     "built",
+					Apply: []ApplyConfig{
+						{Selector: "human", Template: `Class: {{.Class}}, Race: {{.Race}}, Level: {{.Level}}`},
+						{Selector: "missingkey", Template: `{{.Name}}`},
+					},
+				},
+			},
+			inputs: []buildSimInput{
+				{
+					desc: "not match rule selector",
+					target: mockBuildTarget{
+						tag:   model.Tags{"nothing": {}},
+						Class: "fighter", Race: "orc", Level: 9001,
+					},
+				},
+				{
+					desc: "not match rule match selector",
+					target: mockBuildTarget{
+						tag:   model.Tags{"build": {}},
+						Class: "fighter", Race: "orc", Level: 9001,
+					},
+				},
+				{
+					desc: "match everything",
+					target: mockBuildTarget{
+						tag:   model.Tags{"build": {}, "human": {}},
+						Class: "fighter", Race: "human", Level: 9001,
+					},
+					expectedCfgs: []model.Config{
+						{Conf: "Class: fighter, Race: human, Level: 9001", Tags: model.Tags{"built": {}}},
+					},
+				},
+				{
+					desc: "missingkey error",
+					target: mockBuildTarget{
+						tag:   model.Tags{"build": {}, "missingkey": {}},
+						Class: "fighter", Race: "human", Level: 9001,
+					},
+				},
+			},
+		},
+	}
+
+	for name, sim := range tests {
+		t.Run(name, func(t *testing.T) { sim.run(t) })
+	}
+}
+
+type mockBuildTarget struct {
+	tag   model.Tags
+	Class string
+	Race  string
+	Level int
+}
+
+func (m mockBuildTarget) Tags() model.Tags { return m.tag }
+func (mockBuildTarget) Hash() uint64       { return 0 }
+func (mockBuildTarget) TUID() string       { return "" }
+func (m mockBuildTarget) String() string {
+	return fmt.Sprintf("Class: %s, Race: %s, Level: %d, Tags: %s", m.Class, m.Race, m.Level, m.Tags())
+}
+
+type (
+	buildSim struct {
+		cfg     BuildConfig
+		invalid bool
+		inputs  []buildSimInput
+	}
+	buildSimInput struct {
+		desc         string
+		target       mockBuildTarget
+		expectedCfgs []model.Config
+	}
+)
+
+func (sim buildSim) run(t *testing.T) {
+	mgr, err := NewBuildManager(sim.cfg)
+
+	if sim.invalid {
+		require.Error(t, err)
+		return
+	}
+
+	require.NoError(t, err)
+	require.NotNil(t, mgr)
+
+	if len(sim.inputs) == 0 {
+		return
+	}
+
+	for i, input := range sim.inputs {
+		name := fmt.Sprintf("input:'%s'[%d], target:'%s', expected configs:'%v'", input.desc, i+1, input.target, input.expectedCfgs)
+		actual := mgr.Build(input.target)
+
+		assert.Equalf(t, input.expectedCfgs, actual, name)
+	}
+}

--- a/agent/job/discovery/sd/target_tag.go
+++ b/agent/job/discovery/sd/target_tag.go
@@ -1,0 +1,171 @@
+package sd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"github.com/netdata/go.d.plugin/agent/job/discovery/sd/model"
+	"strings"
+	"text/template"
+
+	"github.com/netdata/go.d.plugin/logger"
+)
+
+type (
+	TagConfig  []RuleConfig // mandatory, at least 1
+	RuleConfig struct {
+		Name     string        `yaml:"name"`
+		Selector string        `yaml:"selector"` // mandatory
+		Tags     string        `yaml:"tags"`     // mandatory
+		Match    []MatchConfig `yaml:"match"`    // mandatory, at least 1
+	}
+	MatchConfig struct {
+		Selector string `yaml:"selector"` // optional
+		Tags     string `yaml:"tags"`     // mandatory
+		Expr     string `yaml:"expr"`     // mandatory
+	}
+)
+
+func validateTagConfig(cfg TagConfig) error {
+	if len(cfg) == 0 {
+		return errors.New("empty config, need least 1 rule")
+	}
+	for i, rule := range cfg {
+		if rule.Selector == "" {
+			return fmt.Errorf("'rule->selector' not set (rule %s[%d])", rule.Name, i+1)
+		}
+		if rule.Tags == "" {
+			return fmt.Errorf("'rule->tags' not set (rule %s[%d])", rule.Name, i+1)
+		}
+		if len(rule.Match) == 0 {
+			return fmt.Errorf("'rule->match' not set, need at least 1 rule match (rule %s[%d])", rule.Name, i+1)
+		}
+
+		for j, match := range rule.Match {
+			if match.Tags == "" {
+				return fmt.Errorf("'rule->match->tags' not set (rule %s[%d]/match [%d])", rule.Name, i+1, j+1)
+			}
+			if match.Expr == "" {
+				return fmt.Errorf("'rule->match->expr' not set (rule %s[%d]/match [%d])", rule.Name, i+1, j+1)
+			}
+		}
+	}
+	return nil
+}
+
+type (
+	TagManager struct {
+		rules []*tagRule
+		buf   bytes.Buffer
+		*logger.Logger
+	}
+	tagRule struct {
+		name  string
+		id    int
+		sr    selector
+		tags  model.Tags
+		match []*ruleMatch
+	}
+	ruleMatch struct {
+		id   int
+		sr   selector
+		tags model.Tags
+		expr *template.Template
+	}
+)
+
+func NewTagManager(cfg TagConfig) (*TagManager, error) {
+	if err := validateTagConfig(cfg); err != nil {
+		return nil, fmt.Errorf("tag manager config validation: %v", err)
+	}
+	mgr, err := initTagManager(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("tag manager initialization: %v", err)
+	}
+	return mgr, nil
+}
+
+func (m *TagManager) Tag(target model.Target) {
+	for _, rule := range m.rules {
+		if !rule.sr.matches(target.Tags()) {
+			continue
+		}
+
+		for _, match := range rule.match {
+			if !match.sr.matches(target.Tags()) {
+				continue
+			}
+
+			m.buf.Reset()
+			if err := match.expr.Execute(&m.buf, target); err != nil {
+				m.Warningf("failed to execute rule match '%d/%d' on target '%s': %v", rule.id, match.id, target.TUID(), err)
+				continue
+			}
+			if strings.TrimSpace(m.buf.String()) != "true" {
+				continue
+			}
+
+			target.Tags().Merge(rule.tags)
+			target.Tags().Merge(match.tags)
+			m.Debugf("matched target '%s', tags: %s", target.TUID(), target.Tags())
+		}
+	}
+}
+
+func initTagManager(conf TagConfig) (*TagManager, error) {
+	if len(conf) == 0 {
+		return nil, errors.New("empty config")
+	}
+
+	mgr := &TagManager{
+		rules:  nil,
+		Logger: logger.New("tag", "manager"),
+	}
+	for i, cfg := range conf {
+		rule := tagRule{id: i + 1, name: cfg.Name}
+		if sr, err := parseSelector(cfg.Selector); err != nil {
+			return nil, err
+		} else {
+			rule.sr = sr
+		}
+
+		if tags, err := model.ParseTags(cfg.Tags); err != nil {
+			return nil, err
+		} else {
+			rule.tags = tags
+		}
+
+		for i, cfg := range cfg.Match {
+			match := ruleMatch{id: i + 1}
+
+			sr, err := parseSelector(cfg.Selector)
+			if err != nil {
+				return nil, err
+			}
+			match.sr = sr
+
+			tags, err := model.ParseTags(cfg.Tags)
+			if err != nil {
+				return nil, err
+			}
+			match.tags = tags
+
+			tmpl, err := parseTemplate(cfg.Expr)
+			if err != nil {
+				return nil, err
+			}
+			match.expr = tmpl
+
+			rule.match = append(rule.match, &match)
+		}
+		mgr.rules = append(mgr.rules, &rule)
+	}
+	return mgr, nil
+}
+
+func parseTemplate(line string) (*template.Template, error) {
+	return template.New("root").
+		Option("missingkey=error").
+		Funcs(funcMap).
+		Parse(line)
+}

--- a/agent/job/discovery/sd/target_tag_test.go
+++ b/agent/job/discovery/sd/target_tag_test.go
@@ -1,0 +1,327 @@
+package sd
+
+import (
+	"fmt"
+	"github.com/netdata/go.d.plugin/agent/job/discovery/sd/model"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	tests := map[string]tagSim{
+		"valid config": {
+			cfg: TagConfig{
+				{
+					Selector: "unknown",
+					Tags:     "-unknown",
+					Match: []MatchConfig{
+						{Tags: "wizard", Expr: `{{eq .Class "wizard"}}`},
+					},
+				},
+			},
+		},
+		"empty config": {
+			cfg:     TagConfig{},
+			invalid: true,
+		},
+		"config rule->selector not set": {
+			invalid: true,
+			cfg: TagConfig{
+				{
+					Selector: "",
+					Tags:     "-unknown",
+					Match: []MatchConfig{
+						{Tags: "wizard", Expr: `{{eq .Class "wizard"}}`},
+					},
+				},
+			},
+		},
+		"config rule->selector bad syntax": {
+			invalid: true,
+			cfg: TagConfig{
+				{
+					Selector: "!",
+					Tags:     "-unknown",
+					Match: []MatchConfig{
+						{Tags: "wizard", Expr: `{{eq .Class "wizard"}}`},
+					},
+				},
+			},
+		},
+		"config rule->tags not set": {
+			invalid: true,
+			cfg: TagConfig{
+				{
+					Selector: "unknown",
+					Tags:     "",
+					Match: []MatchConfig{
+						{Tags: "wizard", Expr: `{{eq .Class "wizard"}}`},
+					},
+				},
+			},
+		},
+		"config rule->match not set": {
+			invalid: true,
+			cfg: TagConfig{
+				{
+					Selector: "unknown",
+					Tags:     "-unknown",
+				},
+			},
+		},
+		"config rule->match->selector bad syntax": {
+			invalid: true,
+			cfg: TagConfig{
+				{
+					Selector: "unknown",
+					Tags:     "-unknown",
+					Match: []MatchConfig{
+						{Selector: "!", Tags: "wizard", Expr: `{{eq .Class "wizard"}}`},
+					},
+				},
+			},
+		},
+		"config rule->match->tags not set": {
+			invalid: true,
+			cfg: TagConfig{
+				{
+					Selector: "unknown",
+					Tags:     "-unknown",
+					Match: []MatchConfig{
+						{Tags: "", Expr: `{{eq .Class "wizard"}}`},
+					},
+				},
+			},
+		},
+		"config rule->match->expr not set": {
+			invalid: true,
+			cfg: TagConfig{
+				{
+					Selector: "unknown",
+					Tags:     "-unknown",
+					Match: []MatchConfig{
+						{Tags: "wizard", Expr: ""},
+					},
+				},
+			},
+		},
+		"config rule->match->expr unknown func": {
+			invalid: true,
+			cfg: TagConfig{
+				{
+					Selector: "unknown",
+					Tags:     "-unknown",
+					Match: []MatchConfig{
+						{Tags: "wizard", Expr: `{{error .Class "wizard"}}`},
+					},
+				},
+			},
+		},
+	}
+
+	for name, sim := range tests {
+		t.Run(name, func(t *testing.T) { sim.run(t) })
+	}
+}
+
+func TestManager_Tag(t *testing.T) {
+	tests := map[string]tagSim{
+		"3 rule service": {
+			cfg: TagConfig{
+				{
+					Selector: "unknown",
+					Tags:     "-unknown",
+					Match: []MatchConfig{
+						{Tags: "wizard", Expr: `{{eq .Class "wizard"}}`},
+						{Tags: "knight", Expr: `{{eq .Class "knight"}}`},
+						{Tags: "cleric", Expr: `{{eq .Class "cleric"}}`},
+					},
+				},
+				{
+					Selector: "!unknown",
+					Tags:     "candidate",
+					Match: []MatchConfig{
+						{Tags: "human", Expr: `{{eq .Race "human"}}`},
+						{Tags: "elf", Expr: `{{eq .Race "elf"}}`},
+						{Tags: "dwarf", Expr: `{{eq .Race "dwarf"}}`},
+					},
+				},
+				{
+					Selector: "candidate",
+					Tags:     "-candidate",
+					Match: []MatchConfig{
+						{Tags: "teamup", Expr: `{{gt .Level 9000}}`},
+					},
+				},
+			},
+			inputs: []tagSimInput{
+				{
+					desc:         "all rules fail",
+					target:       mockTagTarget{tags: model.Tags{"unknown": {}}, Class: "fighter", Race: "orc", Level: 9001},
+					expectedTags: model.Tags{"unknown": {}},
+				},
+				{
+					desc:         "1st rule match",
+					target:       mockTagTarget{tags: model.Tags{"unknown": {}}, Class: "knight", Race: "undead", Level: 9001},
+					expectedTags: model.Tags{"knight": {}},
+				},
+				{
+					desc:         "1st, 2nd rules match",
+					target:       mockTagTarget{tags: model.Tags{"unknown": {}}, Class: "knight", Race: "human", Level: 8999},
+					expectedTags: model.Tags{"knight": {}, "human": {}, "candidate": {}},
+				},
+				{
+					desc:         "all rules match",
+					target:       mockTagTarget{tags: model.Tags{"unknown": {}}, Class: "wizard", Race: "human", Level: 9001},
+					expectedTags: model.Tags{"wizard": {}, "human": {}, "teamup": {}},
+				},
+				{
+					desc:         "all rules match",
+					target:       mockTagTarget{tags: model.Tags{"unknown": {}}, Class: "knight", Race: "dwarf", Level: 9001},
+					expectedTags: model.Tags{"knight": {}, "dwarf": {}, "teamup": {}},
+				},
+				{
+					desc:         "all rules match",
+					target:       mockTagTarget{tags: model.Tags{"unknown": {}}, Class: "cleric", Race: "elf", Level: 9001},
+					expectedTags: model.Tags{"cleric": {}, "elf": {}, "teamup": {}},
+				},
+			},
+		},
+	}
+
+	for name, sim := range tests {
+		t.Run(name, func(t *testing.T) { sim.run(t) })
+	}
+}
+
+func TestRule_Tag(t *testing.T) {
+	tests := map[string]tagSim{
+		"simple rule": {
+			cfg: TagConfig{
+				{
+					Selector: "unknown",
+					Tags:     "-unknown",
+					Match: []MatchConfig{
+						{Selector: "human", Tags: "wizard", Expr: `{{eq .Class "wizard"}}`},
+						{Tags: "missingkey", Expr: `{{eq .Name "yoda"}}`},
+					},
+				},
+			},
+			inputs: []tagSimInput{
+				{
+					desc:         "not match rule selector",
+					target:       mockTagTarget{Class: "fighter"},
+					expectedTags: nil,
+				},
+				{
+					desc:         "not match rule match selector",
+					target:       mockTagTarget{tags: model.Tags{"unknown": {}}, Class: "fighter"},
+					expectedTags: model.Tags{"unknown": {}},
+				},
+				{
+					desc:         "not match rule match expression",
+					target:       mockTagTarget{tags: model.Tags{"unknown": {}, "human": {}}, Class: "fighter"},
+					expectedTags: model.Tags{"unknown": {}, "human": {}},
+				},
+				{
+					desc:         "match expression",
+					target:       mockTagTarget{tags: model.Tags{"unknown": {}, "human": {}}, Class: "wizard"},
+					expectedTags: model.Tags{"wizard": {}, "human": {}},
+				},
+				{
+					desc:         "match expression missingkey error",
+					target:       mockTagTarget{tags: model.Tags{"unknown": {}, "missingkey": {}}, Class: "knight"},
+					expectedTags: model.Tags{"unknown": {}, "missingkey": {}},
+				},
+			},
+		},
+	}
+
+	for name, sim := range tests {
+		t.Run(name, func(t *testing.T) { sim.run(t) })
+	}
+}
+
+func TestRule_Tag_UseCustomFunction(t *testing.T) {
+	newSim := func(expr string) tagSim {
+		return tagSim{
+			cfg: TagConfig{
+				{
+					Selector: "*",
+					Tags:     "-nothing",
+					Match: []MatchConfig{
+						{Tags: "wizard", Expr: expr},
+					},
+				},
+			},
+			inputs: []tagSimInput{
+				{
+					target:       mockTagTarget{Class: "wizard", tags: model.Tags{"key": {}}},
+					expectedTags: model.Tags{"key": {}, "wizard": {}},
+				},
+			},
+		}
+	}
+
+	tests := map[string]tagSim{
+		"glob": newSim(`{{glob .Class "w*z*rd"}}`),
+		"re":   newSim(`{{re .Class "^w[iI]z.*d$"}}`),
+	}
+
+	for name, sim := range tests {
+		t.Run(name, func(t *testing.T) { sim.run(t) })
+	}
+}
+
+type mockTagTarget struct {
+	tags  model.Tags
+	Class string
+	Race  string
+	Level int
+}
+
+func (m mockTagTarget) Tags() model.Tags { return m.tags }
+func (m mockTagTarget) Hash() uint64     { return 0 }
+func (m mockTagTarget) TUID() string     { return "" }
+func (m mockTagTarget) String() string {
+	return fmt.Sprintf("Class: %s, Race: %s, Level: %d, Tags: %s", m.Class, m.Race, m.Level, m.Tags())
+}
+
+type (
+	tagSim struct {
+		cfg     TagConfig
+		invalid bool
+		inputs  []tagSimInput
+	}
+	tagSimInput struct {
+		desc         string
+		target       mockTagTarget
+		expectedTags model.Tags
+	}
+)
+
+func (sim tagSim) run(t *testing.T) {
+	mgr, err := NewTagManager(sim.cfg)
+
+	if sim.invalid {
+		require.Error(t, err)
+		return
+	}
+
+	require.NoError(t, err)
+	require.NotNil(t, mgr)
+
+	if len(sim.inputs) == 0 {
+		return
+	}
+
+	for i, input := range sim.inputs {
+		name := fmt.Sprintf("input:'%s'[%d], target:'%s', expected tags:'%s'",
+			input.desc, i+1, input.target, input.expectedTags)
+
+		mgr.Tag(input.target)
+		assert.Equalf(t, input.expectedTags, input.target.Tags(), name)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
+	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/Wing924/ltsv v0.3.1
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
@@ -16,6 +17,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/go-sql-driver/mysql v1.7.0
+	github.com/gobwas/glob v0.2.3
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/gofrs/flock v0.8.1
 	github.com/golang/mock v1.6.0
@@ -49,6 +51,8 @@ require (
 require (
 	cloud.google.com/go/compute v1.6.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
@@ -90,6 +94,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
+	github.com/huandu/xstrings v1.3.3 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
@@ -113,6 +118,8 @@ require (
 	github.com/mdlayher/genetlink v1.2.0 // indirect
 	github.com/mdlayher/netlink v1.6.0 // indirect
 	github.com/mdlayher/socket v0.2.3 // indirect
+	github.com/mitchellh/copystructure v1.0.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
@@ -128,8 +135,10 @@ require (
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,15 +82,19 @@ github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20191009163259-e802c2cb94ae/go.mod h1:mjwGPas4yKduTyubHvD1Atl9r1rUq8DfVy+gkVvZ+oo=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
-github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.0.3/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
-github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7YgDP83g=
+github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Masterminds/sprig v2.15.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
+github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj9n6YA=
+github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/Microsoft/go-winio v0.5.1 h1:aPJp2QD7OOrhO5tQXqQoGSJc+DjDtWTGLOmNyAm6FgY=
 github.com/Microsoft/go-winio v0.5.1/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -328,6 +332,8 @@ github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-sql-driver/mysql v1.7.0 h1:ueSltNNllEqE3qcWBTD0iQd3IpL/6U+mJxLkazJ7YPc=
 github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
@@ -517,6 +523,8 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
+github.com/huandu/xstrings v1.3.3 h1:/Gcsuc1x8JVbJ9/rlye4xZnVAbEkGauT8lbebqcQws4=
+github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/iancoleman/strcase v0.0.0-20180726023541-3605ed457bf7/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
@@ -527,6 +535,7 @@ github.com/ilyam8/hashstructure v1.1.0/go.mod h1:LoLuwBSNpZOi3eTMfAqe2i4oW9QkI08
 github.com/imdario/mergo v0.3.4/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
@@ -716,6 +725,7 @@ github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WT
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721 h1:RlZweED6sbSArvlE924+mUcZuXKLBHA35U7LN621Bws=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
+github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -726,6 +736,7 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY70sEEpE=
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQBbIJfabdt4wUm5qy3wOL2Zc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -913,6 +924,8 @@ github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY52
 github.com/spf13/afero v1.3.4/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
+github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
@@ -1087,6 +1100,7 @@ golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220824171710-5757bc0c5503/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
 golang.org/x/crypto v0.6.0 h1:qfktjS5LUO+fFKeJXZ+ikTRijMmljikvG68fpMMruSc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=


### PR DESCRIPTION
This PR:

- [ ] adds https://github.com/netdata/agent-service-discovery. No more reasons to have k8s service discovery as a separate project.
- [ ] refactors job discovery code to simplify adding more discovers (e.g. docker). 