### PR TITLE
postgres: change scheme postgres => postgresql

### DIFF
--- a/config/go.d/postgres.conf
+++ b/config/go.d/postgres.conf
@@ -79,7 +79,7 @@
 jobs:
   # User postgres
   - name: local
-    dsn: 'postgres://postgres:postgres@127.0.0.1:5432/postgres'
+    dsn: 'postgresql://postgres:postgres@127.0.0.1:5432/postgres'
     #collect_databases_matching: '*'
   - name: local
     dsn: 'host=/var/run/postgresql dbname=postgres user=postgres'
@@ -87,7 +87,7 @@ jobs:
 
   # User netdata
   - name: local
-    dsn: 'postgres://netdata@127.0.0.1:5432/postgres'
+    dsn: 'postgresql://netdata@127.0.0.1:5432/postgres'
     #collect_databases_matching: '*'
   - name: local
     dsn: 'host=/var/run/postgresql dbname=postgres user=netdata'

--- a/modules/postgres/README.md
+++ b/modules/postgres/README.md
@@ -141,13 +141,13 @@ See [Connection Strings](https://www.postgresql.org/docs/current/libpq-connect.h
 ```yaml
 jobs:
   - name: local
-    dsn: 'postgres://postgres:postgres@127.0.0.1:5432/postgres'
+    dsn: 'postgresql://postgres:postgres@127.0.0.1:5432/postgres'
 
   - name: local
     dsn: 'host=/var/run/postgresql dbname=postgres user=postgres'
 
   - name: remote
-    dsn: 'postgres://postgres:postgres@203.0.113.10:5432/postgres'
+    dsn: 'postgresql://postgres:postgres@203.0.113.10:5432/postgres'
 ```
 
 ### Database detailed metrics
@@ -164,7 +164,7 @@ supports [Netdata simple patterns](https://github.com/netdata/netdata/blob/maste
 ```yaml
 jobs:
   - name: local
-    dsn: 'postgres://postgres:postgres@127.0.0.1:5432/postgres'
+    dsn: 'postgresql://postgres:postgres@127.0.0.1:5432/postgres'
     collect_databases_matching: 'mydb1 mydb2 !mydb3 mydb4'
 ```
 


### PR DESCRIPTION
[Both work](https://github.com/jackc/pgconn/blob/1e1135688ea919f66b9425b5bfe06f14ef1e5285/config.go#L236). Change it to `postgresql` because it is used in https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING.