### PR TITLE
Modify collector heading to XYZ collector

### DIFF
--- a/modules/activemq/README.md
+++ b/modules/activemq/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Message brokers"
 -->
 
-# ActiveMQ monitoring with Netdata
+# ActiveMQ collector
 
 [`ActiveMQ`](https://activemq.apache.org/) is an open source message broker written in Java together with a full Java
 Message Service client.

--- a/modules/apache/README.md
+++ b/modules/apache/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# Apache monitoring with Netdata
+# Apache collector
 
 [`Apache`](https://httpd.apache.org/) is an open-source HTTP server for modern operating systems including UNIX and
 Windows.

--- a/modules/bind/README.md
+++ b/modules/bind/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# Bind9 monitoring with Netdata
+# Bind9 collector
 
 [`Bind9`](https://www.isc.org/bind/) (or named) is a very flexible, full-featured DNS system.
 

--- a/modules/cassandra/README.md
+++ b/modules/cassandra/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Databases"
 -->
 
-# Cassandra monitoring with Netdata
+# Cassandra collector
 
 [Cassandra](https://cassandra.apache.org/_/index.html) is an open-source NoSQL database management system.
 

--- a/modules/chrony/README.md
+++ b/modules/chrony/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Apps"
 -->
 
-# Chrony monitoring with Netdata
+# Chrony collector
 
 [chrony](https://chrony.tuxfamily.org/) is a versatile implementation of the Network Time Protocol (NTP).
 

--- a/modules/cockroachdb/README.md
+++ b/modules/cockroachdb/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Databases"
 -->
 
-# CockroachDB monitoring with Netdata
+# CockroachDB collector
 
 [`CockroachDB`](https://www.cockroachlabs.com/)  is the SQL database for building global, scalable cloud services that
 survive disasters.

--- a/modules/consul/README.md
+++ b/modules/consul/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# Consul monitoring with Netdata
+# Consul collector
 
 [Consul](https://www.consul.io/) is a service networking solution to connect and secure services across any runtime
 platform and public or private cloud.

--- a/modules/coredns/README.md
+++ b/modules/coredns/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Networking"
 -->
 
-# CoreDNS monitoring with Netdata
+# CoreDNS collector
 
 [`CoreDNS`](https://coredns.io/) is a fast and flexible DNS server.
 

--- a/modules/couchbase/README.md
+++ b/modules/couchbase/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Databases"
 -->
 
-# Couchbase monitoring with Netdata
+# Couchbase collector
 
 [Couchbase](https://www.couchbase.com/) is an open source, distributed, JSON document database. It exposes a scale-out,
 key-value store with managed cache for sub-millisecond data operations, purpose-built indexers for efficient queries and

--- a/modules/couchdb/README.md
+++ b/modules/couchdb/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Databases"
 -->
 
-# Apache CouchDB monitoring with Netdata
+# Apache CouchDB collector
 
 Monitors vital statistics of a local Apache CouchDB 2.x server.
 

--- a/modules/dnsdist/README.md
+++ b/modules/dnsdist/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Networking"
 -->
 
-# DNSdist monitoring with Netdata
+# DNSdist collector
 
 [`DNSdist`](https://dnsdist.org/) is a highly DNS-, DoS- and abuse-aware loadbalancer.
 

--- a/modules/dnsmasq_dhcp/README.md
+++ b/modules/dnsmasq_dhcp/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Networking"
 -->
 
-# Dnsmasq DHCP monitoring with Netdata
+# Dnsmasq DHCP collector
 
 [`Dnsmasq`](http://www.thekelleys.org.uk/dnsmasq/doc.html) is a lightweight, easy to configure, DNS forwarder and DHCP
 server.

--- a/modules/dnsquery/README.md
+++ b/modules/dnsquery/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Networking"
 -->
 
-# DNS query monitoring with Netdata
+# DNS query collector
 
 This module provides DNS query round-trip time (RTT).
 

--- a/modules/docker/README.md
+++ b/modules/docker/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Virtualized environments/Containers"
 -->
 
-# Docker monitoring with Netdata
+# Docker collector
 
 [Docker Engine](https://docs.docker.com/engine/) is an open source containerization technology for building and
 containerizing your applications.

--- a/modules/docker_engine/README.md
+++ b/modules/docker_engine/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Virtualized environments/Containers"
 -->
 
-# Docker Engine monitoring with Netdata
+# Docker Engine collector
 
 [`Docker Engine`](https://docs.docker.com/engine/) is the industry’s de facto container runtime that runs on various
 Linux (CentOS, Debian, Fedora, Oracle Linux, RHEL, SUSE, and Ubuntu) and Windows Server operating systems.

--- a/modules/dockerhub/README.md
+++ b/modules/dockerhub/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# Docker Hub repository monitoring with Netdata
+# Docker Hub repository collector
 
 [`Docker Hub`](https://docs.docker.com/docker-hub/) is a service provided by Docker for finding and sharing container
 images with your team.

--- a/modules/elasticsearch/README.md
+++ b/modules/elasticsearch/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Apps"
 -->
 
-# Elasticsearch monitoring with Netdata
+# Elasticsearch collector
 
 [`Elasticsearch`](https://www.elastic.co/elasticsearch/) is a search engine based on the Lucene library.
 

--- a/modules/energid/README.md
+++ b/modules/energid/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Remotes/Devices"
 -->
 
-# Energi Core Wallet monitoring with Netdata
+# Energi Core Wallet collector
 
 This module monitors one or more `Energi Core Wallet` instances, depending on your configuration.
 

--- a/modules/filecheck/README.md
+++ b/modules/filecheck/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/System metrics"
 -->
 
-# Files and directories monitoring with Netdata
+# Files and directories collector
 
 This module monitors files and directories.
 

--- a/modules/fluentd/README.md
+++ b/modules/fluentd/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Logs"
 -->
 
-# Fluentd monitoring with Netdata
+# Fluentd collector
 
 [`Fluentd`](https://www.fluentd.org/) is an open source data collector for unified logging layer.
 

--- a/modules/freeradius/README.md
+++ b/modules/freeradius/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Networking"
 -->
 
-# FreeRADIUS monitoring with Netdata
+# FreeRADIUS collector
 
 [`FreeRADIUS`](https://freeradius.org/) is a modular, high performance free RADIUS suite.
 

--- a/modules/geth/README.md
+++ b/modules/geth/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Blockchain"
 -->
 
-# Geth monitoring with Netdata
+# Geth collector
 
 Go Ethereum, written in Google’s Go language, is one of the three original implementations of the Ethereum protocol,
 alongside C++ and Python.

--- a/modules/haproxy/README.md
+++ b/modules/haproxy/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# HAProxy monitoring with Netdata
+# HAProxy collector
 
 [`HAProxy`](http://www.haproxy.org/) is a free, very fast and reliable solution offering high availability, load
 balancing, and proxying for TCP and HTTP-based applications.

--- a/modules/hdfs/README.md
+++ b/modules/hdfs/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Storage"
 -->
 
-# HDFS monitoring with Netdata
+# HDFS collector
 
 The [`Hadoop Distributed File System (HDFS)`](https://hadoop.apache.org/docs/r1.2.1/hdfs_design.html) is a distributed
 file system designed to run on commodity hardware.

--- a/modules/httpcheck/README.md
+++ b/modules/httpcheck/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Remotes"
 -->
 
-# HTTP endpoint monitoring with Netdata
+# HTTP endpoint collector
 
 This module monitors one or more http servers availability and response time.
 

--- a/modules/isc_dhcpd/README.md
+++ b/modules/isc_dhcpd/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Networking"
 -->
 
-# ISC DHCPd monitoring with Netdata
+# ISC DHCPd collector
 
 [`ISC DHCP`](https://www.isc.org/dhcp/) is a DHCP server that supports both IPv4 and IPv6, and is suitable for use in
 high-volume and high-reliability applications.

--- a/modules/k8s_kubelet/README.md
+++ b/modules/k8s_kubelet/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Container orchestrators/Kubernetes"
 -->
 
-# Kubelet monitoring with Netdata
+# Kubelet collector
 
 [`Kubelet`](https://kubernetes.io/docs/concepts/overview/components/#kubelet) is an agent that runs on each node in the
 cluster. It makes sure that containers are running in a pod.

--- a/modules/k8s_kubeproxy/README.md
+++ b/modules/k8s_kubeproxy/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Container orchestrators/Kubernetes"
 -->
 
-# Kube-proxy monitoring with Netdata
+# Kube-proxy collector
 
 [`Kube-proxy`](https://kubernetes.io/docs/concepts/overview/components/#kube-proxy) is a network proxy that runs on each
 node in your cluster, implementing part of the Kubernetes Service.

--- a/modules/k8s_state/README.md
+++ b/modules/k8s_state/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Container orchestrators/Kubernetes"
 -->
 
-# Kubernetes cluster state monitoring with Netdata
+# Kubernetes cluster state collector
 
 [Kubernetes](https://kubernetes.io/) is an open-source container orchestration system for automating software
 deployment, scaling, and management.

--- a/modules/lighttpd/README.md
+++ b/modules/lighttpd/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# Lighttpd monitoring with Netdata
+# Lighttpd collector
 
 [`Lighttpd`](https://www.lighttpd.net/) is an open-source web server optimized for speed-critical environments while
 remaining standards-compliant, secure and flexible

--- a/modules/lighttpd2/README.md
+++ b/modules/lighttpd2/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# Lighttpd2 monitoring with Netdata
+# Lighttpd2 collector
 
 [`Lighttpd2`](https://redmine.lighttpd.net/projects/lighttpd2) is a work in progress version of open-source web server.
 

--- a/modules/logind/README.md
+++ b/modules/logind/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/System metrics"
 -->
 
-# systemd-logind monitoring with Netdata
+# systemd-logind collector
 
 [systemd-logind](https://www.freedesktop.org/software/systemd/man/systemd-logind.service.html) is a system service that
 manages user logins.

--- a/modules/logstash/README.md
+++ b/modules/logstash/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Apm"
 -->
 
-# Logstash monitoring with Netdata
+# Logstash collector
 
 [Logstash](https://www.elastic.co/products/logstash) is an open-source data processing pipeline that allows you to
 collect, process, and load data into Elasticsearch.

--- a/modules/mongodb/README.md
+++ b/modules/mongodb/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Databases"
 -->
 
-# MongoDB monitoring with Netdata
+# MongoDB collector
 
 [MongoDB](https://www.mongodb.com/) is a source-available cross-platform document-oriented database program.
 

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Databases"
 -->
 
-# MySQL monitoring with Netdata
+# MySQL collector
 
 [MySQL](https://www.mysql.com/) is an open-source relational database management system.
 

--- a/modules/nginx/README.md
+++ b/modules/nginx/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# NGINX monitoring with Netdata
+# NGINX collector
 
 [`NGINX`](https://www.nginx.com/) is a web server which can also be used as a reverse proxy, load balancer, mail proxy
 and HTTP cache.

--- a/modules/nginxplus/README.md
+++ b/modules/nginxplus/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# NGINX Plus monitoring with Netdata
+# NGINX Plus collector
 
 [NGINX Plus](https://www.nginx.com/products/nginx/) is a software load balancer, API gateway, and reverse proxy built on
 top of NGINX.

--- a/modules/nginxvts/README.md
+++ b/modules/nginxvts/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# NGINX VTS monitoring with Netdata
+# NGINX VTS collector
 
 `nginxvts` can monitor statistics of NGINX which configured
 with [`nginx-module-vts`](https://github.com/vozlt/nginx-module-vts).

--- a/modules/ntpd/README.md
+++ b/modules/ntpd/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Apps"
 -->
 
-# NTP daemon monitoring with Netdata
+# NTP daemon collector
 
 Monitors the system variables of the local `ntpd` daemon (optional incl. variables of the polled peers) using the NTP
 Control Message Protocol via UDP socket, similar to `ntpq`,

--- a/modules/nvidia_smi/README.md
+++ b/modules/nvidia_smi/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Devices"
 -->
 
-# Nvidia GPU monitoring with Netdata
+# Nvidia GPU collector
 
 Monitors performance metrics (memory usage, fan speed, pcie bandwidth utilization, temperature, etc.)
 using the [nvidia-smi](https://developer.nvidia.com/nvidia-system-management-interface) CLI tool.

--- a/modules/nvme/README.md
+++ b/modules/nvme/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Devices"
 -->
 
-# NVMe devices monitoring with Netdata
+# NVMe devices collector
 
 Monitors health metrics (estimated endurance, space capacity, critical warnings, temperature, etc.) using
 the [nvme](https://github.com/linux-nvme/nvme-cli#nvme-cli) CLI tool.

--- a/modules/openvpn/README.md
+++ b/modules/openvpn/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Networking"
 -->
 
-# OpenVPN monitoring with Netdata
+# OpenVPN collector
 
 [`OpenVPN`](https://openvpn.net/) is an open-source commercial software that implements virtual private network
 techniques to create secure point-to-point or site-to-site connections in routed or bridged configurations and remote

--- a/modules/openvpn_status_log/README.md
+++ b/modules/openvpn_status_log/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Networking"
 -->
 
-# OpenVPN monitoring with Netdata
+# OpenVPN collector
 
 Parses server log files and provides summary (client, traffic) metrics. Please *note* that this collector is similar to
 another OpenVPN collector. However, this collector requires status logs from OpenVPN in contrast to another collector

--- a/modules/pgbouncer/README.md
+++ b/modules/pgbouncer/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Databases"
 -->
 
-# PgBouncer monitoring with Netdata
+# PgBouncer collector
 
 [PgBouncer](https://www.pgbouncer.org/) is an open-source connection pooler
 for [PostgreSQL](https://www.postgresql.org/).

--- a/modules/phpdaemon/README.md
+++ b/modules/phpdaemon/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Apm"
 -->
 
-# phpDaemon monitoring with Netdata
+# phpDaemon collector
 
 [`phpDaemon`](https://github.com/kakserpom/phpdaemon) is an asynchronous server-side framework for Web and network
 applications implemented in PHP using libevent.

--- a/modules/phpfpm/README.md
+++ b/modules/phpfpm/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# PHP-FPM monitoring with Netdata
+# PHP-FPM collector
 
 [`PHP-FPM`](https://php-fpm.org/) is an alternative PHP FastCGI implementation with some additional features useful for
 sites of any size, especially busier sites.

--- a/modules/pihole/README.md
+++ b/modules/pihole/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Apps"
 -->
 
-# Pi-hole monitoring with Netdata
+# Pi-hole collector
 
 [`Pi-hole`](https://pi-hole.net) is a Linux network-level advertisement and Internet tracker blocking application which
 acts as a DNS sinkhole, intended for use on a private network.

--- a/modules/pika/README.md
+++ b/modules/pika/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Storage"
 -->
 
-# Pika monitoring with Netdata
+# Pika collector
 
 [`Pika`](https://github.com/Qihoo360/pika#introduction%E4%B8%AD%E6%96%87) is a persistent huge storage service,
 compatible with the vast majority of redis interfaces (details), including string, hash, list, zset, set and management

--- a/modules/ping/README.md
+++ b/modules/ping/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/QoS"
 -->
 
-# Ping monitoring with Netdata
+# Ping collector
 
 This module measures round-tripe time and packet loss by sending ping messages to network hosts.
 

--- a/modules/portcheck/README.md
+++ b/modules/portcheck/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Remotes"
 -->
 
-# TCP endpoint monitoring with Netdata
+# TCP endpoint collector
 
 This module monitors one or more TCP services availability and response time.
 

--- a/modules/postgres/README.md
+++ b/modules/postgres/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Databases"
 -->
 
-# PostgreSQL monitoring with Netdata
+# PostgreSQL collector
 
 [PostgreSQL](https://www.postgresql.org/), also known as Postgres, is a free and open-source relational database
 management system emphasizing extensibility and SQL compliance.

--- a/modules/powerdns/README.md
+++ b/modules/powerdns/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Devices"
 -->
 
-# PowerDNS Authoritative Server monitoring with Netdata
+# PowerDNS Authoritative Server collector
 
 [`PowerDNS Authoritative Server`](https://doc.powerdns.com/authoritative/) is a versatile nameserver which supports a
 large number of backends.

--- a/modules/powerdns_recursor/README.md
+++ b/modules/powerdns_recursor/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Devices"
 -->
 
-# PowerDNS Recursor monitoring with Netdata
+# PowerDNS Recursor collector
 
 [`PowerDNS Recursor`](https://doc.powerdns.com/recursor/) is a high-performance DNS recursor with built-in scripting
 capabilities.

--- a/modules/prometheus/README.md
+++ b/modules/prometheus/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Anything"
 -->
 
-# Prometheus endpoint monitoring with Netdata
+# Prometheus endpoint collector
 
 The generic Prometheus endpoint collector gathers metrics from [`Prometheus`](https://prometheus.io/) endpoints that use
 the [OpenMetrics exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/).

--- a/modules/proxysql/README.md
+++ b/modules/proxysql/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Databases"
 -->
 
-# ProxySQL monitoring with Netdata
+# ProxySQL collector
 
 [ProxySQL](https://www.proxysql.com/) is an open-source proxy for mySQL.
 

--- a/modules/pulsar/README.md
+++ b/modules/pulsar/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Message brokers"
 -->
 
-# Apache Pulsar monitoring with Netdata
+# Apache Pulsar collector
 
 [`Apache Pulsar`](http://pulsar.apache.org/) is an open-source distributed pub-sub messaging system.
 

--- a/modules/rabbitmq/README.md
+++ b/modules/rabbitmq/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Message brokers"
 -->
 
-# RabbitMQ monitoring with Netdata
+# RabbitMQ collector
 
 [RabbitMQ](https://www.rabbitmq.com/) is an open-source message broker.
 

--- a/modules/redis/README.md
+++ b/modules/redis/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Databases"
 -->
 
-# Redis monitoring with Netdata
+# Redis collector
 
 [`Redis`](https://redis.io/) is an open source (BSD licensed), in-memory data structure store, used as a database, cache
 and message broker.

--- a/modules/scaleio/README.md
+++ b/modules/scaleio/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Storage"
 -->
 
-# ScaleIO monitoring with Netdata
+# ScaleIO collector
 
 [`Dell EMC ScaleIO`](https://www.dellemc.com/en-us/storage/data-storage/software-defined-storage.htm) is a
 software-defined storage product from Dell EMC that creates a server-based storage area network from local application

--- a/modules/snmp/README.md
+++ b/modules/snmp/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Remotes"
 -->
 
-# SNMP device monitoring with Netdata
+# SNMP device collector
 
 Collects data from any SNMP device and uses the [gosnmp](https://github.com/gosnmp/gosnmp) package.
 

--- a/modules/solr/README.md
+++ b/modules/solr/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Apps"
 -->
 
-# Solr monitoring with Netdata
+# Solr collector
 
 [`Solr`](https://lucene.apache.org/solr/) is an open-source enterprise-search platform, written in Java, from the Apache
 Lucene project.

--- a/modules/springboot2/README.md
+++ b/modules/springboot2/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Apm"
 -->
 
-# Java Spring Boot 2 application monitoring with Netdata
+# Java Spring Boot 2 application collector
 
 This module monitors one or more Java Spring-boot 2 applications depending on configuration. Netdata can be used to
 monitor running Java [Spring Boot 2](https://spring.io/) applications that expose their metrics with the use of the **

--- a/modules/squidlog/README.md
+++ b/modules/squidlog/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Quantify logs to metrics"
 -->
 
-# Squid log monitoring with Netdata
+# Squid log collector
 
 [`Squid`](http://www.squid-cache.org/) is a caching and forwarding HTTP web proxy.
 

--- a/modules/supervisord/README.md
+++ b/modules/supervisord/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Virtualized environments/Virtualize hosts"
 -->
 
-# Supervisord monitoring with Netdata
+# Supervisord collector
 
 [Supervisor](http://supervisord.org/) is a client/server system that allows its users to monitor and control a number of
 processes on UNIX-like operating systems.

--- a/modules/systemdunits/README.md
+++ b/modules/systemdunits/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/System metrics"
 -->
 
-# Systemd units state monitoring with Netdata
+# Systemd units state collector
 
 [Systemd](https://www.freedesktop.org/wiki/Software/systemd/) is a suite of basic building blocks for a Linux system.
 

--- a/modules/tengine/README.md
+++ b/modules/tengine/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# Tengine monitoring with Netdata
+# Tengine collector
 
 [`Tengine`](https://tengine.taobao.org/) is a web server originated by Taobao, the largest e-commerce website in Asia.
 It is based on the Nginx HTTP server and has many advanced features.

--- a/modules/traefik/README.md
+++ b/modules/traefik/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# Traefik monitoring with Netdata
+# Traefik collector
 
 [`Traefik`](https://traefik.io/traefik/) is a leading modern reverse proxy and load balancer that makes deploying
 microservices easy. .

--- a/modules/unbound/README.md
+++ b/modules/unbound/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Networking"
 -->
 
-# Unbound monitoring with Netdata
+# Unbound collector
 
 [`Unbound`](https://nlnetlabs.nl/projects/unbound/about/) is a validating, recursive, and caching DNS resolver product
 from NLnet Labs.

--- a/modules/vcsa/README.md
+++ b/modules/vcsa/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Virtualized environments/Virtualize hosts"
 -->
 
-# vCenter Server Appliance monitoring with Netdata
+# vCenter Server Appliance collector
 
 The [`vCenter Server Appliance`](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcsa.doc/GUID-223C2821-BD98-4C7A-936B-7DBE96291BA4.html)
 using [`Health API`](https://code.vmware.com/apis/60/vcenter-server-appliance-management) is a preconfigured Linux

--- a/modules/vernemq/README.md
+++ b/modules/vernemq/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Message brokers"
 -->
 
-# VerneMQ monitoring with Netdata
+# VerneMQ collector
 
 [`VerneMQ`](https://vernemq.com/) is a scalable and open source MQTT broker that connects IoT, M2M, Mobile, and web
 applications.

--- a/modules/vsphere/README.md
+++ b/modules/vsphere/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Virtualized environments/Virtualize hosts"
 -->
 
-# vCenter Server monitoring with Netdata
+# vCenter Server collector
 
 [`VMware vCenter Server`](https://www.vmware.com/products/vcenter-server.html) is advanced server management software
 that provides a centralized platform for controlling your VMware vSphere environments.

--- a/modules/weblog/README.md
+++ b/modules/weblog/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Quantify logs to metrics"
 -->
 
-# Web server log (Apache, NGINX, IIS) monitoring with Netdata
+# Web server log (Apache, NGINX, IIS) collector
 
 This module parses [`Apache`](https://httpd.apache.org/), [`NGINX`](https://nginx.org/en/) and [Microsoft IIS](https://www.iis.net/) web servers logs.
 

--- a/modules/whoisquery/README.md
+++ b/modules/whoisquery/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# Whois domain expiry monitoring with Netdata
+# Whois domain expiry collector
 
 This collector module checks the remaining time until a domain is expired.
 

--- a/modules/windows/README.md
+++ b/modules/windows/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/System metrics"
 -->
 
-# Windows machine monitoring with Netdata
+# Windows machine collector
 
 This module will monitor one or more Windows machines, using
 the [windows_exporter](https://github.com/prometheus-community/windows_exporter).

--- a/modules/wireguard/README.md
+++ b/modules/wireguard/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Networking"
 -->
 
-# WireGuard monitoring with Netdata
+# WireGuard collector
 
 [WireGuard](https://www.wireguard.com/) is an extremely simple yet fast and modern VPN that utilizes state-of-the-art
 cryptography.

--- a/modules/x509check/README.md
+++ b/modules/x509check/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# x509 certificate monitoring with Netdata
+# x509 certificate collector
 
 This module checks the time until a x509 certificate expiration and its revocation status.
 

--- a/modules/zookeeper/README.md
+++ b/modules/zookeeper/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Databases"
 -->
 
-# Apache ZooKeeper monitoring with Netdata
+# Apache ZooKeeper collector
 
 [ZooKeeper](https://zookeeper.apache.org/) is a centralized service for maintaining configuration information, naming,
 providing distributed synchronization, and providing group services.


### PR DESCRIPTION
"XYZ monitoring with Netdata" is now reserved for [www.netdata.cloud](http://www.netdata.cloud/).

Collector documentation titles must be "XYZ collector"

See also https://github.com/netdata/netdata/pull/14715