### PR TITLE
add opensearch job config

### DIFF
--- a/config/go.d/elasticsearch.conf
+++ b/config/go.d/elasticsearch.conf
@@ -178,7 +178,10 @@
 jobs:
   - name: local
     url: http://127.0.0.1:9200
-#    collect_node_stats: yes
-#    collect_cluster_health: yes
-#    collect_cluster_stats: yes
-#    collect_indices_stats: yes
+
+  # opensearch
+  - name: local
+    url: https://127.0.0.1:9200
+    tls_skip_verify: yes
+    username: admin
+    password: admin


### PR DESCRIPTION
Related [discussion in Community Forum](https://community.netdata.cloud/t/opensearch-elasticsearch-alternative-does-not-appear-automatically/3995).