### PR TITLE
feat(ping): add 'interface' option

### DIFF
--- a/config/go.d/ping.conf
+++ b/config/go.d/ping.conf
@@ -80,6 +80,13 @@
 #    Syntax:
 #      interval: 100ms
 #
+#  - interface
+#    The network interface to use as the source of ICMP packets.
+#    If set, the plugin will try to find the IP address of the interface and
+#    will listen for incoming ICMP packets addressed to it.
+#    Syntax:
+#      interface: eth0
+#
 #
 # [ JOB defaults ]:
 #  privileged: yes

--- a/config/go.d/ping.conf
+++ b/config/go.d/ping.conf
@@ -81,9 +81,8 @@
 #      interval: 100ms
 #
 #  - interface
-#    The network interface to use as the source of ICMP packets.
-#    If set, the plugin will try to find the IP address of the interface and
-#    will listen for incoming ICMP packets addressed to it.
+#    Network interface name.
+#    If set, ping will attempt to use the interface's IP address as the source of ICMP packets.
 #    Syntax:
 #      interface: eth0
 #

--- a/modules/ping/init.go
+++ b/modules/ping/init.go
@@ -30,6 +30,7 @@ func (p *Ping) initProber() (prober, error) {
 	conf := pingProberConfig{
 		privileged: p.Privileged,
 		packets:    p.SendPackets,
+		iface:      p.Interface,
 		interval:   p.Interval.Duration,
 		deadline:   deadline,
 	}

--- a/modules/ping/ping.go
+++ b/modules/ping/ping.go
@@ -42,6 +42,7 @@ type (
 		Privileged  bool         `yaml:"privileged"`
 		SendPackets int          `yaml:"packets"`
 		Interval    web.Duration `yaml:"interval"`
+		Interface   string       `yaml:"interface"`
 	}
 )
 

--- a/modules/ping/prober.go
+++ b/modules/ping/prober.go
@@ -3,7 +3,9 @@
 package ping
 
 import (
+	"errors"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/netdata/go.d.plugin/logger"
@@ -12,9 +14,20 @@ import (
 )
 
 func newPingProber(conf pingProberConfig, log *logger.Logger) prober {
+	var source string
+	if conf.iface != "" {
+		if addr, err := getInterfaceIPAddress(conf.iface); err != nil {
+			log.Warningf("error getting interface '%s' IP address: %v", conf.iface, err)
+		} else {
+			log.Infof("interface '%s' IP address '%s', will use it as the source", conf.iface, addr)
+			source = addr
+		}
+	}
+
 	return &pingProber{
 		privileged: conf.privileged,
 		packets:    conf.packets,
+		source:     source,
 		interval:   conf.interval,
 		deadline:   conf.deadline,
 		Logger:     log,
@@ -24,6 +37,7 @@ func newPingProber(conf pingProberConfig, log *logger.Logger) prober {
 type pingProberConfig struct {
 	privileged bool
 	packets    int
+	iface      string
 	interval   time.Duration
 	deadline   time.Duration
 }
@@ -31,6 +45,7 @@ type pingProberConfig struct {
 type pingProber struct {
 	privileged bool
 	packets    int
+	source     string
 	interval   time.Duration
 	deadline   time.Duration
 	*logger.Logger
@@ -43,6 +58,7 @@ func (p *pingProber) ping(host string) (*probing.Statistics, error) {
 		return nil, fmt.Errorf("DNS lookup '%s' : %v", host, err)
 	}
 
+	pr.Source = p.source
 	pr.RecordRtts = false
 	pr.Interval = p.interval
 	pr.Count = p.packets
@@ -59,4 +75,31 @@ func (p *pingProber) ping(host string) (*probing.Statistics, error) {
 	p.Debugf("ping stats for host '%s' (ip '%s'): %+v", pr.Addr(), pr.IPAddr(), stats)
 
 	return stats, nil
+}
+
+func getInterfaceIPAddress(ifaceName string) (ipaddr string, err error) {
+	iface, err := net.InterfaceByName(ifaceName)
+	if err != nil {
+		return "", err
+	}
+
+	addresses, err := iface.Addrs()
+	if err != nil {
+		return "", err
+	}
+
+	// FIXME: add IPv6 support
+	var v4Addr string
+	for _, addr := range addresses {
+		if ipnet, ok := addr.(*net.IPNet); ok && ipnet.IP.To4() != nil {
+			v4Addr = ipnet.IP.To4().String()
+			break
+		}
+	}
+
+	if v4Addr == "" {
+		return "", errors.New("ipv4 addresses not found")
+	}
+
+	return v4Addr, nil
 }


### PR DESCRIPTION
Implements https://github.com/netdata/netdata/discussions/15056

This PR adds the `interface` configuration option. If set, ping will attempt to use the interface's IP address as the source of ICMP packets.

> **Note**: only IPv4 address support added. I don't have a VM with v6 configured to test the change.