### PR TITLE
Replace all links that lead to `learn.netdata.cloud` with their `https://github.com/...` counterparts

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Go.d.plugin is shipped with Netdata.
 ## Configuration
 
 Edit the `go.d.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Then [restart netdata](https://github.com/netdata/netdata/blob/master/docs/confi
 ## Contributing
 
 If you want to contribute to this project, we are humbled. Please take a look at
-our [contributing guidelines](https://learn.netdata.cloud/contribute/handbook) and don't hesitate to contact us in our
+our [contributing guidelines](https://github.com/netdata/.github/blob/main/CONTRIBUTING.md) and don't hesitate to contact us in our
 forums.
 
 ### How to develop a collector
@@ -197,4 +197,4 @@ modules.
 This repository follows the Netdata Code of Conduct and is part of the Netdata Community.
 
 - [Community Forums](https://community.netdata.cloud)
-- [Netdata Code of Conduct](https://learn.netdata.cloud/contribute/code-of-conduct)
+- [Netdata Code of Conduct](https://github.com/netdata/.github/blob/main/CODE_OF_CONDUCT.md)

--- a/docs/how-to-write-a-module.md
+++ b/docs/how-to-write-a-module.md
@@ -13,7 +13,7 @@ sidebar_position: 20
 
 ## Prerequisites
 
-- Take a look at our [contributing guidelines](https://learn.netdata.cloud/contribute/handbook).
+- Take a look at our [contributing guidelines](https://github.com/netdata/.github/blob/main/CONTRIBUTING.md).
 - [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) this repository to your personal
   GitHub account.
 - [Clone](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository#:~:text=to%20GitHub%20Desktop-,On%20GitHub%2C%20navigate%20to%20the%20main%20page%20of%20the%20repository,Desktop%20to%20complete%20the%20clone.)
@@ -43,10 +43,10 @@ The steps are:
   developed collector. It will be placed into the `bin` directory (e.g `go.d.plugin/bin`)
 - Run it in the debug mode `bin/godplugin -d -m <MODULE_NAME>`. This will output the `STDOUT` of the collector, the same
   output that is sent to the Netdata Agent and is transformed into charts. You can read more about this collector API in
-  our [documentation](https://learn.netdata.cloud/docs/agent/collectors/plugins.d#external-plugins-api).
+  our [documentation](https://github.com/netdata/netdata/blob/master/collectors/plugins.d/README.md#external-plugins-api).
 - If you want to test the collector with the actual Netdata Agent, you need to replace the `go.d.plugin` binary that
   exists in the Netdata Agent installation directory with the one you just compiled. Once
-  you [restart](https://learn.netdata.cloud/docs/configure/start-stop-restart) the Netdata Agent, it will detect and run
+  you [restart](https://github.com/netdata/netdata/blob/master/docs/configure/start-stop-restart.md) the Netdata Agent, it will detect and run
   it, creating all the charts. It is advised not to remove the default `go.d.plugin` binary, but simply rename it
   to `go.d.plugin.old` so that the Agent doesn't run it, but you can easily rename it back once you are done.
 - Run `make clean` when you are done with testing.
@@ -116,13 +116,13 @@ func (e *Example) Check() bool {
 
 ### Charts method
 
-:exclamation: Netdata module produces [`charts`](https://learn.netdata.cloud/docs/agent/collectors/plugins.d#chart), not
+:exclamation: Netdata module produces [`charts`](https://github.com/netdata/netdata/blob/master/collectors/plugins.d/README.md#chart), not
 raw metrics.
 
 Use [`agent/module`](https://github.com/netdata/go.d.plugin/blob/master/agent/module/charts.go) package to create them,
 it contains charts and dimensions structs.
 
-- `Charts` returns the [charts](https://learn.netdata.cloud/docs/agent/collectors/plugins.d#chart1) (`*module.Charts`).
+- `Charts` returns the [charts](https://github.com/netdata/netdata/blob/master/collectors/plugins.d/README.md#chart) (`*module.Charts`).
 - Called after `Check` and only if `Check` returned `true`.
 - If it returns `nil`, the job will be disabled
 - :warning: Make sure not to share returned value between module instances (jobs).

--- a/modules/activemq/README.md
+++ b/modules/activemq/README.md
@@ -28,7 +28,7 @@ All metrics have "activemq." prefix.
 ## Configuration
 
 Edit the `go.d/activemq.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/apache/README.md
+++ b/modules/apache/README.md
@@ -39,7 +39,7 @@ All metrics have "apache." prefix.
 ## Configuration
 
 Edit the `go.d/apache.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/bind/README.md
+++ b/modules/bind/README.md
@@ -60,7 +60,7 @@ Per View Statistics (the following set will be added for each bind view):
 ## Configuration
 
 Edit the `go.d/bind.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/cassandra/README.md
+++ b/modules/cassandra/README.md
@@ -76,7 +76,7 @@ Labels per scope:
 ## Configuration
 
 Edit the `go.d/cassandra.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/chrony/README.md
+++ b/modules/chrony/README.md
@@ -36,7 +36,7 @@ All metrics have "chrony." prefix.
 ## Configuration
 
 Edit the `go.d/chrony.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/modules/cockroachdb/README.md
+++ b/modules/cockroachdb/README.md
@@ -85,7 +85,7 @@ All metrics have "cockroachdb." prefix.
 ## Configuration
 
 Edit the `go.d/cockroachdb.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/consul/README.md
+++ b/modules/consul/README.md
@@ -86,7 +86,7 @@ Labels per scope:
 ## Configuration
 
 Edit the `go.d/consul.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/coredns/README.md
+++ b/modules/coredns/README.md
@@ -48,7 +48,7 @@ All metrics have "coredns." prefix.
 ## Configuration
 
 Edit the `go.d/coredns.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/couchbase/README.md
+++ b/modules/couchbase/README.md
@@ -49,7 +49,7 @@ Collected from `/pools/default/buckets ` endpoint.
 ## Configuration
 
 Edit the `go.d/couchbase.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/couchdb/README.md
+++ b/modules/couchdb/README.md
@@ -40,7 +40,7 @@ All metrics have "couchdb." prefix.
 ## Configuration
 
 Edit the `go.d/couchdb.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/modules/dnsdist/README.md
+++ b/modules/dnsdist/README.md
@@ -46,7 +46,7 @@ All metrics have "dnsdist." prefix.
 ## Configuration
 
 Edit the `go.d/dnsdist.conf` configuration file using `edit-config` from the
-Agent's [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Agent's [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/dnsmasq/README.md
+++ b/modules/dnsmasq/README.md
@@ -45,7 +45,7 @@ All metrics have "dnsmasq." prefix.
 ## Configuration
 
 Edit the `go.d/dnsmasq.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/dnsmasq_dhcp/README.md
+++ b/modules/dnsmasq_dhcp/README.md
@@ -43,7 +43,7 @@ By default it uses:
 ## Configuration
 
 Edit the `go.d/dnsmasq_dhcp.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/dnsquery/README.md
+++ b/modules/dnsquery/README.md
@@ -28,7 +28,7 @@ Labels per scope:
 ## Configuration
 
 Edit the `go.d/dns_query.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/docker/README.md
+++ b/modules/docker/README.md
@@ -30,7 +30,7 @@ All metrics have "docker." prefix.
 ## Configuration
 
 Edit the `go.d/docker.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/docker_engine/README.md
+++ b/modules/docker_engine/README.md
@@ -37,7 +37,7 @@ All metrics have "docker_engine." prefix.
 ## Configuration
 
 Edit the `go.d/docker_engine.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/dockerhub/README.md
+++ b/modules/dockerhub/README.md
@@ -31,7 +31,7 @@ All metrics have "docker_engine." prefix.
 ## Configuration
 
 Edit the `go.d/dockerhub.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/elasticsearch/README.md
+++ b/modules/elasticsearch/README.md
@@ -85,7 +85,7 @@ Labels per scope:
 ## Configuration
 
 Edit the `go.d/elasticsearch.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/energid/README.md
+++ b/modules/energid/README.md
@@ -33,7 +33,7 @@ All metrics have "energid." prefix.
 ## Configuration
 
 Edit the `go.d/energid.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/example/README.md
+++ b/modules/example/README.md
@@ -19,7 +19,7 @@ This module produces example charts with random values. Number of charts, dimens
 ## Configuration
 
 Edit the `go.d/example.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/filecheck/README.md
+++ b/modules/filecheck/README.md
@@ -59,7 +59,7 @@ All metrics have "filecheck." prefix.
 ## Configuration
 
 Edit the `go.d/filecheck.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/fluentd/README.md
+++ b/modules/fluentd/README.md
@@ -32,7 +32,7 @@ All metrics have "fluentd." prefix.
 ## Configuration
 
 Edit the `go.d/fluentd.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/freeradius/README.md
+++ b/modules/freeradius/README.md
@@ -47,7 +47,7 @@ All metrics have "freeradius." prefix.
 ## Configuration
 
 Edit the `go.d/freeradius.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/geth/README.md
+++ b/modules/geth/README.md
@@ -68,7 +68,7 @@ merge it and have your code being shipped with **every** Netdata agent.
 ## Configuration
 
 Edit the `go.d/geth.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/haproxy/README.md
+++ b/modules/haproxy/README.md
@@ -57,7 +57,7 @@ All metrics have "haproxy." prefix.
 ## Configuration
 
 Edit the `go.d/haproxy.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/hdfs/README.md
+++ b/modules/hdfs/README.md
@@ -55,7 +55,7 @@ All metrics have "hdfs." prefix.
 ## Configuration
 
 Edit the `go.d/hdfs.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/httpcheck/README.md
+++ b/modules/httpcheck/README.md
@@ -39,7 +39,7 @@ Labels per scope:
 ## Configuration
 
 Edit the `go.d/httpcheck.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/isc_dhcpd/README.md
+++ b/modules/isc_dhcpd/README.md
@@ -33,7 +33,7 @@ All metrics have "isc_dhcps." prefix.
 ## Configuration
 
 Edit the `go.d/isc_dhcpd.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/k8s_kubelet/README.md
+++ b/modules/k8s_kubelet/README.md
@@ -44,7 +44,7 @@ All metrics have "k8s_kubelet." prefix.
 ## Configuration
 
 Edit the `go.d/k8s_kubelet.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/k8s_kubeproxy/README.md
+++ b/modules/k8s_kubeproxy/README.md
@@ -31,7 +31,7 @@ All metrics have "k8s_kubeproxy." prefix.
 ## Configuration
 
 Edit the `go.d/k8s_kubeproxy.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/lighttpd/README.md
+++ b/modules/lighttpd/README.md
@@ -34,7 +34,7 @@ All metrics have "lighttpd." prefix.
 ## Configuration
 
 Edit the `go.d/lighttpd.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/lighttpd2/README.md
+++ b/modules/lighttpd2/README.md
@@ -35,7 +35,7 @@ All metrics have "lighttpd2." prefix.
 ## Configuration
 
 Edit the `go.d/lighttpd2.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/logstash/README.md
+++ b/modules/logstash/README.md
@@ -44,7 +44,7 @@ Labels per scope:
 ## Configuration
 
 Edit the `go.d/logstash.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/mongodb/README.md
+++ b/modules/mongodb/README.md
@@ -121,7 +121,7 @@ Labels per scope:
 ## Configuration
 
 Edit the `go.d/mongodb.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -136,7 +136,7 @@ Labels per scope:
 ## Configuration
 
 Edit the `go.d/mysql.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/nginx/README.md
+++ b/modules/nginx/README.md
@@ -34,7 +34,7 @@ All metrics have "nginx." prefix.
 ## Configuration
 
 Edit the `go.d/nginx.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/nginxplus/README.md
+++ b/modules/nginxplus/README.md
@@ -91,7 +91,7 @@ Labels per scope:
 ## Configuration
 
 Edit the `go.d/nginxplus.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/nginxvts/README.md
+++ b/modules/nginxvts/README.md
@@ -34,7 +34,7 @@ Refer [`nginx-module-vts`](https://github.com/vozlt/nginx-module-vts#json) for m
 ## Configuration
 
 Edit the `go.d/nginxvts.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/ntpd/README.md
+++ b/modules/ntpd/README.md
@@ -50,7 +50,7 @@ Labels per scope:
 ## Configuration
 
 Edit the `go.d/ntpd.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory, if different

--- a/modules/nvidia_smi/README.md
+++ b/modules/nvidia_smi/README.md
@@ -56,7 +56,7 @@ This module supports data collection in CSV and XML formats. The default is CSV.
 The format can be changed in the configuration file.
 
 Edit the `go.d/nvidia_smi.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```yaml
 jobs:

--- a/modules/openvpn/README.md
+++ b/modules/openvpn/README.md
@@ -44,7 +44,7 @@ Reason:
 We disabled it to not break other tools which uses `Management Interface`.
 
 Edit the `go.d/openvpn.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/openvpn_status_log/README.md
+++ b/modules/openvpn_status_log/README.md
@@ -35,7 +35,7 @@ All metrics have "openvpn." prefix.
 ## Configuration
 
 Edit the `go.d/openvpn_status_log.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/modules/pgbouncer/README.md
+++ b/modules/pgbouncer/README.md
@@ -80,7 +80,7 @@ Labels per scope:
 ## Configuration
 
 Edit the `go.d/pgbouncer.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/phpdaemon/README.md
+++ b/modules/phpdaemon/README.md
@@ -43,7 +43,7 @@ It produces the following charts:
 ## Configuration
 
 Edit the `go.d/phpdaemon.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/phpfpm/README.md
+++ b/modules/phpfpm/README.md
@@ -37,7 +37,7 @@ All metrics have "phpfpm." prefix.
 ## Configuration
 
 Edit the `go.d/phpfpm.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/pihole/README.md
+++ b/modules/pihole/README.md
@@ -37,7 +37,7 @@ All metrics have "pihole." prefix.
 ## Configuration
 
 Edit the `go.d/pihole.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/pika/README.md
+++ b/modules/pika/README.md
@@ -54,7 +54,7 @@ All metrics have "pika." prefix.
 ## Configuration
 
 Edit the `go.d/pika.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/ping/README.md
+++ b/modules/ping/README.md
@@ -53,7 +53,7 @@ Labels per scope:
 ## Configuration
 
 Edit the `go.d/ping.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/portcheck/README.md
+++ b/modules/portcheck/README.md
@@ -29,7 +29,7 @@ Labels per scope:
 ## Configuration
 
 Edit the `go.d/portcheck.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/postgres/README.md
+++ b/modules/postgres/README.md
@@ -32,7 +32,7 @@ CREATE USER netdata;
 GRANT pg_monitor TO netdata;
 ```
 
-After creating the new user, restart the Netdata agent with `sudo systemctl restart netdata`, or the [appropriate method](https://learn.netdata.cloud/docs/configure/start-stop-restart) for your system
+After creating the new user, restart the Netdata agent with `sudo systemctl restart netdata`, or the [appropriate method](https://github.com/netdata/netdata/blob/master/docs/configure/start-stop-restart.md) for your system
 
 ## Metrics
 
@@ -159,7 +159,7 @@ databases on a database server is disabled because each database requires an add
 
 Use the `collect_databases_matching` configuration option to select the databases from which you want to collect
 detailed metrics. The value
-supports [Netdata simple patterns](https://learn.netdata.cloud/docs/agent/libnetdata/simple_pattern).
+supports [Netdata simple patterns](https://github.com/netdata/netdata/blob/master/libnetdata/simple_pattern/README.md).
 
 ```yaml
 jobs:

--- a/modules/postgres/README.md
+++ b/modules/postgres/README.md
@@ -128,7 +128,7 @@ Labels per scope:
 ## Configuration
 
 Edit the `go.d/postgres.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/powerdns/README.md
+++ b/modules/powerdns/README.md
@@ -43,7 +43,7 @@ All metrics have "powerdns." prefix.
 ## Configuration
 
 Edit the `go.d/powerdns.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/powerdns_recursor/README.md
+++ b/modules/powerdns_recursor/README.md
@@ -45,7 +45,7 @@ All metrics have "powerdns_recursor." prefix.
 ## Configuration
 
 Edit the `go.d/powerdns_recursor.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/prometheus/README.md
+++ b/modules/prometheus/README.md
@@ -33,7 +33,7 @@ For example, scraping [`node_exporter`](https://github.com/prometheus/node_expor
 ## Configuration
 
 Edit the `go.d/prometheus.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/proxysql/README.md
+++ b/modules/proxysql/README.md
@@ -72,7 +72,7 @@ Labels per scope:
 > **Note**: this collector uses `stats` username and password which is enabled by default.
 
 Edit the `go.d/proxysql.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/pulsar/README.md
+++ b/modules/pulsar/README.md
@@ -85,7 +85,7 @@ All metrics have "pulsar." prefix.
 ## Configuration
 
 Edit the `go.d/pulsar.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/rabbitmq/README.md
+++ b/modules/rabbitmq/README.md
@@ -58,7 +58,7 @@ Labels per scope:
 ## Configuration
 
 Edit the `go.d/rabbitmq.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/redis/README.md
+++ b/modules/redis/README.md
@@ -56,7 +56,7 @@ All metrics have "redis." prefix.
 ## Configuration
 
 Edit the `go.d/redis.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/scaleio/README.md
+++ b/modules/scaleio/README.md
@@ -67,7 +67,7 @@ All metrics have "scaleio." prefix.
 ## Configuration
 
 Edit the `go.d/scaleio.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/snmp/README.md
+++ b/modules/snmp/README.md
@@ -24,7 +24,7 @@ It supports:
 ## Configuration
 
 Edit the `go.d/snmp.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes#the-netdata-config-directory), which is
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md#the-netdata-config-directory), which is
 typically at `/etc/netdata`.
 
 ```bash

--- a/modules/solr/README.md
+++ b/modules/solr/README.md
@@ -41,7 +41,7 @@ All metrics have "solr." prefix.
 ## Configuration
 
 Edit the `go.d/solr.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/springboot2/README.md
+++ b/modules/springboot2/README.md
@@ -34,7 +34,7 @@ All metrics have "springboot2." prefix.
 ## Configuration
 
 Edit the `go.d/springboot2.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/squidlog/README.md
+++ b/modules/squidlog/README.md
@@ -131,7 +131,7 @@ jobs:
 ## Configuration
 
 Edit the `go.d/squidlog.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/supervisord/README.md
+++ b/modules/supervisord/README.md
@@ -39,7 +39,7 @@ All metrics have "supervisord." prefix.
 ## Configuration
 
 Edit the `go.d/supervisord.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/systemdunits/README.md
+++ b/modules/systemdunits/README.md
@@ -53,7 +53,7 @@ Labels per scope:
 ## Configuration
 
 Edit the `go.d/systemdunits.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/tengine/README.md
+++ b/modules/tengine/README.md
@@ -38,7 +38,7 @@ All metrics have "tengine." prefix.
 ## Configuration
 
 Edit the `go.d/tengine.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/traefik/README.md
+++ b/modules/traefik/README.md
@@ -34,7 +34,7 @@ All metrics have "vcsa." prefix.
 ## Configuration
 
 Edit the `go.d/traefik.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/unbound/README.md
+++ b/modules/unbound/README.md
@@ -86,7 +86,7 @@ All metrics have "vcsa." prefix.
 ## Configuration
 
 Edit the `go.d/unbound.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/vcsa/README.md
+++ b/modules/vcsa/README.md
@@ -68,7 +68,7 @@ Software Updates Health:
 ## Configuration
 
 Edit the `go.d/vcsa.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/vernemq/README.md
+++ b/modules/vernemq/README.md
@@ -91,7 +91,7 @@ All metrics have "vernemq." prefix.
 ## Configuration
 
 Edit the `go.d/vernemq.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/vsphere/README.md
+++ b/modules/vsphere/README.md
@@ -52,7 +52,7 @@ All metrics have "vsphere." prefix.
 ## Configuration
 
 Edit the `go.d/vsphere.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/weblog/README.md
+++ b/modules/weblog/README.md
@@ -299,7 +299,7 @@ info from them.
 ## Configuration
 
 Edit the `go.d/web_log.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/whoisquery/README.md
+++ b/modules/whoisquery/README.md
@@ -27,7 +27,7 @@ Labels per scope:
 ## Configuration
 
 Edit the `go.d/whoisquery.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/x509check/README.md
+++ b/modules/x509check/README.md
@@ -28,7 +28,7 @@ Labels per scope:
 ## Configuration
 
 Edit the `go.d/x509check.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/modules/zookeeper/README.md
+++ b/modules/zookeeper/README.md
@@ -40,7 +40,7 @@ All metrics have "zookeeper." prefix.
 ## Configuration
 
 Edit the `go.d/zookeeper.conf` configuration file using `edit-config` from the
-Netdata [config directory](https://learn.netdata.cloud/docs/configure/nodes), which is typically at `/etc/netdata`.
+Netdata [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata # Replace this path with your Netdata config directory

--- a/pkg/prometheus/selector/README.md
+++ b/pkg/prometheus/selector/README.md
@@ -21,7 +21,7 @@ In the simplest form you need to specify only a metric name.
  <metric_name_pattern>  ::= simple pattern
 ```
 
-The metric name pattern syntax is [simple pattern](https://learn.netdata.cloud/docs/agent/libnetdata/simple_pattern/).
+The metric name pattern syntax is [simple pattern](https://github.com/netdata/netdata/blob/master/libnetdata/simple_pattern/README.md).
 
 ### Examples
 
@@ -58,7 +58,7 @@ It is possible to filter these time series further by appending a comma separate
  <label_value_pattern>  ::= a label value pattern, depends on <op>
 ```
 
-The metric name pattern syntax is [simple pattern](https://learn.netdata.cloud/docs/agent/libnetdata/simple_pattern/).
+The metric name pattern syntax is [simple pattern](https://github.com/netdata/netdata/blob/master/libnetdata/simple_pattern/README.md).
 
 Label matching operators:
 
@@ -66,8 +66,8 @@ Label matching operators:
 -   `!=`: Match labels that are not equal to the provided string.
 -   `=~`: Match labels that [regex-match](https://golang.org/pkg/regexp/syntax/) the provided string.
 -   `!~`: Match labels that do not [regex-match](https://golang.org/pkg/regexp/syntax/) the provided string.
--   `=*`: Match labels that [simple-pattern-match](https://learn.netdata.cloud/docs/agent/libnetdata/simple_pattern/) the provided string.
--   `!*`: Match labels that do not [simple-pattern-match](https://learn.netdata.cloud/docs/agent/libnetdata/simple_pattern/) the provided string.
+-   `=*`: Match labels that [simple-pattern-match](https://github.com/netdata/netdata/blob/master/libnetdata/simple_pattern/README.md) the provided string.
+-   `!*`: Match labels that do not [simple-pattern-match](https://github.com/netdata/netdata/blob/master/libnetdata/simple_pattern/README.md) the provided string.
 
 ### Examples
 


### PR DESCRIPTION
Related to: https://github.com/netdata/learn/issues/1522

Essentially don't use hardcoded links to learn, the ingest will re-route them, this is done to reduce organic traffic to 3xx pages which is redirect pages (these learn links are obselete so they lead to a redirect)