### PR TITLE
docker: add api version negotiation

### DIFF
--- a/modules/docker/collect.go
+++ b/modules/docker/collect.go
@@ -18,6 +18,11 @@ func (d *Docker) collect() (map[string]int64, error) {
 		d.client = client
 	}
 
+	if !d.verNegotiated {
+		d.verNegotiated = true
+		d.negotiateAPIVersion()
+	}
+
 	defer func() { _ = d.client.Close() }()
 
 	mx := make(map[string]int64)
@@ -99,4 +104,11 @@ func (d *Docker) collectContainersHealth(mx map[string]int64) error {
 	mx["unhealthy_containers"] = int64(len(unhealthy))
 
 	return nil
+}
+
+func (d *Docker) negotiateAPIVersion() {
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout.Duration)
+	defer cancel()
+
+	d.client.NegotiateAPIVersion(ctx)
 }

--- a/modules/docker/docker.go
+++ b/modules/docker/docker.go
@@ -44,10 +44,12 @@ type (
 
 		charts *module.Charts
 
-		newClient func(Config) (dockerClient, error)
-		client    dockerClient
+		newClient     func(Config) (dockerClient, error)
+		client        dockerClient
+		verNegotiated bool
 	}
 	dockerClient interface {
+		NegotiateAPIVersion(context.Context)
 		Info(context.Context) (types.Info, error)
 		ImageList(context.Context, types.ImageListOptions) ([]types.ImageSummary, error)
 		ContainerList(context.Context, types.ContainerListOptions) ([]types.Container, error)

--- a/modules/docker/docker_test.go
+++ b/modules/docker/docker_test.go
@@ -243,6 +243,8 @@ func (m *mockClient) ImageList(_ context.Context, _ types.ImageListOptions) ([]t
 	}, nil
 }
 
+func (m *mockClient) NegotiateAPIVersion(_ context.Context) {}
+
 func (m *mockClient) Close() error {
 	m.closeCalled = true
 	return nil


### PR DESCRIPTION
Fix the problem [reported on Community Forum](https://community.netdata.cloud/t/docker-stats-broken-on-v1-38-0-153-nightly-on-v1-37-0-91-g6954b6f88-it-works/3900/12?u=ilyam8)