### PR TITLE
Make four module yamls fit schema

### DIFF
--- a/modules/activemq/metadata.yaml
+++ b/modules/activemq/metadata.yaml
@@ -1,11 +1,25 @@
-module_name: activemq
-plugin_name: go.d.plugin
-monitored_instance:
-  name: ActiveMQ
-  link: https://activemq.apache.org/
-alternative_monitored_instances: []
-keywords:
-  - message broker
+meta:
+  module_name: activemq
+  plugin_name: go.d.plugin
+  monitored_instance:
+    categories:
+      - data-collection.message-brokers
+    icon_filename: activemq.png
+    name: ActiveMQ
+    link: https://activemq.apache.org/
+  alternative_monitored_instances: []
+  keywords:
+    - message broker
+  most_popular: false
+  info_provided_to_referring_integrations:
+    description: ""
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: go.d.plugin
+          module_name: httpcheck
+        - plugin_name: apps.plugin
+          module_name: apps
 overview:
   data_collection:
     metrics_description: This collector monitors ActiveMQ queues and topics.
@@ -17,7 +31,7 @@ overview:
       description: |
         This collector discovers instances running on the local host that provide metrics on port 8161.
         On startup, it tries to collect metrics from:
-        
+
         - http://localhost:8161
     limits:
       description: ""
@@ -127,10 +141,12 @@ setup:
           default_value: ""
           required: false
     examples:
+      folding:
+        title: Config
+        enabled: true
       list:
         - name: Basic
           folding:
-            title: Config
             enabled: false
           description: A basic example configuration.
           config: |
@@ -139,9 +155,6 @@ setup:
                 url: http://127.0.0.1:8161
                 webadmin: admin
         - name: HTTP authentication
-          folding:
-            title: Config
-            enabled: true
           description: Basic HTTP authentication.
           config: |
             jobs:
@@ -151,9 +164,6 @@ setup:
                 username: foo
                 password: bar
         - name: Filters and limits
-          folding:
-            title: Config
-            enabled: true
           description: Using filters and limits for queues and topics.
           config: |
             jobs:
@@ -165,9 +175,6 @@ setup:
                 queues_filter: '!sandr* *'
                 topics_filter: '!sandr* *'
         - name: Multi-instance
-          folding:
-            title: Config
-            enabled: true
           description: |
             > **Note**: When you define multiple jobs, their names must be unique.
 
@@ -184,15 +191,6 @@ setup:
 troubleshooting:
   problems:
     list: []
-info_provided_to_referring_integrations:
-  description: ""
-related_resources:
-  integrations:
-    list:
-      - plugin_name: go.d.plugin
-        module_name: httpcheck
-      - plugin_name: apps.plugin
-        module_name: apps
 alerts: []
 metrics:
   folding:

--- a/modules/apache/metadata.yaml
+++ b/modules/apache/metadata.yaml
@@ -1,11 +1,27 @@
-module_name: apache
-plugin_name: go.d.plugin
-monitored_instance:
-  name: Apache
-  link: https://httpd.apache.org/
-alternative_monitored_instances: []
-keywords:
-  - "webserver"
+meta:
+  module_name: apache
+  plugin_name: go.d.plugin
+  monitored_instance:
+    categories:
+      - data-collection.web-servers-and-web-proxies
+    icon_filename: apache.png
+    name: Apache
+    link: https://httpd.apache.org/
+  alternative_monitored_instances: []
+  keywords:
+    - webserver
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: go.d.plugin
+          module_name: weblog
+        - plugin_name: go.d.plugin
+          module_name: httpcheck
+        - plugin_name: apps.plugin
+          module_name: apps
+  info_provided_to_referring_integrations:
+    description: ""
+  most_popular: true
 overview:
   data_collection:
     metrics_description: |
@@ -116,10 +132,12 @@ setup:
           default_value: ""
           required: false
     examples:
+      folding:
+        title: Config
+        enabled: true
       list:
         - name: Basic
           folding:
-            title: Config
             enabled: false
           description: A basic example configuration.
           config: |
@@ -127,9 +145,6 @@ setup:
               - name: local
                 url: http://127.0.0.1/server-status?auto
         - name: HTTP authentication
-          folding:
-            title: Config
-            enabled: true
           description: Basic HTTP authentication.
           config: |
             jobs:
@@ -138,9 +153,6 @@ setup:
                 username: username
                 password: password
         - name: HTTPS with self-signed certificate
-          folding:
-            title: Config
-            enabled: true
           description: Apache with enabled HTTPS and self-signed certificate.
           config: |
             jobs:
@@ -148,9 +160,6 @@ setup:
                 url: https://127.0.0.1/server-status?auto
                 tls_skip_verify: yes
         - name: Multi-instance
-          folding:
-            title: Config
-            enabled: true
           description: |
             > **Note**: When you define multiple jobs, their names must be unique.
 
@@ -165,17 +174,6 @@ setup:
 troubleshooting:
   problems:
     list: []
-related_resources:
-  integrations:
-    list:
-      - plugin_name: go.d.plugin
-        module_name: weblog
-      - plugin_name: go.d.plugin
-        module_name: httpcheck
-      - plugin_name: apps.plugin
-        module_name: apps
-info_provided_to_referring_integrations:
-  description: ""
 alerts: []
 metrics:
   folding:

--- a/modules/cassandra/metadata.yaml
+++ b/modules/cassandra/metadata.yaml
@@ -1,12 +1,24 @@
-module_name: cassandra
-plugin_name: go
-monitored_instance:
-  name: Cassandra
-  link: https://cassandra.apache.org/_/index.html
-alternative_monitored_instances: []
-keywords:
-  - nosql
-  - dbms
+meta:
+  module_name: cassandra
+  plugin_name: go
+  monitored_instance:
+    categories:
+      - data-collection.database-servers
+    icon_filename: cassandra.png
+    name: Cassandra
+    link: https://cassandra.apache.org/_/index.html
+  alternative_monitored_instances: []
+  keywords:
+    - nosql
+    - dbms
+    - db
+    - database
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ""
+  most_popular: false
 overview:
   data_collection:
     metrics_description: |
@@ -117,10 +129,12 @@ setup:
           default_value: ""
           required: false
     examples:
+      folding:
+        title: Config
+        enabled: true
       list:
         - name: Basic
           folding:
-            title: Config
             enabled: false
           description: A basic example configuration.
           config: |
@@ -128,9 +142,6 @@ setup:
               - name: local
                 url: http://127.0.0.1:7072/metrics
         - name: HTTP authentication
-          folding:
-            title: Config
-            enabled: true
           description: Local server with basic HTTP authentication.
           config: |
             jobs:
@@ -139,9 +150,6 @@ setup:
                 username: foo
                 password: bar
         - name: HTTPS with self-signed certificate
-          folding:
-            title: Config
-            enabled: true
           description: Local server with enabled HTTPS and self-signed certificate.
           config: |
             jobs:
@@ -149,9 +157,6 @@ setup:
                 url: https://127.0.0.1:7072/metrics
                 tls_skip_verify: yes
         - name: Multi-instance
-          folding:
-            title: Config
-            enabled: true
           description: |
             > **Note**: When you define multiple jobs, their names must be unique.
 
@@ -166,11 +171,6 @@ setup:
 troubleshooting:
   problems:
     list: []
-related_resources:
-  integrations:
-    list: []
-info_provided_to_referring_integrations:
-  description: ""
 alerts: []
 metrics:
   folding:

--- a/modules/chrony/metadata.yaml
+++ b/modules/chrony/metadata.yaml
@@ -1,10 +1,20 @@
-module_name: chrony
-plugin_name: go.d.plugin
-monitored_instance:
-  name: Chrony
-  link: https://chrony.tuxfamily.org/
-alternative_monitored_instances: []
-keywords: []
+meta:
+  module_name: chrony
+  plugin_name: go.d.plugin
+  monitored_instance:
+    categories:
+      - data-collection.system-clock-and-ntp
+    icon_filename: chrony.jpg
+    name: Chrony
+    link: https://chrony.tuxfamily.org/
+  alternative_monitored_instances: []
+  keywords: []
+  info_provided_to_referring_integrations:
+    description: ""
+  related_resources:
+    integrations:
+      list: []
+  most_popular: false
 overview:
   data_collection:
     metrics_description: This collector monitors the system's clock performance and peers activity status
@@ -56,10 +66,12 @@ setup:
           default_value: 1
           required: false
     examples:
+      folding:
+        title: Config
+        enabled: true
       list:
         - name: Basic
           folding:
-            title: Config
             enabled: false
           description: A basic example configuration.
           config: |
@@ -67,9 +79,6 @@ setup:
               - name: local
                 address: 127.0.0.1:323
         - name: Multi-instance
-          folding:
-            title: Config
-            enabled: true
           description: |
             > **Note**: When you define multiple jobs, their names must be unique.
 
@@ -83,11 +92,6 @@ setup:
                 address: 192.0.2.1:323
 troubleshooting:
   problems:
-    list: []
-info_provided_to_referring_integrations:
-  description: ""
-related_resources:
-  integrations:
     list: []
 alerts: []
 metrics:


### PR DESCRIPTION
activemq, apache, cassandra and chrony were made to be valid against the related schema.