### PR TITLE
Replace deprecated set-output with ...>> $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -25,46 +25,46 @@ jobs:
         id: actionlint
         run: |
           if git diff --name-only origin/${{ github.base_ref }} HEAD -- | grep -Eq '\.github/workflows/.*' ; then
-            echo '::set-output name=run::true'
+            echo "run=true" >> $GITHUB_OUTPUT
             echo 'GitHub Actions workflows have changed, need to run actionlint.'
           else
-            echo '::set-output name=run::false'
+            echo "run=false" >> $GITHUB_OUTPUT
           fi
       - name: Check files for golangci-lint
         id: golangci-lint
         run: |
           if git diff --name-only origin/${{ github.base_ref }} HEAD -- | grep -Eq '.*\.go' ; then
-            echo '::set-output name=run::true'
+            echo "run=true" >> $GITHUB_OUTPUT
             echo 'Go code has changed, need to run golangci-lint.'
           else
-            echo '::set-output name=run::false'
+            echo "run=false" >> $GITHUB_OUTPUT
           fi
       - name: Check files for hadolint
         id: hadolint
         run: |
           if git diff --name-only origin/${{ github.base_ref }} HEAD -- | grep -Eq '.*Dockerfile.*' ; then
-            echo '::set-output name=run::true'
+            echo "run=true" >> $GITHUB_OUTPUT
             echo 'Dockerfiles have changed, need to run Hadolint.'
           else
-            echo '::set-output name=run::false'
+            echo "run=false" >> $GITHUB_OUTPUT
           fi
       - name: Check files for shellcheck
         id: shellcheck
         run: |
           if git diff --name-only origin/${{ github.base_ref }} HEAD -- | grep -Eq '.*\.sh.*' ; then
-            echo '::set-output name=run::true'
+            echo "run=true" >> $GITHUB_OUTPUT
             echo 'Shell scripts have changed, need to run shellcheck.'
           else
-            echo '::set-output name=run::false'
+            echo "run=false" >> $GITHUB_OUTPUT
           fi
       - name: Check files for yamllint
         id: yamllint
         run: |
           if git diff --name-only origin/${{ github.base_ref }} HEAD -- | grep -Eq '.*\.ya?ml|config/.*\.conf' ; then
-            echo '::set-output name=run::true'
+            echo "run=true" >> $GITHUB_OUTPUT
             echo 'YAML files have changed, need to run yamllint.'
           else
-            echo '::set-output name=run::false'
+            echo "run=false" >> $GITHUB_OUTPUT
           fi
 
   actionlint:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

TL;DR

> name: Save state
> run: echo "::save-state name={name}::{value}"
> 
> name: Set output
> run: echo "::set-output name={name}::{value}"
> 
> name: Save state
> run: echo "{name}={value}" >> $GITHUB_STATE
> 
> name: Set output
> run: echo "{name}={value}" >> $GITHUB_OUTPUT

Ref: https://github.com/netdata/infra/issues/3541