### PR TITLE
Attempt to add chart_type, and make most yamls pass schema

### DIFF
--- a/modules/cockroachdb/metadata.yaml
+++ b/modules/cockroachdb/metadata.yaml
@@ -2,90 +2,92 @@ name: cockroachdb
 title: CockroachDB collector
 overview:
   application:
-    description: |
-      [CockroachDB](https://www.cockroachlabs.com/)  is the SQL database for building global, scalable cloud services that survive disasters.
+    description: "[CockroachDB](https://www.cockroachlabs.com/)  is the SQL database
+      for building global, scalable cloud services that survive disasters.\n"
   collector:
-    description: |
-      This collector monitors one or more CockroachDB databases, depending on your configuration.
+    description: "This collector monitors one or more CockroachDB databases, depending
+      on your configuration.\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 10
           required: false
+          default_value: 10
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: http://127.0.0.1:8080/_status/vars
           required: true
+          default_value: http://127.0.0.1:8080/_status/vars
         - name: timeout
           description: HTTP request timeout.
-          default: 1
           required: false
+          default_value: 1
         - name: username
           description: Username for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: password
           description: Password for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_url
           description: Proxy URL.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_username
           description: Username for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_password
           description: Password for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: method
           description: HTTP request method.
-          default: "GET"
           required: false
+          default_value: GET
         - name: body
           description: HTTP request body.
-          default: ""
           required: false
+          default_value: ''
         - name: headers
           description: HTTP request headers.
-          default: ""
           required: false
+          default_value: ''
         - name: not_follow_redirects
-          description: Redirect handling policy. Controls whether the client follows redirects.
-          default: no
+          description: Redirect handling policy. Controls whether the client follows
+            redirects.
           required: false
+          default_value: no
         - name: tls_skip_verify
-          description: Server certificate chain and hostname validation policy. Controls whether the client performs this check.
-          default: no
+          description: Server certificate chain and hostname validation policy. Controls
+            whether the client performs this check.
           required: false
+          default_value: no
         - name: tls_ca
-          description: Certification authority that the client uses when verifying the server's certificates.
-          default: ""
+          description: Certification authority that the client uses when verifying
+            the server's certificates.
           required: false
+          default_value: ''
         - name: tls_cert
           description: Client TLS certificate.
-          default: ""
           required: false
+          default_value: ''
         - name: tls_key
           description: Client TLS key.
-          default: ""
           required: false
+          default_value: ''
     examples:
       folding:
         title: Config
@@ -93,37 +95,22 @@ setup:
       list:
         - name: Basic
           description: An example configuration.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8080/_status/vars
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8080/_status/vars\n"
         - name: HTTP authentication
           description: Local server with basic HTTP authentication.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8080/_status/vars
-                username: username
-                password: password
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8080/_status/vars\n\
+            \    username: username\n    password: password\n"
         - name: HTTPS with self-signed certificate
           description: CockroachDB with enabled HTTPS and self-signed certificate.
-          data: |
-            jobs:
-              - name: local
-                url: https://127.0.0.1:8080/_status/vars
-                tls_skip_verify: yes
+          config: "jobs:\n  - name: local\n    url: https://127.0.0.1:8080/_status/vars\n\
+            \    tls_skip_verify: yes\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-
-            Collecting metrics from local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8080/_status/vars
-
-              - name: remote
-                url: http://203.0.113.10:8080/_status/vars
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nCollecting metrics from local and remote instances.\n"
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8080/_status/vars\n\
+            \n  - name: remote\n    url: http://203.0.113.10:8080/_status/vars\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -131,8 +118,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -142,129 +130,152 @@ metrics:
           unit: percentage
           dimensions:
             - name: used
+          chart_type: line
         - name: cockroachdb.process_cpu_time_percentage
           description: CPU Time Percentage
           unit: percentage
           dimensions:
             - name: user
             - name: sys
+          chart_type: stacked
         - name: cockroachdb.process_cpu_time
           description: CPU Time
           unit: ms
           dimensions:
             - name: user
             - name: sys
+          chart_type: stacked
         - name: cockroachdb.process_memory
           description: Memory Usage
           unit: KiB
           dimensions:
             - name: rss
+          chart_type: line
         - name: cockroachdb.process_file_descriptors
           description: File Descriptors
           unit: fd
           dimensions:
             - name: open
+          chart_type: line
         - name: cockroachdb.process_uptime
           description: Uptime
           unit: seconds
           dimensions:
             - name: uptime
+          chart_type: line
         - name: cockroachdb.host_disk_bandwidth
           description: Host Disk Cumulative Bandwidth
           unit: KiB
           dimensions:
             - name: read
             - name: write
+          chart_type: area
         - name: cockroachdb.host_disk_operations
           description: Host Disk Cumulative Operations
           unit: operations
           dimensions:
             - name: reads
             - name: writes
+          chart_type: line
         - name: cockroachdb.host_disk_iops_in_progress
           description: Host Disk Cumulative IOPS In Progress
           unit: iops
           dimensions:
             - name: in_progress
+          chart_type: line
         - name: cockroachdb.host_network_bandwidth
           description: Host Network Cumulative Bandwidth
           unit: kilobits
           dimensions:
             - name: received
             - name: sent
+          chart_type: area
         - name: cockroachdb.host_network_packets
           description: Host Network Cumulative Packets
           unit: packets
           dimensions:
             - name: received
             - name: sent
+          chart_type: line
         - name: cockroachdb.live_nodes
           description: Live Nodes in the Cluster
           unit: nodes
           dimensions:
             - name: live_nodes
+          chart_type: line
         - name: cockroachdb.node_liveness_heartbeats
           description: Node Liveness Heartbeats
           unit: heartbeats
           dimensions:
             - name: successful
             - name: failed
+          chart_type: stacked
         - name: cockroachdb.total_storage_capacity
           description: Total Storage Capacity
           unit: KiB
           dimensions:
             - name: total
+          chart_type: line
         - name: cockroachdb.storage_capacity_usability
           description: Storage Capacity Usability
           unit: KiB
           dimensions:
             - name: usable
             - name: unusable
+          chart_type: stacked
         - name: cockroachdb.storage_usable_capacity
           description: Storage Usable Capacity
           unit: KiB
           dimensions:
             - name: available
             - name: used
+          chart_type: stacked
         - name: cockroachdb.storage_used_capacity_percentage
           description: Storage Used Capacity Utilization
           unit: percentage
           dimensions:
             - name: total
             - name: usable
+          chart_type: line
         - name: cockroachdb.sql_connections
           description: Active SQL Connections
           unit: connections
           dimensions:
             - name: active
+          chart_type: line
         - name: cockroachdb.sql_bandwidth
           description: SQL Bandwidth
           unit: KiB
           dimensions:
             - name: received
             - name: sent
+          chart_type: area
         - name: cockroachdb.sql_statements_total
           description: SQL Statements Total
           unit: statements
           dimensions:
             - name: started
             - name: executed
+          chart_type: area
         - name: cockroachdb.sql_errors
           description: SQL Statements and Transaction Errors
           unit: errors
           dimensions:
             - name: statement
             - name: transaction
+          chart_type: line
         - name: cockroachdb.sql_started_ddl_statements
           description: SQL Started DDL Statements
           unit: statements
           dimensions:
             - name: ddl
+          chart_type: line
         - name: cockroachdb.sql_executed_ddl_statements
           description: SQL Executed DDL Statements
           unit: statements
           dimensions:
             - name: ddl
+          chart_type: line
         - name: cockroachdb.sql_started_dml_statements
           description: SQL Started DML Statements
           unit: statements
@@ -273,6 +284,7 @@ metrics:
             - name: update
             - name: delete
             - name: insert
+          chart_type: stacked
         - name: cockroachdb.sql_executed_dml_statements
           description: SQL Executed DML Statements
           unit: statements
@@ -281,6 +293,7 @@ metrics:
             - name: update
             - name: delete
             - name: insert
+          chart_type: stacked
         - name: cockroachdb.sql_started_tcl_statements
           description: SQL Started TCL Statements
           unit: statements
@@ -292,6 +305,7 @@ metrics:
             - name: savepoint_cockroach_restart
             - name: release_savepoint_cockroach_restart
             - name: rollback_to_savepoint_cockroach_restart
+          chart_type: stacked
         - name: cockroachdb.sql_executed_tcl_statements
           description: SQL Executed TCL Statements
           unit: statements
@@ -303,35 +317,41 @@ metrics:
             - name: savepoint_cockroach_restart
             - name: release_savepoint_cockroach_restart
             - name: rollback_to_savepoint_cockroach_restart
+          chart_type: stacked
         - name: cockroachdb.sql_active_distributed_queries
           description: Active Distributed SQL Queries
           unit: queries
           dimensions:
             - name: active
+          chart_type: line
         - name: cockroachdb.sql_distributed_flows
           description: Distributed SQL Flows
           unit: flows
           dimensions:
             - name: active
             - name: queued
+          chart_type: stacked
         - name: cockroachdb.live_bytes
           description: Used Live Data
           unit: KiB
           dimensions:
             - name: applications
             - name: system
+          chart_type: line
         - name: cockroachdb.logical_data
           description: Logical Data
           unit: KiB
           dimensions:
             - name: keys
             - name: values
+          chart_type: stacked
         - name: cockroachdb.logical_data_count
           description: Logical Data Count
           unit: num
           dimensions:
             - name: keys
             - name: values
+          chart_type: stacked
         - name: cockroachdb.kv_transactions
           description: KV Transactions
           unit: transactions
@@ -339,6 +359,7 @@ metrics:
             - name: committed
             - name: fast-path_committed
             - name: aborted
+          chart_type: area
         - name: cockroachdb.kv_transaction_restarts
           description: KV Transaction Restarts
           unit: restarts
@@ -352,11 +373,13 @@ metrics:
             - name: aborted
             - name: push_failure
             - name: unknown
+          chart_type: stacked
         - name: cockroachdb.ranges
           description: Ranges
           unit: ranges
           dimensions:
             - name: ranges
+          chart_type: line
         - name: cockroachdb.ranges_replication_problem
           description: Ranges Replication Problems
           unit: ranges
@@ -364,6 +387,7 @@ metrics:
             - name: unavailable
             - name: under_replicated
             - name: over_replicated
+          chart_type: stacked
         - name: cockroachdb.range_events
           description: Range Events
           unit: events
@@ -372,6 +396,7 @@ metrics:
             - name: add
             - name: remove
             - name: merge
+          chart_type: stacked
         - name: cockroachdb.range_snapshot_events
           description: Range Snapshot Events
           unit: events
@@ -380,60 +405,71 @@ metrics:
             - name: applied_raft_initiated
             - name: applied_learner
             - name: applied_preemptive
+          chart_type: stacked
         - name: cockroachdb.rocksdb_read_amplification
           description: RocksDB Read Amplification
           unit: reads/query
           dimensions:
             - name: reads
+          chart_type: line
         - name: cockroachdb.rocksdb_table_operations
           description: RocksDB Table Operations
           unit: operations
           dimensions:
             - name: compactions
             - name: flushes
+          chart_type: line
         - name: cockroachdb.rocksdb_cache_usage
           description: RocksDB Block Cache Usage
           unit: KiB
           dimensions:
             - name: used
+          chart_type: area
         - name: cockroachdb.rocksdb_cache_operations
           description: RocksDB Block Cache Operations
           unit: operations
           dimensions:
             - name: hits
             - name: misses
+          chart_type: stacked
         - name: cockroachdb.rocksdb_cache_hit_rate
           description: RocksDB Block Cache Hit Rate
           unit: percentage
           dimensions:
             - name: hit_rate
+          chart_type: area
         - name: cockroachdb.rocksdb_sstables
           description: RocksDB SSTables
           unit: sstables
           dimensions:
             - name: sstables
+          chart_type: line
         - name: cockroachdb.replicas
           description: Number of Replicas
           unit: replicas
           dimensions:
             - name: replicas
+          chart_type: line
         - name: cockroachdb.replicas_quiescence
           description: Replicas Quiescence
           unit: replicas
           dimensions:
             - name: quiescent
             - name: active
+          chart_type: stacked
         - name: cockroachdb.replicas_leaders
           description: Number of Raft Leaders
           unit: replicas
           dimensions:
             - name: leaders
             - name: not_leaseholders
+          chart_type: area
         - name: cockroachdb.replicas_leaseholders
           description: Number of Leaseholders
           unit: leaseholders
           dimensions:
             - name: leaseholders
+          chart_type: line
         - name: cockroachdb.queue_processing_failures
           description: Queues Processing Failures
           unit: failures
@@ -446,31 +482,37 @@ metrics:
             - name: raft_log
             - name: raft_snapshot
             - name: time_series_maintenance
+          chart_type: stacked
         - name: cockroachdb.rebalancing_queries
           description: Rebalancing Average Queries
           unit: queries/s
           dimensions:
             - name: avg
+          chart_type: line
         - name: cockroachdb.rebalancing_writes
           description: Rebalancing Average Writes
           unit: writes/s
           dimensions:
             - name: avg
+          chart_type: line
         - name: cockroachdb.timeseries_samples
           description: Time Series Written Samples
           unit: samples
           dimensions:
             - name: written
+          chart_type: line
         - name: cockroachdb.timeseries_write_errors
           description: Time Series Write Errors
           unit: errors
           dimensions:
             - name: write
+          chart_type: line
         - name: cockroachdb.timeseries_write_bytes
           description: Time Series Bytes Written
           unit: KiB
           dimensions:
             - name: written
+          chart_type: line
         - name: cockroachdb.slow_requests
           description: Slow Requests
           unit: requests
@@ -478,29 +520,35 @@ metrics:
             - name: acquiring_latches
             - name: acquiring_lease
             - name: in_raft
+          chart_type: stacked
         - name: cockroachdb.code_heap_memory_usage
           description: Heap Memory Usage
           unit: KiB
           dimensions:
             - name: go
             - name: cgo
+          chart_type: stacked
         - name: cockroachdb.goroutines
           description: Number of Goroutines
           unit: goroutines
           dimensions:
             - name: goroutines
+          chart_type: line
         - name: cockroachdb.gc_count
           description: GC Runs
           unit: invokes
           dimensions:
             - name: gc
+          chart_type: line
         - name: cockroachdb.gc_pause
           description: GC Pause Time
           unit: us
           dimensions:
             - name: pause
+          chart_type: line
         - name: cockroachdb.cgo_calls
           description: Cgo Calls
           unit: calls
           dimensions:
             - name: cgo
+          chart_type: line

--- a/modules/coredns/metadata.yaml
+++ b/modules/coredns/metadata.yaml
@@ -2,98 +2,100 @@ name: coredns
 title: CoreDNS collector
 overview:
   application:
-    description: |
-      [CoreDNS](https://coredns.io/) is a fast and flexible DNS server.
+    description: "[CoreDNS](https://coredns.io/) is a fast and flexible DNS server.\n"
   collector:
-    description: |
-      This module monitor one or more CoreDNS instances depending on configuration.
+    description: "This module monitor one or more CoreDNS instances depending on configuration.\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: All options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
-          required: no
+          required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
-          required: no
+          required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: "`http://127.0.0.1:9153/metrics`"
-          required: yes
+          required: true
+          default_value: '`http://127.0.0.1:9153/metrics`'
         - name: per_server_stats
-          description: "Server filter. Module will collect server statistics if filter matches the server. Filter logic: (pattern1 OR pattern2) AND !(pattern3 or pattern4). Check the [pattern syntax](https://github.com/netdata/go.d.plugin/tree/master/pkg/matcher#supported-format)."
-          default: "-"
-          required: no
+          description: 'Server filter. Module will collect server statistics if filter
+            matches the server. Filter logic: (pattern1 OR pattern2) AND !(pattern3
+            or pattern4). Check the [pattern syntax](https://github.com/netdata/go.d.plugin/tree/master/pkg/matcher#supported-format).'
+          required: false
+          default_value: '-'
         - name: per_zone_stats
-          description: "Zone filter. Module will collect zone statistics if filter matches the zone. Filter logic: (pattern1 OR pattern2) AND !(pattern3 or pattern4). Check the [pattern syntax](https://github.com/netdata/go.d.plugin/tree/master/pkg/matcher#supported-format)."
-          default: "-"
-          required: no
+          description: 'Zone filter. Module will collect zone statistics if filter
+            matches the zone. Filter logic: (pattern1 OR pattern2) AND !(pattern3
+            or pattern4). Check the [pattern syntax](https://github.com/netdata/go.d.plugin/tree/master/pkg/matcher#supported-format).'
+          required: false
+          default_value: '-'
         - name: username
           description: Username for basic HTTP authentication.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: password
           description: Password for basic HTTP authentication.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: proxy_url
           description: The Proxie's URL.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: proxy_username
           description: Username for proxy basic HTTP authentication.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: proxy_password
           description: Password for proxy basic HTTP authentication.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: timeout
           description: HTTP request timeout.
-          default: 2
-          required: no
+          required: false
+          default_value: 2
         - name: method
           description: HTTP request method.
-          default: "GET"
-          required: no
+          required: false
+          default_value: GET
         - name: body
           description: HTTP request body.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: headers
           description: HTTP request headers.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: not_follow_redirects
           description: Whether to not follow redirects from the server.
-          default: no
-          required: no
+          required: false
+          default_value: no
         - name: tls_skip_verify
           description: Whether to skip verifying server's certificate chain and hostname.
-          default: no
-          required: no
+          required: false
+          default_value: no
         - name: tls_ca
-          description: Certificate authority that client use when verifying server certificates.
-          default: "-"
-          required: no
+          description: Certificate authority that client use when verifying server
+            certificates.
+          required: false
+          default_value: '-'
         - name: tls_cert
           description: Client tls certificate.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: tls_key
           description: Client tls key.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
     examples:
       list:
         - name: Basic
@@ -101,33 +103,27 @@ setup:
           folding:
             title: Example
             enabled: true
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:9153/metrics
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:9153/metrics\n"
         - name: Basic HTTP auth
           description: Local server with basic HTTP authentication.
           folding:
             title: Example
             enabled: true
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:9153/metrics
-                username: foo
-                password: bar
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:9153/metrics\n\
+            \    username: foo\n    password: bar\n"
         - name: Multi-instance
-          description: When you are defining more than one jobs, you must be careful to use different job names, to not override each other.
+          description: When you are defining more than one jobs, you must be careful
+            to use different job names, to not override each other.
           folding:
             title: Example
             enabled: true
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:9153/metrics
-
-              - name: remote
-                url: http://203.0.113.10:9153/metrics
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:9153/metrics\n\
+            \n  - name: remote\n    url: http://203.0.113.10:9153/metrics\n"
+      folding:
+        title: Config options
+        enabled: true
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -136,7 +132,8 @@ metrics:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -146,39 +143,46 @@ metrics:
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: coredns.dns_responses_count_total
           description: Number Of DNS Responses
           unit: responses/s
           dimensions:
             - name: responses
+          chart_type: line
         - name: coredns.dns_request_count_total_per_status
           description: Number Of Processed And Dropped DNS Requests
           unit: requests/s
           dimensions:
             - name: processed
             - name: dropped
+          chart_type: stacked
         - name: coredns.dns_no_matching_zone_dropped_total
           description: Number Of Dropped DNS Requests Because Of No Matching Zone
           unit: requests/s
           dimensions:
             - name: dropped
+          chart_type: line
         - name: coredns.dns_panic_count_total
           description: Number Of Panics
           unit: panics/s
           dimensions:
             - name: panics
+          chart_type: line
         - name: coredns.dns_requests_count_total_per_proto
           description: Number Of DNS Requests Per Transport Protocol
           unit: requests/s
           dimensions:
             - name: udp
             - name: tcp
+          chart_type: stacked
         - name: coredns.dns_requests_count_total_per_ip_family
           description: Number Of DNS Requests Per IP Family
           unit: requests/s
           dimensions:
             - name: v4
             - name: v6
+          chart_type: stacked
         - name: coredns.dns_requests_count_total_per_per_type
           description: Number Of DNS Requests Per Type
           unit: requests/s
@@ -199,6 +203,7 @@ metrics:
             - name: ixfr
             - name: any
             - name: other
+          chart_type: stacked
         - name: coredns.dns_responses_count_total_per_rcode
           description: Number Of DNS Responses Per Rcode
           unit: responses/s
@@ -223,6 +228,7 @@ metrics:
             - name: badtrunc
             - name: badcookie
             - name: other
+          chart_type: stacked
     - name: server
       description: TBD
       labels:
@@ -234,29 +240,34 @@ metrics:
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: coredns.server_dns_responses_count_total
           description: Number Of DNS Responses
           unit: responses/s
           dimensions:
             - name: responses
+          chart_type: line
         - name: coredns.server_request_count_total_per_status
           description: Number Of Processed And Dropped DNS Requests
           unit: requests/s
           dimensions:
             - name: processed
             - name: dropped
+          chart_type: stacked
         - name: coredns.server_requests_count_total_per_proto
           description: Number Of DNS Requests Per Transport Protocol
           unit: requests/s
           dimensions:
             - name: udp
             - name: tcp
+          chart_type: stacked
         - name: coredns.server_requests_count_total_per_ip_family
           description: Number Of DNS Requests Per IP Family
           unit: requests/s
           dimensions:
             - name: v4
             - name: v6
+          chart_type: stacked
         - name: coredns.server_requests_count_total_per_per_type
           description: Number Of DNS Requests Per Type
           unit: requests/s
@@ -277,6 +288,7 @@ metrics:
             - name: ixfr
             - name: any
             - name: other
+          chart_type: stacked
         - name: coredns.server_responses_count_total_per_rcode
           description: Number Of DNS Responses Per Rcode
           unit: responses/s
@@ -301,6 +313,7 @@ metrics:
             - name: badtrunc
             - name: badcookie
             - name: other
+          chart_type: stacked
     - name: zone
       description: TBD
       labels:
@@ -312,23 +325,27 @@ metrics:
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: coredns.zone_dns_responses_count_total
           description: Number Of DNS Responses
           unit: responses/s
           dimensions:
             - name: responses
+          chart_type: line
         - name: coredns.zone_requests_count_total_per_proto
           description: Number Of DNS Requests Per Transport Protocol
           unit: requests/s
           dimensions:
             - name: udp
             - name: tcp
+          chart_type: stacked
         - name: coredns.zone_requests_count_total_per_ip_family
           description: Number Of DNS Requests Per IP Family
           unit: requests/s
           dimensions:
             - name: v4
             - name: v6
+          chart_type: stacked
         - name: coredns.zone_requests_count_total_per_per_type
           description: Number Of DNS Requests Per Type
           unit: requests/s
@@ -349,6 +366,7 @@ metrics:
             - name: ixfr
             - name: any
             - name: other
+          chart_type: stacked
         - name: coredns.zone_responses_count_total_per_rcode
           description: Number Of DNS Responses Per Rcode
           unit: responses/s
@@ -373,3 +391,4 @@ metrics:
             - name: badtrunc
             - name: badcookie
             - name: other
+          chart_type: stacked

--- a/modules/couchbase/metadata.yaml
+++ b/modules/couchbase/metadata.yaml
@@ -2,46 +2,47 @@ name: couchbase
 title: Couchbase collector
 overview:
   application:
-    description: |
-      [Couchbase](https://www.couchbase.com/) is an open source, distributed, JSON document database. It exposes a scale-out, key-value store with managed cache for sub-millisecond data operations, purpose-built indexers for efficient queries and a powerful query engine for executing SQL-like queries.
+    description: "[Couchbase](https://www.couchbase.com/) is an open source, distributed,
+      JSON document database. It exposes a scale-out, key-value store with managed
+      cache for sub-millisecond data operations, purpose-built indexers for efficient
+      queries and a powerful query engine for executing SQL-like queries.\n"
   collector:
-    description: |
-      This collector collects metrics exposed from the `/pools/default/buckets` endpoint.
+    description: "This collector collects metrics exposed from the `/pools/default/buckets`
+      endpoint.\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: All options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
-          required: no
+          required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
-          required: no
+          required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: "`http://127.0.0.1:8091`"
-          required: yes
+          required: true
+          default_value: '`http://127.0.0.1:8091`'
         - name: username
           description: Username for basic HTTP authentication.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: password
           description: Password for basic HTTP authentication.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: timeout
           description: HTTP request timeout.
-          default: 10
-          required: no
+          required: false
+          default_value: 10
     examples:
       list:
         - name: Basic
@@ -49,33 +50,27 @@ setup:
           folding:
             title: Example
             enabled: true
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8091
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8091\n"
         - name: Basic HTTP auth
           description: Local server with basic HTTP authentication.
           folding:
             title: Example
             enabled: true
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8091
-                username: foo
-                password: bar
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8091\n    username:
+            foo\n    password: bar\n"
         - name: Multi-instance
-          description: When you are defining more than one jobs, you must be careful to use different job names, to not override each other.
+          description: When you are defining more than one jobs, you must be careful
+            to use different job names, to not override each other.
           folding:
             title: Example
             enabled: true
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8091
-
-              - name: remote
-                url: http://203.0.113.0:8091
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8091\n\n  - name:
+            remote\n    url: http://203.0.113.0:8091\n"
+      folding:
+        title: Config options
+        enabled: true
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -84,7 +79,8 @@ metrics:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -94,38 +90,46 @@ metrics:
           unit: percentage
           dimensions:
             - name: a dimension per bucket
+          chart_type: line
         - name: couchbase.bucket_ops_per_sec
           description: Operations Per Second Per Bucket
           unit: ops/s
           dimensions:
             - name: a dimension per bucket
+          chart_type: stacked
         - name: couchbase.bucket_disk_fetches
           description: Disk Fetches Per Bucket
           unit: fetches
           dimensions:
             - name: a dimension per bucket
+          chart_type: stacked
         - name: couchbase.bucket_item_count
           description: Item Count Per Bucket
           unit: items
           dimensions:
             - name: a dimension per bucket
+          chart_type: stacked
         - name: couchbase.bucket_disk_used_stats
           description: Disk Used Per Bucket
           unit: bytes
           dimensions:
             - name: a dimension per bucket
+          chart_type: stacked
         - name: couchbase.bucket_data_used
           description: Data Used Per Bucket
           unit: bytes
           dimensions:
             - name: a dimension per bucket
+          chart_type: stacked
         - name: couchbase.bucket_mem_used
           description: Memory Used Per Bucket
           unit: bytes
           dimensions:
             - name: a dimension per bucket
+          chart_type: stacked
         - name: couchbase.bucket_vb_active_num_non_resident
           description: Number Of Non-Resident Items Per Bucket
           unit: items
           dimensions:
             - name: a dimension per bucket
+          chart_type: stacked

--- a/modules/couchdb/metadata.yaml
+++ b/modules/couchdb/metadata.yaml
@@ -2,98 +2,100 @@ name: couchdb
 title: Apache CouchDB collector
 overview:
   application:
-    description: |
-      [Apache CouchDB](https://couchdb.apache.org/) is an open source NoSQL document database that collects and stores data in JSON-based document formats.
+    description: "[Apache CouchDB](https://couchdb.apache.org/) is an open source
+      NoSQL document database that collects and stores data in JSON-based document
+      formats.\n"
   collector:
-    description: |
-      This collector monitors vital statistics of one or more Apache CouchDB 2.x servers, depending on your configuration.
+    description: "This collector monitors vital statistics of one or more Apache CouchDB
+      2.x servers, depending on your configuration.\n"
 setup:
-  prerequisites: 
+  prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: All options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
-          required: no
+          required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
-          required: no
+          required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: "`http://127.0.0.1:5984`"
-          required: yes
+          required: true
+          default_value: '`http://127.0.0.1:5984`'
         - name: username
           description: Username for basic HTTP authentication.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: password
           description: Password for basic HTTP authentication.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: proxy_url
           description: The Proxie's URL.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: proxy_username
           description: Username for proxy basic HTTP authentication.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: proxy_password
           description: Password for proxy basic HTTP authentication.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: node
           description: CouchDB node name. Same as -name vm.args argument.
-          default: "_local"
-          required: no
+          required: false
+          default_value: _local
         - name: databases
-          description: List of database names for which db-specific stats should be displayed, space separated.
-          default: "-"
-          required: no
+          description: List of database names for which db-specific stats should be
+            displayed, space separated.
+          required: false
+          default_value: '-'
         - name: timeout
           description: HTTP request timeout.
-          default: 5
-          required: no
+          required: false
+          default_value: 5
         - name: method
           description: HTTP request method.
-          default: "GET"
-          required: no
+          required: false
+          default_value: GET
         - name: body
           description: HTTP request body.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: headers
           description: HTTP request headers.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: not_follow_redirects
           description: Whether to not follow redirects from the server.
-          default: no
-          required: no
+          required: false
+          default_value: no
         - name: tls_skip_verify
           description: Whether to skip verifying server's certificate chain and hostname.
-          default: no
-          required: no
+          required: false
+          default_value: no
         - name: tls_ca
-          description: Certificate authority that client use when verifying server certificates.
-          default: "-"
-          required: no
+          description: Certificate authority that client use when verifying server
+            certificates.
+          required: false
+          default_value: '-'
         - name: tls_cert
           description: Client tls certificate.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: tls_key
           description: Client tls key.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
     examples:
       list:
         - name: Basic
@@ -101,35 +103,32 @@ setup:
           folding:
             title: Example
             enabled: true
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:5984
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:5984\n"
         - name: Basic HTTP auth
-          description: Local server with basic HTTP authentication, node name and multiple databases defined. Make sure to match the node name with the `NODENAME` value in your CouchDB's `etc/vm.args` file. Typically, this is of the form `couchdb@fully.qualified.domain.name` in a cluster, or `couchdb@127.0.0.1` for a single-node server.
+          description: Local server with basic HTTP authentication, node name and
+            multiple databases defined. Make sure to match the node name with the
+            `NODENAME` value in your CouchDB's `etc/vm.args` file. Typically, this
+            is of the form `couchdb@fully.qualified.domain.name` in a cluster, or
+            `couchdb@127.0.0.1` for a single-node server.
           folding:
             title: Example
             enabled: true
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:5984
-                node: couchdb@127.0.0.1
-                databases: my-db other-db
-                username: foo
-                password: bar
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:5984\n    node:
+            couchdb@127.0.0.1\n    databases: my-db other-db\n    username: foo\n\
+            \    password: bar\n"
         - name: Multi-instance
-          description: When you are defining more than one jobs, you must be careful to use different job names, to not override each other.
+          description: When you are defining more than one jobs, you must be careful
+            to use different job names, to not override each other.
           folding:
             title: Example
             enabled: true
-          data: |
-            jobs:
-              - name: local
-                http://127.0.0.1:5984
-              
-              - name: remote
-                http://192.0.2.0:5984
+          config: "jobs:\n  - name: local\n    http://127.0.0.1:5984\n  \n  - name:
+            remote\n    http://192.0.2.0:5984\n"
+      folding:
+        title: Config options
+        enabled: true
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -138,7 +137,8 @@ metrics:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -150,6 +150,7 @@ metrics:
             - name: db_reads
             - name: db_writes
             - name: view_reads
+          chart_type: stacked
         - name: couchdb.request_methods
           description: HTTP request methods
           unit: requests/s
@@ -161,6 +162,7 @@ metrics:
             - name: options
             - name: post
             - name: put
+          chart_type: stacked
         - name: couchdb.response_codes
           description: HTTP response status codes
           unit: responses/s
@@ -188,6 +190,7 @@ metrics:
             - name: '500'
             - name: '501'
             - name: '503'
+          chart_type: stacked
         - name: couchdb.response_code_classes
           description: HTTP response status code classes
           unit: responses/s
@@ -196,6 +199,7 @@ metrics:
             - name: 3xx
             - name: 4xx
             - name: 5xx
+          chart_type: stacked
         - name: couchdb.active_tasks
           description: Active task breakdown
           unit: tasks
@@ -204,6 +208,7 @@ metrics:
             - name: db_compaction
             - name: replication
             - name: view_compaction
+          chart_type: stacked
         - name: couchdb.replicator_jobs
           description: Replicator job breakdown
           unit: jobs
@@ -212,11 +217,13 @@ metrics:
             - name: pending
             - name: crashed
             - name: internal_replication_jobs
+          chart_type: stacked
         - name: couchdb.open_files
           description: Open files
           unit: files
           dimensions:
             - name: files
+          chart_type: line
         - name: couchdb.erlang_vm_memory
           description: Erlang VM memory usage
           unit: B
@@ -227,44 +234,53 @@ metrics:
             - name: ets
             - name: procs
             - name: other
+          chart_type: stacked
         - name: couchdb.proccounts
           description: Process counts
           unit: processes
           dimensions:
             - name: os_procs
             - name: erl_procs
+          chart_type: line
         - name: couchdb.peakmsgqueue
           description: Peak message queue size
           unit: messages
           dimensions:
             - name: peak_size
+          chart_type: line
         - name: couchdb.reductions
           description: Erlang reductions
           unit: reductions
           dimensions:
             - name: reductions
+          chart_type: line
         - name: couchdb.db_sizes_file
           description: Database sizes (file)
           unit: KiB
           dimensions:
             - name: a dimension per database
+          chart_type: line
         - name: couchdb.db_sizes_external
           description: Database sizes (external)
           unit: KiB
           dimensions:
             - name: a dimension per database
+          chart_type: line
         - name: couchdb.db_sizes_active
           description: Database sizes (active)
           unit: KiB
           dimensions:
             - name: a dimension per database
+          chart_type: line
         - name: couchdb.db_doc_count
           description: 'Database # of docs'
           unit: docs
           dimensions:
             - name: a dimension per database
+          chart_type: line
         - name: couchdb.db_doc_del_count
           description: 'Database # of deleted docs'
           unit: docs
           dimensions:
             - name: a dimension per database
+          chart_type: line

--- a/modules/dnsdist/metadata.yaml
+++ b/modules/dnsdist/metadata.yaml
@@ -2,99 +2,96 @@ name: dnsdist
 title: DNSdist collector
 overview:
   application:
-    description: |
-      [DNSdist](https://dnsdist.org/) is a highly DNS-, DoS- and abuse-aware loadbalancer.
+    description: "[DNSdist](https://dnsdist.org/) is a highly DNS-, DoS- and abuse-aware
+      loadbalancer.\n"
   collector:
-    description: |
-      This collector monitors load-balancer performance and health metrics.  
-      
-      It collects metrics from [the internal webserver](https://dnsdist.org/guides/webserver.html).  
-      
-      Used endpoints:
-
-      - [/jsonstat?command=stats](https://dnsdist.org/guides/webserver.html#get--jsonstat).
+    description: "This collector monitors load-balancer performance and health metrics.\
+      \  \n\nIt collects metrics from [the internal webserver](https://dnsdist.org/guides/webserver.html).\
+      \  \n\nUsed endpoints:\n\n- [/jsonstat?command=stats](https://dnsdist.org/guides/webserver.html#get--jsonstat).\n"
 setup:
   prerequisites:
     list:
       - title: Enable DNSdist's built-in Webserver
-        text: |
-          For collecting metrics via HTTP, you need to [enable the built-in webserver](https://dnsdist.org/guides/webserver.html).
+        description: "For collecting metrics via HTTP, you need to [enable the built-in
+          webserver](https://dnsdist.org/guides/webserver.html).\n"
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: http://127.0.0.1:8083
           required: true
+          default_value: http://127.0.0.1:8083
         - name: username
           description: Username for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: password
           description: Password for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_url
           description: Proxy URL.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_username
           description: Username for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_password
           description: Password for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: timeout
           description: HTTP request timeout.
-          default: 1
           required: false
+          default_value: 1
         - name: method
           description: HTTP request method.
-          default: "GET"
           required: false
+          default_value: GET
         - name: body
           description: HTTP request body.
-          default: "-"
           required: false
+          default_value: '-'
         - name: headers
           description: HTTP request headers.
-          default: ""
           required: false
+          default_value: ''
         - name: not_follow_redirects
-          description: Redirect handling policy. Controls whether the client follows redirects.
-          default: no
+          description: Redirect handling policy. Controls whether the client follows
+            redirects.
           required: false
+          default_value: no
         - name: tls_skip_verify
-          description: Server certificate chain and hostname validation policy. Controls whether the client performs this check.
-          default: no
+          description: Server certificate chain and hostname validation policy. Controls
+            whether the client performs this check.
           required: false
+          default_value: no
         - name: tls_ca
-          description: Certification authority that the client uses when verifying the server's certificates.
-          default: ""
+          description: Certification authority that the client uses when verifying
+            the server's certificates.
           required: false
+          default_value: ''
         - name: tls_cert
           description: Client TLS certificate.
-          default: ""
           required: false
+          default_value: ''
         - name: tls_key
           description: Client TLS key.
-          default: ""
           required: false
+          default_value: ''
     examples:
       folding:
         title: Config
@@ -102,40 +99,18 @@ setup:
       list:
         - name: Basic
           description: An example configuration.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8083
-                headers:
-                  X-API-Key: your-api-key # static pre-shared authentication key for access to the REST API (api-key).
-        #TODO:
-        # - name: Basic HTTP auth
-        #   description: Local server with basic HTTP authentication.
-        #   folding:
-        #     title: Example
-        #     enabled: true
-        #   data: |
-        #     jobs:
-        #       - name: local
-        #         url: http://127.0.0.1:8083
-        #         username: foo
-        #         password: bar
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8083\n    headers:\n\
+            \      X-API-Key: your-api-key # static pre-shared authentication key
+            for access to the REST API (api-key).\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-
-            Collecting metrics from local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8083
-                headers:
-                  X-API-Key: 'your-api-key' # static pre-shared authentication key for access to the REST API (api-key).
-
-              - name: remote
-                url: http://203.0.113.0:8083
-                headers:
-                  X-API-Key: 'your-api-key'
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nCollecting metrics from local and remote instances.\n"
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8083\n    headers:\n\
+            \      X-API-Key: 'your-api-key' # static pre-shared authentication key
+            for access to the REST API (api-key).\n\n  - name: remote\n    url: http://203.0.113.0:8083\n\
+            \    headers:\n      X-API-Key: 'your-api-key'\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -143,8 +118,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -156,6 +132,7 @@ metrics:
             - name: all
             - name: recursive
             - name: empty
+          chart_type: line
         - name: dnsdist.queries_dropped
           description: Client queries dropped
           unit: queries/s
@@ -164,11 +141,13 @@ metrics:
             - name: dynamic_blocked
             - name: no_policy
             - name: non_queries
+          chart_type: line
         - name: dnsdist.packets_dropped
           description: Packets dropped
           unit: packets/s
           dimensions:
             - name: acl
+          chart_type: line
         - name: dnsdist.answers
           description: Answers statistics
           unit: answers/s
@@ -177,16 +156,19 @@ metrics:
             - name: nxdomain
             - name: refused
             - name: trunc_failures
+          chart_type: line
         - name: dnsdist.backend_responses
           description: Backend responses
           unit: responses/s
           dimensions:
             - name: responses
+          chart_type: line
         - name: dnsdist.backend_commerrors
           description: Backend communication errors
           unit: errors/s
           dimensions:
             - name: send_errors
+          chart_type: line
         - name: dnsdist.backend_errors
           description: Backend error responses
           unit: responses/s
@@ -194,23 +176,27 @@ metrics:
             - name: timeouts
             - name: servfail
             - name: non_compliant
+          chart_type: line
         - name: dnsdist.cache
           description: Cache performance
           unit: answers/s
           dimensions:
             - name: hits
             - name: misses
+          chart_type: line
         - name: dnsdist.servercpu
           description: DNSdist server CPU utilization
           unit: ms/s
           dimensions:
             - name: system_state
             - name: user_state
+          chart_type: stacked
         - name: dnsdist.servermem
           description: DNSdist server memory utilization
           unit: MiB
           dimensions:
             - name: memory_usage
+          chart_type: area
         - name: dnsdist.query_latency
           description: Query latency
           unit: queries/s
@@ -221,6 +207,7 @@ metrics:
             - name: 100ms
             - name: 1sec
             - name: slow
+          chart_type: stacked
         - name: dnsdist.query_latency_avg
           description: Average latency for the last N queries
           unit: microseconds
@@ -229,3 +216,4 @@ metrics:
             - name: 1k
             - name: 10k
             - name: 1000k
+          chart_type: line

--- a/modules/dnsmasq/metadata.yaml
+++ b/modules/dnsmasq/metadata.yaml
@@ -2,57 +2,49 @@ name: dnsmasq
 title: Dnsmasq collector
 overview:
   application:
-    description: |
-      [Dnsmasq](https://thekelleys.org.uk/dnsmasq/doc.html) is a lightweight, easy to configure DNS forwarder, designed to provide DNS (and optionally DHCP and TFTP) services to a small-scale network.
+    description: "[Dnsmasq](https://thekelleys.org.uk/dnsmasq/doc.html) is a lightweight,
+      easy to configure DNS forwarder, designed to provide DNS (and optionally DHCP
+      and TFTP) services to a small-scale network.\n"
   collector:
-    description: |
-      This collector monitors one or more Dnsmasq DNS Forwarder instances, depending on your configuration.
-
-      It collects DNS cache statistics by [reading the response on the following query](https://manpages.debian.org/stretch/dnsmasq-base/dnsmasq.8.en.html#NOTES):
-
-      ```cmd
-      ;; opcode: QUERY, status: NOERROR, id: 37862
-      ;; flags: rd; QUERY: 7, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0
-
-      ;; QUESTION SECTION:
-      ;cachesize.bind.   CH	 TXT
-      ;insertions.bind.  CH	 TXT
-      ;evictions.bind.   CH	 TXT
-      ;hits.bind.        CH	 TXT
-      ;misses.bind.      CH	 TXT
-      ;servers.bind.     CH	 TXT
-      ```
+    description: "This collector monitors one or more Dnsmasq DNS Forwarder instances,
+      depending on your configuration.\n\nIt collects DNS cache statistics by [reading
+      the response on the following query](https://manpages.debian.org/stretch/dnsmasq-base/dnsmasq.8.en.html#NOTES):\n
+      \n```cmd\n;; opcode: QUERY, status: NOERROR, id: 37862\n;; flags: rd; QUERY:
+      7, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0\n\n;; QUESTION SECTION:\n;cachesize.bind.\
+      \   CH\t TXT\n;insertions.bind.  CH\t TXT\n;evictions.bind.   CH\t TXT\n;hits.bind.\
+      \        CH\t TXT\n;misses.bind.      CH\t TXT\n;servers.bind.     CH\t TXT\n\
+      ```\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: address
           description: Server's address. Format is 'ip_address:port'.
-          default: 127.0.0.1:53
           required: true
+          default_value: 127.0.0.1:53
         - name: protocol
-          description: "DNS query transport protocol. Supported protocols: udp, tcp, tcp-tls."
-          default: udp
+          description: 'DNS query transport protocol. Supported protocols: udp, tcp,
+            tcp-tls.'
           required: false
+          default_value: udp
         - name: timeout
-          description: "DNS query timeout (dial, write and read) in seconds."
-          default: 1
+          description: DNS query timeout (dial, write and read) in seconds.
           required: false
+          default_value: 1
     examples:
       folding:
         title: Config
@@ -60,29 +52,18 @@ setup:
       list:
         - name: Basic
           description: An example configuration.
-          data: |
-            jobs:
-              - name: local
-                address: 127.0.0.1:53
+          config: "jobs:\n  - name: local\n    address: 127.0.0.1:53\n"
         - name: Using TCP protocol
           description: Local server with specific DNS query transport protocol.
-          data: |
-            jobs:
-              - name: local
-                address: 127.0.0.1:53
-                protocol: tcp
+          config: "jobs:\n  - name: local\n    address: 127.0.0.1:53\n    protocol:
+            tcp\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-
-            Collecting metrics from local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                address: 127.0.0.1:53
-
-              - name: remote
-                address: 203.0.113.0:53
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nCollecting metrics from local and remote instances.\n"
+          config: "jobs:\n  - name: local\n    address: 127.0.0.1:53\n\n  - name:
+            remote\n    address: 203.0.113.0:53\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -90,8 +71,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: The metrics apply to the entire monitored application.
       labels: []
@@ -102,20 +84,24 @@ metrics:
           dimensions:
             - name: success
             - name: failed
+          chart_type: line
         - name: dnsmasq.cache_performance
           description: Cache performance
           unit: events/s
           dimensions:
             - name: hist
             - name: misses
+          chart_type: line
         - name: dnsmasq.cache_operations
           description: Cache operations
           unit: operations/s
           dimensions:
             - name: insertions
             - name: evictions
+          chart_type: line
         - name: dnsmasq.cache_size
           description: Cache size
           unit: entries
           dimensions:
             - name: size
+          chart_type: line

--- a/modules/dnsmasq_dhcp/metadata.yaml
+++ b/modules/dnsmasq_dhcp/metadata.yaml
@@ -2,50 +2,45 @@ name: dnsmasq_dhcp
 title: Dnsmasq DHCP collector
 overview:
   application:
-    description: |
-      [Dnsmasq](https://www.thekelleys.org.uk/dnsmasq/doc.html) is a lightweight, easy to configure DNS forwarder, designed to provide DNS (and optionally DHCP and TFTP) services to a small-scale network.
+    description: "[Dnsmasq](https://www.thekelleys.org.uk/dnsmasq/doc.html) is a lightweight,
+      easy to configure DNS forwarder, designed to provide DNS (and optionally DHCP
+      and TFTP) services to a small-scale network.\n"
   collector:
-    description: |
-      This collector monitors one or more Dnsmasq DHCP leases databases, depending on your configuration.
-
-      By default, it uses:
-
-      - `/var/lib/misc/dnsmasq.leases` to read leases.
-      - `/etc/dnsmasq.conf` to detect dhcp-ranges.
-      - `/etc/dnsmasq.d` to find additional configurations.
-      
-      All configured dhcp-ranges are detected automatically.
+    description: "This collector monitors one or more Dnsmasq DHCP leases databases,
+      depending on your configuration.\n\nBy default, it uses:\n\n- `/var/lib/misc/dnsmasq.leases`
+      to read leases.\n- `/etc/dnsmasq.conf` to detect dhcp-ranges.\n- `/etc/dnsmasq.d`
+      to find additional configurations.\n\nAll configured dhcp-ranges are detected
+      automatically.\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: leases_path
           description: Path to dnsmasq DHCP leases file.
-          default: "/var/lib/misc/dnsmasq.leases"
           required: false
+          default_value: /var/lib/misc/dnsmasq.leases
         - name: conf_path
           description: Path to dnsmasq configuration file.
-          default: "/etc/dnsmasq.conf"
           required: false
+          default_value: /etc/dnsmasq.conf
         - name: conf_dir
           description: Path to dnsmasq configuration directory.
-          default: "/etc/dnsmasq.d,.dpkg-dist,.dpkg-old,.dpkg-new"
           required: false
+          default_value: /etc/dnsmasq.d,.dpkg-dist,.dpkg-old,.dpkg-new
     examples:
       folding:
         title: Config
@@ -53,20 +48,14 @@ setup:
       list:
         - name: Basic
           description: An example configuration.
-          data: |
-            jobs:
-              - name: dnsmasq_dhcp
-                leases_path: /var/lib/misc/dnsmasq.leases
-                conf_path: /etc/dnsmasq.conf
-                conf_dir: /etc/dnsmasq.d
+          config: "jobs:\n  - name: dnsmasq_dhcp\n    leases_path: /var/lib/misc/dnsmasq.leases\n\
+            \    conf_path: /etc/dnsmasq.conf\n    conf_dir: /etc/dnsmasq.d\n"
         - name: Pi-hole
           description: Dnsmasq DHCP on Pi-hole.
-          data: |
-            jobs:
-              - name: dnsmasq_dhcp
-                leases_path: /etc/pihole/dhcp.leases
-                conf_path: /etc/dnsmasq.conf
-                conf_dir: /etc/dnsmasq.d
+          config: "jobs:\n  - name: dnsmasq_dhcp\n    leases_path: /etc/pihole/dhcp.leases\n\
+            \    conf_path: /etc/dnsmasq.conf\n    conf_dir: /etc/dnsmasq.d\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -74,8 +63,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -86,12 +76,14 @@ metrics:
           dimensions:
             - name: ipv4
             - name: ipv6
+          chart_type: stacked
         - name: dnsmasq_dhcp.dhcp_hosts
           description: Number of DHCP Hosts
           unit: hosts
           dimensions:
             - name: ipv4
             - name: ipv6
+          chart_type: stacked
     - name: dhcp range
       description: These metrics refer to the DHCP range.
       labels:
@@ -103,8 +95,10 @@ metrics:
           unit: percentage
           dimensions:
             - name: used
+          chart_type: line
         - name: dnsmasq_dhcp.dhcp_range_allocated_leases
           description: DHCP Range Allocated Leases
           unit: leases
           dimensions:
             - name: allocated
+          chart_type: line

--- a/modules/dnsquery/metadata.yaml
+++ b/modules/dnsquery/metadata.yaml
@@ -2,54 +2,53 @@ name: dnsquery
 title: DNS query collector
 overview:
   application:
-    description: |
-      TBD
+    description: "TBD\n"
   collector:
-    description: |
-      This module provides DNS query round-trip time (RTT).
+    description: "This module provides DNS query round-trip time (RTT).\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: All options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
-          required: no
+          required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
-          required: no
+          required: false
+          default_value: 0
         - name: domains
-          description: Domain or subdomains to query. The collector will choose a random domain from the list on every iteration.
-          default: "-"
-          required: yes
+          description: Domain or subdomains to query. The collector will choose a
+            random domain from the list on every iteration.
+          required: true
+          default_value: '-'
         - name: servers
           description: Servers to query.
-          default: "-"
-          required: yes
+          required: true
+          default_value: '-'
         - name: port
           description: DNS server port.
-          default: 53
-          required: no
+          required: false
+          default_value: 53
         - name: network
-          description: "Network protocol name. Vailable options: udp, tcp, tcp-tls."
-          default: "udp"
-          required: no
+          description: 'Network protocol name. Vailable options: udp, tcp, tcp-tls.'
+          required: false
+          default_value: udp
         - name: record_types
-          description: "Query record type. Available options: A, AAAA, CNAME, MX, NS, PTR, TXT, SOA, SPF, TXT, SRV."
-          default: "A"
-          required: no
+          description: 'Query record type. Available options: A, AAAA, CNAME, MX,
+            NS, PTR, TXT, SOA, SPF, TXT, SRV.'
+          required: false
+          default_value: A
         - name: timeout
-          description: "Query read timeout."
-          default: 2
-          required: no
+          description: Query read timeout.
+          required: false
+          default_value: 2
     examples:
       list:
         - name: Basic
@@ -57,19 +56,14 @@ setup:
           folding:
             title: Example
             enabled: true
-          data: |
-            jobs:
-              - name: job1
-                record_types:
-                  - A
-                  - AAAA
-                domains:
-                  - google.com
-                  - github.com
-                  - reddit.com
-                servers:
-                  - 8.8.8.8
-                  - 8.8.4.4
+          config: "jobs:\n  - name: job1\n    record_types:\n      - A\n      - AAAA\n\
+            \    domains:\n      - google.com\n      - github.com\n      - reddit.com\n\
+            \    servers:\n      - 8.8.8.8\n      - 8.8.4.4\n"
+      folding:
+        title: Config options
+        enabled: true
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -78,7 +72,8 @@ metrics:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: server
       description: TBD
       labels:
@@ -96,8 +91,10 @@ metrics:
             - name: success
             - name: network_error
             - name: dns_error
+          chart_type: line
         - name: dns_query.query_time
           description: DNS Query Time
           unit: seconds
           dimensions:
             - name: query_time
+          chart_type: line

--- a/modules/dockerhub/metadata.yaml
+++ b/modules/dockerhub/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -13,28 +68,34 @@ metrics:
           unit: pulls
           dimensions:
             - name: sum
+          chart_type: line
         - name: dockerhub.pulls
           description: Pulls
           unit: pulls
           dimensions:
             - name: a dimension per repository
+          chart_type: stacked
         - name: dockerhub.pulls_rate
           description: Pulls Rate
           unit: pulls/s
           dimensions:
             - name: a dimension per repository
+          chart_type: stacked
         - name: dockerhub.stars
           description: Stars
           unit: stars
           dimensions:
             - name: a dimension per repository
+          chart_type: stacked
         - name: dockerhub.status
           description: Current Status
           unit: status
           dimensions:
             - name: a dimension per repository
+          chart_type: line
         - name: dockerhub.last_updated
           description: Time Since Last Updated
           unit: seconds
           dimensions:
             - name: a dimension per repository
+          chart_type: line

--- a/modules/energid/metadata.yaml
+++ b/modules/energid/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -14,11 +69,13 @@ metrics:
           dimensions:
             - name: blocks
             - name: headers
+          chart_type: area
         - name: energid.difficulty
           description: Blockchain difficulty
           unit: difficulty
           dimensions:
             - name: difficulty
+          chart_type: line
         - name: energid.mempool
           description: Memory pool
           unit: bytes
@@ -26,6 +83,7 @@ metrics:
             - name: max
             - name: usage
             - name: tx_size
+          chart_type: area
         - name: energid.secmem
           description: Secure memory
           unit: bytes
@@ -34,19 +92,23 @@ metrics:
             - name: used
             - name: free
             - name: locked
+          chart_type: area
         - name: energid.network
           description: Network
           unit: connections
           dimensions:
             - name: connections
+          chart_type: line
         - name: energid.timeoffset
           description: Network time offset
           unit: seconds
           dimensions:
             - name: timeoffset
+          chart_type: line
         - name: energid.utxo_transactions
           description: Transactions
           unit: transactions
           dimensions:
             - name: transactions
             - name: output_transactions
+          chart_type: line

--- a/modules/envoy/metadata.yaml
+++ b/modules/envoy/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -16,42 +71,50 @@ metrics:
             - name: draining
             - name: pre_initializing
             - name: initializing
+          chart_type: line
         - name: envoy.server_connections_count
           description: Server current connections
           unit: connections
           dimensions:
             - name: connections
+          chart_type: line
         - name: envoy.server_parent_connections_count
           description: Server current parent connections
           unit: connections
           dimensions:
             - name: connections
+          chart_type: line
         - name: envoy.server_memory_allocated_size
           description: Server memory allocated size
           unit: bytes
           dimensions:
             - name: allocated
+          chart_type: line
         - name: envoy.server_memory_heap_size
           description: Server memory heap size
           unit: bytes
           dimensions:
             - name: heap
+          chart_type: line
         - name: envoy.server_memory_physical_size
           description: Server memory physical size
           unit: bytes
           dimensions:
             - name: physical
+          chart_type: line
         - name: envoy.server_uptime
           description: Server uptime
           unit: seconds
           dimensions:
             - name: uptime
+          chart_type: line
         - name: envoy.cluster_manager_cluster_count
           description: Cluster manager current clusters
           unit: clusters
           dimensions:
             - name: active
             - name: not_active
+          chart_type: line
         - name: envoy.cluster_manager_cluster_changes_rate
           description: Cluster manager cluster changes
           unit: clusters/s
@@ -59,26 +122,31 @@ metrics:
             - name: added
             - name: modified
             - name: removed
+          chart_type: line
         - name: envoy.cluster_manager_cluster_updates_rate
           description: Cluster manager updates
           unit: updates/s
           dimensions:
             - name: cluster
+          chart_type: line
         - name: envoy.cluster_manager_cluster_updated_via_merge_rate
           description: Cluster manager updates applied as merged updates
           unit: updates/s
           dimensions:
             - name: via_merge
+          chart_type: line
         - name: envoy.cluster_manager_update_merge_cancelled_rate
           description: Cluster manager cancelled merged updates
           unit: updates/s
           dimensions:
             - name: merge_cancelled
+          chart_type: line
         - name: envoy.cluster_manager_update_out_of_merge_window_rate
           description: Cluster manager out of a merge window updates
           unit: updates/s
           dimensions:
             - name: out_of_merge_window
+          chart_type: line
         - name: envoy.cluster_membership_endpoints_count
           description: Cluster membership current endpoints
           unit: endpoints
@@ -86,11 +154,13 @@ metrics:
             - name: healthy
             - name: degraded
             - name: excluded
+          chart_type: line
         - name: envoy.cluster_membership_changes_rate
           description: Cluster membership changes
           unit: changes/s
           dimensions:
             - name: membership
+          chart_type: line
         - name: envoy.cluster_membership_updates_rate
           description: Cluster membership updates
           unit: updates/s
@@ -99,16 +169,19 @@ metrics:
             - name: failure
             - name: empty
             - name: no_rebuild
+          chart_type: line
         - name: envoy.cluster_upstream_cx_active_count
           description: Cluster upstream current active connections
           unit: connections
           dimensions:
             - name: active
+          chart_type: line
         - name: envoy.cluster_upstream_cx_rate
           description: Cluster upstream connections
           unit: connections/s
           dimensions:
             - name: created
+          chart_type: line
         - name: envoy.cluster_upstream_cx_http_rate
           description: Cluster upstream connections by HTTP version
           unit: connections/s
@@ -116,44 +189,52 @@ metrics:
             - name: http1
             - name: http2
             - name: http3
+          chart_type: line
         - name: envoy.cluster_upstream_cx_destroy_rate
           description: Cluster upstream destroyed connections
           unit: connections/s
           dimensions:
             - name: local
             - name: remote
+          chart_type: line
         - name: envoy.cluster_upstream_cx_connect_fail_rate
           description: Cluster upstream failed connections
           unit: connections/s
           dimensions:
             - name: failed
+          chart_type: line
         - name: envoy.cluster_upstream_cx_connect_timeout_rate
           description: Cluster upstream timed out connections
           unit: connections/s
           dimensions:
             - name: timeout
+          chart_type: line
         - name: envoy.cluster_upstream_cx_bytes_rate
           description: Cluster upstream connection traffic
           unit: bytes/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: line
         - name: envoy.cluster_upstream_cx_bytes_buffered_size
           description: Cluster upstream current connection buffered size
           unit: bytes
           dimensions:
             - name: received
             - name: send
+          chart_type: line
         - name: envoy.cluster_upstream_rq_active_count
           description: Cluster upstream current active requests
           unit: requests
           dimensions:
             - name: active
+          chart_type: line
         - name: envoy.cluster_upstream_rq_rate
           description: Cluster upstream requests
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: envoy.cluster_upstream_rq_failed_rate
           description: Cluster upstream failed requests
           unit: requests/s
@@ -165,38 +246,45 @@ metrics:
             - name: per_try_timeout
             - name: reset_local
             - name: reset_remote
+          chart_type: line
         - name: envoy.cluster_upstream_rq_pending_active_count
           description: Cluster upstream current active pending requests
           unit: requests
           dimensions:
             - name: active_pending
+          chart_type: line
         - name: envoy.cluster_upstream_rq_pending_rate
           description: Cluster upstream pending requests
           unit: requests/s
           dimensions:
             - name: pending
+          chart_type: line
         - name: envoy.cluster_upstream_rq_pending_failed_rate
           description: Cluster upstream failed pending requests
           unit: requests/s
           dimensions:
             - name: overflow
             - name: failure_eject
+          chart_type: line
         - name: envoy.cluster_upstream_rq_retry_rate
           description: Cluster upstream request retries
           unit: retries/s
           dimensions:
             - name: request
+          chart_type: line
         - name: envoy.cluster_upstream_rq_retry_success_rate
           description: Cluster upstream request successful retries
           unit: retries/s
           dimensions:
             - name: success
+          chart_type: line
         - name: envoy.cluster_upstream_rq_retry_backoff_rate
           description: Cluster upstream request backoff retries
           unit: retries/s
           dimensions:
             - name: exponential
             - name: ratelimited
+          chart_type: line
         - name: envoy.listener_manager_listeners_count
           description: Listener manager current listeners
           unit: listeners
@@ -204,6 +292,7 @@ metrics:
             - name: active
             - name: warming
             - name: draining
+          chart_type: line
         - name: envoy.listener_manager_listener_changes_rate
           description: Listener manager listener changes
           unit: listeners/s
@@ -212,6 +301,7 @@ metrics:
             - name: modified
             - name: removed
             - name: stopped
+          chart_type: line
         - name: envoy.listener_manager_listener_object_events_rate
           description: Listener manager listener object events
           unit: objects/s
@@ -219,26 +309,31 @@ metrics:
             - name: create_success
             - name: create_failure
             - name: in_place_updated
+          chart_type: line
         - name: envoy.listener_admin_downstream_cx_active_count
           description: Listener admin downstream current active connections
           unit: connections
           dimensions:
             - name: active
+          chart_type: line
         - name: envoy.listener_admin_downstream_cx_rate
           description: Listener admin downstream connections
           unit: connections/s
           dimensions:
             - name: created
+          chart_type: line
         - name: envoy.listener_admin_downstream_cx_destroy_rate
           description: Listener admin downstream destroyed connections
           unit: connections/s
           dimensions:
             - name: destroyed
+          chart_type: line
         - name: envoy.listener_admin_downstream_cx_transport_socket_connect_timeout_rate
           description: Listener admin downstream timed out connections
           unit: connections/s
           dimensions:
             - name: timeout
+          chart_type: line
         - name: envoy.listener_admin_downstream_cx_rejected_rate
           description: Listener admin downstream rejected connections
           unit: connections/s
@@ -246,48 +341,57 @@ metrics:
             - name: overflow
             - name: overload
             - name: global_overflow
+          chart_type: line
         - name: envoy.listener_admin_downstream_listener_filter_remote_close_rate
           description: Listener admin downstream connections closed by remote when
             peek data for listener filters
           unit: connections/s
           dimensions:
             - name: closed
+          chart_type: line
         - name: envoy.listener_admin_downstream_listener_filter_error_rate
           description: Listener admin downstream read errors when peeking data for
             listener filters
           unit: errors/s
           dimensions:
             - name: read
+          chart_type: line
         - name: envoy.listener_admin_downstream_pre_cx_active_count
           description: Listener admin downstream current active sockets
           unit: sockets
           dimensions:
             - name: active
+          chart_type: line
         - name: envoy.listener_admin_downstream_pre_cx_timeout_rate
           description: Listener admin downstream timed out sockets
           unit: sockets/s
           dimensions:
             - name: timeout
+          chart_type: line
         - name: envoy.listener_downstream_cx_active_count
           description: Listener downstream current active connections
           unit: connections
           dimensions:
             - name: active
+          chart_type: line
         - name: envoy.listener_downstream_cx_rate
           description: Listener downstream connections
           unit: connections/s
           dimensions:
             - name: created
+          chart_type: line
         - name: envoy.listener_downstream_cx_destroy_rate
           description: Listener downstream destroyed connections
           unit: connections/s
           dimensions:
             - name: destroyed
+          chart_type: line
         - name: envoy.listener_downstream_cx_transport_socket_connect_timeout_rate
           description: Listener downstream timed out connections
           unit: connections/s
           dimensions:
             - name: timeout
+          chart_type: line
         - name: envoy.listener_downstream_cx_rejected_rate
           description: Listener downstream rejected connections
           unit: connections/s
@@ -295,25 +399,30 @@ metrics:
             - name: overflow
             - name: overload
             - name: global_overflow
+          chart_type: line
         - name: envoy.listener_downstream_listener_filter_remote_close_rate
           description: Listener downstream connections closed by remote when peek
             data for listener filters
           unit: connections/s
           dimensions:
             - name: closed
+          chart_type: line
         - name: envoy.listener_downstream_listener_filter_error_rate
           description: Listener downstream read errors when peeking data for listener
             filters
           unit: errors/s
           dimensions:
             - name: read
+          chart_type: line
         - name: envoy.listener_downstream_pre_cx_active_count
           description: Listener downstream current active sockets
           unit: sockets
           dimensions:
             - name: active
+          chart_type: line
         - name: envoy.listener_downstream_pre_cx_timeout_rate
           description: Listener downstream timed out sockets
           unit: sockets/s
           dimensions:
             - name: timeout
+          chart_type: line

--- a/modules/filecheck/metadata.yaml
+++ b/modules/filecheck/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -13,33 +68,40 @@ metrics:
           unit: boolean
           dimensions:
             - name: a dimension per file
+          chart_type: line
         - name: filecheck.file_mtime_ago
           description: File Time Since the Last Modification
           unit: seconds
           dimensions:
             - name: a dimension per file
+          chart_type: line
         - name: filecheck.file_size
           description: File Size
           unit: bytes
           dimensions:
             - name: a dimension per file
+          chart_type: line
         - name: filecheck.dir_existence
           description: 'Dir Existence (0: not exists, 1: exists)'
           unit: boolean
           dimensions:
             - name: a dimension per directory
+          chart_type: line
         - name: filecheck.dir_mtime_ago
           description: Dir Time Since the Last Modification
           unit: seconds
           dimensions:
             - name: a dimension per directory
+          chart_type: line
         - name: filecheck.dir_num_of_files
           description: Dir Number of Files
           unit: files
           dimensions:
             - name: a dimension per directory
+          chart_type: line
         - name: filecheck.dir_size
           description: Dir Size
           unit: bytes
           dimensions:
             - name: a dimension per directory
+          chart_type: line

--- a/modules/fluentd/metadata.yaml
+++ b/modules/fluentd/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -13,13 +68,16 @@ metrics:
           unit: count
           dimensions:
             - name: a dimension per plugin
+          chart_type: line
         - name: fluentd.buffer_queue_length
           description: Plugin Buffer Queue Length
           unit: queue_length
           dimensions:
             - name: a dimension per plugin
+          chart_type: line
         - name: fluentd.buffer_total_queued_size
           description: Plugin Buffer Total Size
           unit: queued_size
           dimensions:
             - name: a dimension per plugin
+          chart_type: line

--- a/modules/freeradius/metadata.yaml
+++ b/modules/freeradius/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -14,6 +69,7 @@ metrics:
           dimensions:
             - name: requests
             - name: responses
+          chart_type: line
         - name: freeradius.authentication_access_responses
           description: Authentication Responses
           unit: packets/s
@@ -21,6 +77,7 @@ metrics:
             - name: accepts
             - name: rejects
             - name: challenges
+          chart_type: line
         - name: freeradius.bad_authentication
           description: Bad Authentication Requests
           unit: packets/s
@@ -30,12 +87,14 @@ metrics:
             - name: invalid
             - name: malformed
             - name: unknown-types
+          chart_type: line
         - name: freeradius.proxy_authentication
           description: Authentication
           unit: packets/s
           dimensions:
             - name: requests
             - name: responses
+          chart_type: line
         - name: freeradius.proxy_authentication_access_responses
           description: Authentication Responses
           unit: packets/s
@@ -43,6 +102,7 @@ metrics:
             - name: accepts
             - name: rejects
             - name: challenges
+          chart_type: line
         - name: freeradius.proxy_bad_authentication
           description: Bad Authentication Requests
           unit: packets/s
@@ -52,12 +112,14 @@ metrics:
             - name: invalid
             - name: malformed
             - name: unknown-types
+          chart_type: line
         - name: freeradius.accounting
           description: Accounting
           unit: packets/s
           dimensions:
             - name: requests
             - name: responses
+          chart_type: line
         - name: freeradius.bad_accounting
           description: Bad Accounting Requests
           unit: packets/s
@@ -67,12 +129,14 @@ metrics:
             - name: invalid
             - name: malformed
             - name: unknown-types
+          chart_type: line
         - name: freeradius.proxy_accounting
           description: Accounting
           unit: packets/s
           dimensions:
             - name: requests
             - name: responses
+          chart_type: line
         - name: freeradius.proxy_bad_accounting
           description: Bad Accounting Requests
           unit: packets/s
@@ -82,3 +146,4 @@ metrics:
             - name: invalid
             - name: malformed
             - name: unknown-types
+          chart_type: line

--- a/modules/geth/metadata.yaml
+++ b/modules/geth/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -14,35 +69,41 @@ metrics:
           dimensions:
             - name: reads
             - name: writes
+          chart_type: line
         - name: geth.eth_db_chaindata_ancient_io
           description: Session ancient Chaindata
           unit: bytes
           dimensions:
             - name: reads
             - name: writes
+          chart_type: line
         - name: geth.eth_db_chaindata_disk_io
           description: Session chaindata on disk
           unit: bytes
           dimensions:
             - name: reads
             - name: writes
+          chart_type: line
         - name: geth.goroutines
           description: Number of goroutines
           unit: goroutines
           dimensions:
             - name: goroutines
+          chart_type: line
         - name: geth.eth_db_chaindata_disk_io_rate
           description: On disk Chaindata rate
           unit: bytes/s
           dimensions:
             - name: reads
             - name: writes
+          chart_type: line
         - name: geth.chaindata_db_size
           description: Chaindata Size
           unit: bytes
           dimensions:
             - name: level_db
             - name: ancient_db
+          chart_type: line
         - name: geth.chainhead
           description: Chainhead
           unit: block
@@ -50,6 +111,7 @@ metrics:
             - name: block
             - name: receipt
             - name: header
+          chart_type: line
         - name: geth.tx_pool_pending
           description: Pending Transaction Pool
           unit: transactions
@@ -61,6 +123,7 @@ metrics:
             - name: no_funds
             - name: ratelimit
             - name: replace
+          chart_type: line
         - name: geth.tx_pool_current
           description: Transaction Pool
           unit: transactions
@@ -69,6 +132,7 @@ metrics:
             - name: pending
             - name: local
             - name: pool
+          chart_type: line
         - name: geth.tx_pool_queued
           description: Queued Transaction Pool
           unit: transactions
@@ -77,37 +141,44 @@ metrics:
             - name: eviction
             - name: no_funds
             - name: ratelimit
+          chart_type: line
         - name: geth.p2p_bandwidth
           description: P2P bandwidth
           unit: bytes/s
           dimensions:
             - name: ingress
             - name: egress
+          chart_type: line
         - name: geth.reorgs
           description: Executed Reorgs
           unit: reorgs
           dimensions:
             - name: executed
+          chart_type: line
         - name: geth.reorgs_blocks
           description: Blocks Added/Removed from Reorg
           unit: blocks
           dimensions:
             - name: added
             - name: dropped
+          chart_type: line
         - name: geth.p2p_peers
           description: Number of Peers
           unit: peers
           dimensions:
             - name: peers
+          chart_type: line
         - name: geth.p2p_peers_calls
           description: P2P Serves and Dials
           unit: calls/s
           dimensions:
             - name: dials
             - name: serves
+          chart_type: line
         - name: geth.rpc_calls
           description: rpc calls
           unit: calls/s
           dimensions:
             - name: failed
             - name: successful
+          chart_type: line

--- a/modules/haproxy/metadata.yaml
+++ b/modules/haproxy/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -13,26 +68,31 @@ metrics:
           unit: sessions
           dimensions:
             - name: a dimension per proxy
+          chart_type: line
         - name: haproxy.backend_sessions
           description: Sessions rate
           unit: sessions/s
           dimensions:
             - name: a dimension per proxy
+          chart_type: line
         - name: haproxy.backend_response_time_average
           description: Average response time for last 1024 successful connections
           unit: milliseconds
           dimensions:
             - name: a dimension per proxy
+          chart_type: line
         - name: haproxy.backend_queue_time_average
           description: Average queue time for last 1024 successful connections
           unit: milliseconds
           dimensions:
             - name: a dimension per proxy
+          chart_type: line
         - name: haproxy.backend_current_queue
           description: Current number of queued requests
           unit: requests
           dimensions:
             - name: a dimension per proxy
+          chart_type: line
     - name: proxy
       description: TBD
       labels: []
@@ -47,9 +107,11 @@ metrics:
             - name: 4xx
             - name: 5xx
             - name: other
+          chart_type: stacked
         - name: haproxy.backend_network_io
           description: Network traffic
           unit: bytes/s
           dimensions:
             - name: in
             - name: out
+          chart_type: area

--- a/modules/hdfs/metadata.yaml
+++ b/modules/hdfs/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -14,22 +69,26 @@ metrics:
           dimensions:
             - name: committed
             - name: used
+          chart_type: area
         - name: hdfs.gc_count_total
           description: GC Events
           unit: events/s
           dimensions:
             - name: gc
+          chart_type: line
         - name: hdfs.gc_time_total
           description: GC Time
           unit: ms
           dimensions:
             - name: ms
+          chart_type: line
         - name: hdfs.gc_threshold
           description: Number of Times That the GC Threshold is Exceeded
           unit: events/s
           dimensions:
             - name: info
             - name: warn
+          chart_type: line
         - name: hdfs.threads
           description: Number of Threads
           unit: num
@@ -40,6 +99,7 @@ metrics:
             - name: waiting
             - name: timed_waiting
             - name: terminated
+          chart_type: stacked
         - name: hdfs.logs_total
           description: Number of Logs
           unit: logs/s
@@ -48,70 +108,83 @@ metrics:
             - name: error
             - name: warn
             - name: fatal
+          chart_type: stacked
         - name: hdfs.rpc_bandwidth
           description: RPC Bandwidth
           unit: kilobits/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: area
         - name: hdfs.rpc_calls
           description: RPC Calls
           unit: calls/s
           dimensions:
             - name: calls
+          chart_type: line
         - name: hdfs.open_connections
           description: RPC Open Connections
           unit: connections
           dimensions:
             - name: open
+          chart_type: line
         - name: hdfs.call_queue_length
           description: RPC Call Queue Length
           unit: num
           dimensions:
             - name: length
+          chart_type: line
         - name: hdfs.avg_queue_time
           description: RPC Avg Queue Time
           unit: ms
           dimensions:
             - name: time
+          chart_type: line
         - name: hdfs.avg_processing_time
           description: RPC Avg Processing Time
           unit: ms
           dimensions:
             - name: time
+          chart_type: line
         - name: hdfs.capacity
           description: Capacity Across All Datanodes
           unit: KiB
           dimensions:
             - name: remaining
             - name: used
+          chart_type: stacked
         - name: hdfs.used_capacity
           description: Used Capacity Across All Datanodes
           unit: KiB
           dimensions:
             - name: dfs
             - name: non_dfs
+          chart_type: stacked
         - name: hdfs.load
           description: Number of Concurrent File Accesses (read/write) Across All
             DataNodes
           unit: load
           dimensions:
             - name: load
+          chart_type: line
         - name: hdfs.volume_failures_total
           description: Number of Volume Failures Across All Datanodes
           unit: events/s
           dimensions:
             - name: failures
+          chart_type: line
         - name: hdfs.files_total
           description: Number of Tracked Files
           unit: num
           dimensions:
             - name: files
+          chart_type: line
         - name: hdfs.blocks_total
           description: Number of Allocated Blocks in the System
           unit: num
           dimensions:
             - name: blocks
+          chart_type: line
         - name: hdfs.blocks
           description: Number of Problem Blocks (can point to an unhealthy cluster)
           unit: num
@@ -119,6 +192,7 @@ metrics:
             - name: corrupt
             - name: missing
             - name: under_replicated
+          chart_type: line
         - name: hdfs.data_nodes
           description: Number of Data Nodes By Status
           unit: num
@@ -126,26 +200,31 @@ metrics:
             - name: live
             - name: dead
             - name: stale
+          chart_type: stacked
         - name: hdfs.datanode_capacity
           description: Capacity
           unit: KiB
           dimensions:
             - name: remaining
             - name: used
+          chart_type: stacked
         - name: hdfs.datanode_used_capacity
           description: Used Capacity
           unit: KiB
           dimensions:
             - name: dfs
             - name: non_dfs
+          chart_type: stacked
         - name: hdfs.datanode_failed_volumes
           description: Number of Failed Volumes
           unit: num
           dimensions:
             - name: failed volumes
+          chart_type: line
         - name: hdfs.datanode_bandwidth
           description: Bandwidth
           unit: KiB/s
           dimensions:
             - name: reads
             - name: writes
+          chart_type: area

--- a/modules/httpcheck/metadata.yaml
+++ b/modules/httpcheck/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels:
@@ -15,11 +70,13 @@ metrics:
           unit: ms
           dimensions:
             - name: time
+          chart_type: line
         - name: httpcheck.response_length
           description: HTTP Response Body Length
           unit: characters
           dimensions:
             - name: length
+          chart_type: line
         - name: httpcheck.status
           description: HTTP Check Status
           unit: boolean
@@ -29,8 +86,10 @@ metrics:
             - name: timeout
             - name: bad_content
             - name: bad_status
+          chart_type: line
         - name: httpcheck.in_state
           description: HTTP Current State Duration
           unit: boolean
           dimensions:
             - name: time
+          chart_type: line

--- a/modules/isc_dhcpd/metadata.yaml
+++ b/modules/isc_dhcpd/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -13,13 +68,16 @@ metrics:
           unit: leases
           dimensions:
             - name: active
+          chart_type: line
         - name: isc_dhcpd.pool_active_leases
           description: Pool Active Leases
           unit: leases
           dimensions:
             - name: a dimension per DHCP pool
+          chart_type: line
         - name: isc_dhcpd.pool_utilization
           description: Pool Utilization
           unit: percentage
           dimensions:
             - name: a dimension per DHCP pool
+          chart_type: line

--- a/modules/k8s_kubelet/metadata.yaml
+++ b/modules/k8s_kubelet/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -13,11 +68,13 @@ metrics:
           unit: requests/s
           dimensions:
             - name: rejected
+          chart_type: line
         - name: k8s_kubelet.apiserver_storage_data_key_generation_failures
           description: API Server Failed Data Encryption Key(DEK) Generation Operations
           unit: events/s
           dimensions:
             - name: failures
+          chart_type: line
         - name: k8s_kubelet.apiserver_storage_data_key_generation_latencies
           description: API Server Latencies Of Data Encryption Key(DEK) Generation
             Operations
@@ -38,6 +95,7 @@ metrics:
             - name: 20480_µs
             - name: 40960_µs
             - name: +Inf
+          chart_type: stacked
         - name: k8s_kubelet.apiserver_storage_data_key_generation_latencies_percent
           description: API Server Latencies Of Data Encryption Key(DEK) Generation
             Operations Percentage
@@ -58,51 +116,61 @@ metrics:
             - name: 20480_µs
             - name: 40960_µs
             - name: +Inf
+          chart_type: stacked
         - name: k8s_kubelet.apiserver_storage_envelope_transformation_cache_misses
           description: API Server Storage Envelope Transformation Cache Misses
           unit: events/s
           dimensions:
             - name: cache misses
+          chart_type: line
         - name: k8s_kubelet.kubelet_containers_running
           description: Number Of Containers Currently Running
           unit: running_containers
           dimensions:
             - name: total
+          chart_type: line
         - name: k8s_kubelet.kubelet_pods_running
           description: Number Of Pods Currently Running
           unit: running_pods
           dimensions:
             - name: total
+          chart_type: line
         - name: k8s_kubelet.kubelet_pods_log_filesystem_used_bytes
           description: Bytes Used By The Pod Logs On The Filesystem
           unit: B
           dimensions:
             - name: a dimension per namespace and pod
+          chart_type: stacked
         - name: k8s_kubelet.kubelet_runtime_operations
           description: Runtime Operations By Type
           unit: operations/s
           dimensions:
             - name: a dimension per operation type
+          chart_type: stacked
         - name: k8s_kubelet.kubelet_runtime_operations_errors
           description: Runtime Operations Errors By Type
           unit: errors/s
           dimensions:
             - name: a dimension per operation type
+          chart_type: stacked
         - name: k8s_kubelet.kubelet_docker_operations
           description: Docker Operations By Type
           unit: operations/s
           dimensions:
             - name: a dimension per operation type
+          chart_type: stacked
         - name: k8s_kubelet.kubelet_docker_operations_errors
           description: Docker Operations Errors By Type
           unit: errors/s
           dimensions:
             - name: a dimension per operation type
+          chart_type: stacked
         - name: k8s_kubelet.kubelet_node_config_error
           description: Node Configuration-Related Error
           unit: bool
           dimensions:
             - name: experiencing_error
+          chart_type: line
         - name: k8s_kubelet.kubelet_pleg_relist_interval_microseconds
           description: PLEG Relisting Interval Summary
           unit: microseconds
@@ -110,6 +178,7 @@ metrics:
             - name: '0.5'
             - name: '0.9'
             - name: '0.99'
+          chart_type: stacked
         - name: k8s_kubelet.kubelet_pleg_relist_latency_microseconds
           description: PLEG Relisting Latency Summary
           unit: microseconds
@@ -117,22 +186,26 @@ metrics:
             - name: '0.5'
             - name: '0.9'
             - name: '0.99'
+          chart_type: stacked
         - name: k8s_kubelet.kubelet_token_requests
           description: Token() Requests To The Alternate Token Source
           unit: token_requests/s
           dimensions:
             - name: total
             - name: failed
+          chart_type: line
         - name: k8s_kubelet.rest_client_requests_by_code
           description: HTTP Requests By Status Code
           unit: requests/s
           dimensions:
             - name: a dimension per HTTP status code
+          chart_type: stacked
         - name: k8s_kubelet.rest_client_requests_by_method
           description: HTTP Requests By Status Method
           unit: requests/s
           dimensions:
             - name: a dimension per HTTP method
+          chart_type: stacked
     - name: volume manager
       description: TBD
       labels: []
@@ -143,3 +216,4 @@ metrics:
           dimensions:
             - name: actual
             - name: desired
+          chart_type: line

--- a/modules/k8s_kubeproxy/metadata.yaml
+++ b/modules/k8s_kubeproxy/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -13,6 +68,7 @@ metrics:
           unit: events/s
           dimensions:
             - name: sync_proxy_rules
+          chart_type: line
         - name: k8s_kubeproxy.kubeproxy_sync_proxy_rules_latency_microsecond
           description: Sync Proxy Rules Latency
           unit: observes/s
@@ -33,6 +89,7 @@ metrics:
             - name: '8.192'
             - name: '16.384'
             - name: +Inf
+          chart_type: stacked
         - name: k8s_kubeproxy.kubeproxy_sync_proxy_rules_latency
           description: Sync Proxy Rules Latency Percentage
           unit: percentage
@@ -53,16 +110,19 @@ metrics:
             - name: '8.192'
             - name: '16.384'
             - name: +Inf
+          chart_type: stacked
         - name: k8s_kubeproxy.rest_client_requests_by_code
           description: HTTP Requests By Status Code
           unit: requests/s
           dimensions:
             - name: a dimension per HTTP status code
+          chart_type: stacked
         - name: k8s_kubeproxy.rest_client_requests_by_method
           description: HTTP Requests By Status Method
           unit: requests/s
           dimensions:
             - name: a dimension per HTTP method
+          chart_type: stacked
         - name: k8s_kubeproxy.http_request_duration
           description: HTTP Requests Duration
           unit: microseconds
@@ -70,3 +130,4 @@ metrics:
             - name: '0.5'
             - name: '0.9'
             - name: '0.99'
+          chart_type: stacked

--- a/modules/k8s_state/metadata.yaml
+++ b/modules/k8s_state/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: node
       description: TBD
       labels:
@@ -21,74 +76,88 @@ metrics:
           unit: '%'
           dimensions:
             - name: requests
+          chart_type: line
         - name: k8s_state.node_allocatable_cpu_requests_used
           description: CPU requests used
           unit: millicpu
           dimensions:
             - name: requests
+          chart_type: line
         - name: k8s_state.node_allocatable_cpu_limits_utilization
           description: CPU limits utilization
           unit: '%'
           dimensions:
             - name: limits
+          chart_type: line
         - name: k8s_state.node_allocatable_cpu_limits_used
           description: CPU limits used
           unit: millicpu
           dimensions:
             - name: limits
+          chart_type: line
         - name: k8s_state.node_allocatable_mem_requests_utilization
           description: Memory requests utilization
           unit: '%'
           dimensions:
             - name: requests
+          chart_type: line
         - name: k8s_state.node_allocatable_mem_requests_used
           description: Memory requests used
           unit: bytes
           dimensions:
             - name: requests
+          chart_type: line
         - name: k8s_state.node_allocatable_mem_limits_utilization
           description: Memory limits utilization
           unit: '%'
           dimensions:
             - name: limits
+          chart_type: line
         - name: k8s_state.node_allocatable_mem_limits_used
           description: Memory limits used
           unit: bytes
           dimensions:
             - name: limits
+          chart_type: line
         - name: k8s_state.node_allocatable_pods_utilization
           description: Pods resource utilization
           unit: '%'
           dimensions:
             - name: allocated
+          chart_type: line
         - name: k8s_state.node_allocatable_pods_usage
           description: Pods resource usage
           unit: pods
           dimensions:
             - name: available
             - name: allocated
+          chart_type: stacked
         - name: k8s_state.node_condition
           description: Condition status
           unit: status
           dimensions:
             - name: a dimension per condition
+          chart_type: line
         - name: k8s_state.node_schedulability
           description: Schedulability
           unit: state
           dimensions:
             - name: schedulable
             - name: unschedulable
+          chart_type: line
         - name: k8s_state.node_pods_readiness
           description: Pods readiness
           unit: '%'
           dimensions:
             - name: ready
+          chart_type: line
         - name: k8s_state.node_pods_readiness_state
           description: Pods readiness state
           unit: pods
           dimensions:
             - name: ready
             - name: unready
+          chart_type: line
         - name: k8s_state.node_pods_condition
           description: Pods condition
           unit: pods
@@ -97,6 +166,7 @@ metrics:
             - name: pod_scheduled
             - name: pod_initialized
             - name: containers_ready
+          chart_type: line
         - name: k8s_state.node_pods_phase
           description: Pods phase
           unit: pods
@@ -105,12 +175,14 @@ metrics:
             - name: failed
             - name: succeeded
             - name: pending
+          chart_type: stacked
         - name: k8s_state.node_containers
           description: Containers
           unit: containers
           dimensions:
             - name: containers
             - name: init_containers
+          chart_type: line
         - name: k8s_state.node_containers_state
           description: Containers state
           unit: containers
@@ -118,6 +190,7 @@ metrics:
             - name: running
             - name: waiting
             - name: terminated
+          chart_type: stacked
         - name: k8s_state.node_init_containers_state
           description: Init containers state
           unit: containers
@@ -125,11 +198,13 @@ metrics:
             - name: running
             - name: waiting
             - name: terminated
+          chart_type: stacked
         - name: k8s_state.node_age
           description: Age
           unit: seconds
           dimensions:
             - name: age
+          chart_type: line
     - name: pod
       description: TBD
       labels:
@@ -159,21 +234,25 @@ metrics:
           unit: millicpu
           dimensions:
             - name: requests
+          chart_type: line
         - name: k8s_state.pod_cpu_limits_used
           description: CPU limits used
           unit: millicpu
           dimensions:
             - name: limits
+          chart_type: line
         - name: k8s_state.pod_mem_requests_used
           description: Memory requests used
           unit: bytes
           dimensions:
             - name: requests
+          chart_type: line
         - name: k8s_state.pod_mem_limits_used
           description: Memory limits used
           unit: bytes
           dimensions:
             - name: limits
+          chart_type: line
         - name: k8s_state.pod_condition
           description: Condition
           unit: state
@@ -182,6 +261,7 @@ metrics:
             - name: pod_scheduled
             - name: pod_initialized
             - name: containers_ready
+          chart_type: line
         - name: k8s_state.pod_phase
           description: Phase
           unit: state
@@ -190,17 +270,20 @@ metrics:
             - name: failed
             - name: succeeded
             - name: pending
+          chart_type: line
         - name: k8s_state.pod_age
           description: Age
           unit: seconds
           dimensions:
             - name: age
+          chart_type: line
         - name: k8s_state.pod_containers
           description: Containers
           unit: containers
           dimensions:
             - name: containers
             - name: init_containers
+          chart_type: line
         - name: k8s_state.pod_containers_state
           description: Containers state
           unit: containers
@@ -208,6 +291,7 @@ metrics:
             - name: running
             - name: waiting
             - name: terminated
+          chart_type: stacked
         - name: k8s_state.pod_init_containers_state
           description: Init containers state
           unit: containers
@@ -215,6 +299,7 @@ metrics:
             - name: running
             - name: waiting
             - name: terminated
+          chart_type: stacked
     - name: container
       description: TBD
       labels:
@@ -248,11 +333,13 @@ metrics:
           unit: state
           dimensions:
             - name: ready
+          chart_type: line
         - name: k8s_state.pod_container_restarts
           description: Restarts
           unit: restarts
           dimensions:
             - name: restarts
+          chart_type: line
         - name: k8s_state.pod_container_state
           description: Container state
           unit: state
@@ -260,13 +347,16 @@ metrics:
             - name: running
             - name: waiting
             - name: terminated
+          chart_type: line
         - name: k8s_state.pod_container_waiting_state_reason
           description: Container waiting state reason
           unit: state
           dimensions:
             - name: a dimension per reason
+          chart_type: line
         - name: k8s_state.pod_container_terminated_state_reason
           description: Container terminated state reason
           unit: state
           dimensions:
             - name: a dimension per reason
+          chart_type: line

--- a/modules/lighttpd/metadata.yaml
+++ b/modules/lighttpd/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -13,17 +68,20 @@ metrics:
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: lighttpd.net
           description: Bandwidth
           unit: kilobits/s
           dimensions:
             - name: sent
+          chart_type: area
         - name: lighttpd.workers
           description: Servers
           unit: servers
           dimensions:
             - name: idle
             - name: busy
+          chart_type: stacked
         - name: lighttpd.scoreboard
           description: ScoreBoard
           unit: connections
@@ -39,8 +97,10 @@ metrics:
             - name: handle_request
             - name: request_start
             - name: request_end
+          chart_type: line
         - name: lighttpd.uptime
           description: Uptime
           unit: seconds
           dimensions:
             - name: uptime
+          chart_type: line

--- a/modules/logind/metadata.yaml
+++ b/modules/logind/metadata.yaml
@@ -2,19 +2,17 @@ name: logind
 title: systemd-logind collector
 overview:
   application:
-    description: |
-      [systemd-logind](https://www.freedesktop.org/software/systemd/man/systemd-logind.service.html) is a system service that
-      manages user logins.
+    description: "[systemd-logind](https://www.freedesktop.org/software/systemd/man/systemd-logind.service.html)
+      is a system service that\nmanages user logins.\n"
   collector:
-    description: |
-      This collector monitors number of sessions and users as reported by the `org.freedesktop.login1` DBus API.
+    description: "This collector monitors number of sessions and users as reported
+      by the `org.freedesktop.login1` DBus API.\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
@@ -24,6 +22,8 @@ setup:
         title: Config
         enabled: true
       list: []
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -31,8 +31,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -43,6 +44,7 @@ metrics:
           dimensions:
             - name: remote
             - name: local
+          chart_type: stacked
         - name: logind.sessions_type
           description: Logind Sessions By Type
           unit: sessions
@@ -50,6 +52,7 @@ metrics:
             - name: console
             - name: graphical
             - name: other
+          chart_type: stacked
         - name: logind.sessions_state
           description: Logind Sessions By State
           unit: sessions
@@ -57,6 +60,7 @@ metrics:
             - name: online
             - name: closing
             - name: active
+          chart_type: stacked
         - name: logind.users_state
           description: Logind Users By State
           unit: users
@@ -66,3 +70,4 @@ metrics:
             - name: online
             - name: lingering
             - name: active
+          chart_type: stacked

--- a/modules/logstash/metadata.yaml
+++ b/modules/logstash/metadata.yaml
@@ -2,91 +2,93 @@ name: logstash
 title: Logstash collector
 overview:
   application:
-    description: |
-      [Logstash](https://www.elastic.co/products/logstash) is an open-source data processing pipeline that allows you to
-      collect, process, and load data into Elasticsearch.
+    description: "[Logstash](https://www.elastic.co/products/logstash) is an open-source
+      data processing pipeline that allows you to\ncollect, process, and load data
+      into Elasticsearch.\n"
   collector:
-    description: |
-      This collector monitors one or more Logstash instances, depending on your configuration.
+    description: "This collector monitors one or more Logstash instances, depending
+      on your configuration.\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: http://localhost:9600
           required: true
+          default_value: http://localhost:9600
         - name: timeout
           description: HTTP request timeout.
-          default: 1
           required: false
+          default_value: 1
         - name: username
           description: Username for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: password
           description: Password for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_url
           description: Proxy URL.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_username
           description: Username for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_password
           description: Password for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: method
           description: HTTP request method.
-          default: "GET"
           required: false
+          default_value: GET
         - name: body
           description: HTTP request body.
-          default: ""
           required: false
+          default_value: ''
         - name: headers
           description: HTTP request headers.
-          default: ""
           required: false
+          default_value: ''
         - name: not_follow_redirects
-          description: Redirect handling policy. Controls whether the client follows redirects.
-          default: no
+          description: Redirect handling policy. Controls whether the client follows
+            redirects.
           required: false
+          default_value: no
         - name: tls_skip_verify
-          description: Server certificate chain and hostname validation policy. Controls whether the client performs this check.
-          default: no
+          description: Server certificate chain and hostname validation policy. Controls
+            whether the client performs this check.
           required: false
+          default_value: no
         - name: tls_ca
-          description: Certification authority that the client uses when verifying the server's certificates.
-          default: ""
+          description: Certification authority that the client uses when verifying
+            the server's certificates.
           required: false
+          default_value: ''
         - name: tls_cert
           description: Client TLS certificate.
-          default: ""
           required: false
+          default_value: ''
         - name: tls_key
           description: Client TLS key.
-          default: ""
           required: false
+          default_value: ''
     examples:
       folding:
         title: Config
@@ -94,37 +96,22 @@ setup:
       list:
         - name: Basic
           description: A basic example configuration.
-          data: |
-            jobs:
-              - name: local
-                url: http://localhost:9600
+          config: "jobs:\n  - name: local\n    url: http://localhost:9600\n"
         - name: HTTP authentication
           description: HTTP authentication.
-          data: |
-            jobs:
-              - name: local
-                url: http://localhost:9600
-                username: username
-                password: password
+          config: "jobs:\n  - name: local\n    url: http://localhost:9600\n    username:
+            username\n    password: password\n"
         - name: HTTPS with self-signed certificate
           description: HTTPS and self-signed certificate.
-          data: |
-            jobs:
-              - name: local
-                url: https://localhost:9600
-                tls_skip_verify: yes
+          config: "jobs:\n  - name: local\n    url: https://localhost:9600\n    tls_skip_verify:
+            yes\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-
-            Collecting metrics from local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                url: http://localhost:9600
-            
-              - name: remote
-                url: http://192.0.2.1:9600
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nCollecting metrics from local and remote instances.\n"
+          config: "jobs:\n  - name: local\n    url: http://localhost:9600\n\n  - name:
+            remote\n    url: http://192.0.2.1:9600\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -132,8 +119,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -143,52 +131,61 @@ metrics:
           unit: count
           dimensions:
             - name: threads
+          chart_type: line
         - name: logstash.jvm_mem_heap_used
           description: JVM Heap Memory Percentage
           unit: percentage
           dimensions:
             - name: in_use
+          chart_type: line
         - name: logstash.jvm_mem_heap
           description: JVM Heap Memory
           unit: KiB
           dimensions:
             - name: committed
             - name: used
+          chart_type: area
         - name: logstash.jvm_mem_pools_eden
           description: JVM Pool Eden Memory
           unit: KiB
           dimensions:
             - name: committed
             - name: used
+          chart_type: area
         - name: logstash.jvm_mem_pools_survivor
           description: JVM Pool Survivor Memory
           unit: KiB
           dimensions:
             - name: committed
             - name: used
+          chart_type: area
         - name: logstash.jvm_mem_pools_old
           description: JVM Pool Old Memory
           unit: KiB
           dimensions:
             - name: committed
             - name: used
+          chart_type: area
         - name: logstash.jvm_gc_collector_count
           description: Garbage Collection Count
           unit: counts/s
           dimensions:
             - name: eden
             - name: old
+          chart_type: line
         - name: logstash.jvm_gc_collector_time
           description: Time Spent On Garbage Collection
           unit: ms
           dimensions:
             - name: eden
             - name: old
+          chart_type: line
         - name: logstash.open_file_descriptors
           description: Open File Descriptors
           unit: fd
           dimensions:
             - name: open
+          chart_type: line
         - name: logstash.event
           description: Events Overview
           unit: events/s
@@ -196,17 +193,20 @@ metrics:
             - name: in
             - name: filtered
             - name: out
+          chart_type: line
         - name: logstash.event_duration
           description: Events Duration
           unit: seconds
           dimensions:
             - name: event
             - name: queue
+          chart_type: line
         - name: logstash.uptime
           description: Uptime
           unit: seconds
           dimensions:
             - name: uptime
+          chart_type: line
     - name: pipeline
       description: These metrics refer to the pipeline.
       labels:
@@ -220,9 +220,11 @@ metrics:
             - name: in
             - name: filtered
             - name: out
+          chart_type: line
         - name: logstash.pipeline_event
           description: Pipeline Events Duration
           unit: seconds
           dimensions:
             - name: event
             - name: queue
+          chart_type: line

--- a/modules/mongodb/metadata.yaml
+++ b/modules/mongodb/metadata.yaml
@@ -2,86 +2,57 @@ name: mongodb
 title: MongoDB collector
 overview:
   application:
-    description: |
-      [MongoDB](https://www.mongodb.com/) is a source-available cross-platform document-oriented database program.
+    description: "[MongoDB](https://www.mongodb.com/) is a source-available cross-platform
+      document-oriented database program.\n"
   collector:
-    description: |
-      This collector monitors one or more MongoDB instances, depending on your configuration.
-      
-      Executed queries:
-      
-      - [serverStatus](https://docs.mongodb.com/manual/reference/command/serverStatus/)
-      - [dbStats](https://docs.mongodb.com/manual/reference/command/dbStats/)
-      - [replSetGetStatus](https://www.mongodb.com/docs/manual/reference/command/replSetGetStatus/)
+    description: "This collector monitors one or more MongoDB instances, depending
+      on your configuration.\n\nExecuted queries:\n\n- [serverStatus](https://docs.mongodb.com/manual/reference/command/serverStatus/)\n
+      - [dbStats](https://docs.mongodb.com/manual/reference/command/dbStats/)\n- [replSetGetStatus](https://www.mongodb.com/docs/manual/reference/command/replSetGetStatus/)\n"
 setup:
   prerequisites:
     list:
       - title: Create a read-only user
-        text: |
-          Create a read-only user for Netdata in the admin database.
-          
-          - Authenticate as the admin user:
-
-            ```bash
-            use admin
-            db.auth("admin", "<MONGODB_ADMIN_PASSWORD>")
-            ```
-
-          - Create a user:
-
-            ```bash
-            db.createUser({
-              "user":"netdata",
-              "pwd": "<UNIQUE_PASSWORD>",
-              "roles" : [
-                {role: 'read', db: 'admin' },
-                {role: 'clusterMonitor', db: 'admin'},
-                {role: 'read', db: 'local' }
-              ]
-            })
-            ```
+        description: "Create a read-only user for Netdata in the admin database.\n
+          \n- Authenticate as the admin user:\n\n  ```bash\n  use admin\n  db.auth(\"\
+          admin\", \"<MONGODB_ADMIN_PASSWORD>\")\n  ```\n\n- Create a user:\n\n  ```bash\n\
+          \  db.createUser({\n    \"user\":\"netdata\",\n    \"pwd\": \"<UNIQUE_PASSWORD>\"\
+          ,\n    \"roles\" : [\n      {role: 'read', db: 'admin' },\n      {role:
+          'clusterMonitor', db: 'admin'},\n      {role: 'read', db: 'local' }\n  \
+          \  ]\n  })\n  ```\n"
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 5
           required: false
+          default_value: 5
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: uri
           description: MongoDB connection string. See [URI syntax](https://www.mongodb.com/docs/manual/reference/connection-string/).
-          default: mongodb://localhost:27017
           required: true
+          default_value: mongodb://localhost:27017
         - name: timeout
           description: Query timeout in seconds.
-          default: 2
           required: false
+          default_value: 2
         - name: databases
-          description: Databases selector. Determines which database metrics will be collected.
-          default: ""
+          description: Databases selector. Determines which database metrics will
+            be collected.
           required: false
-          details: |
-            Metrics of databases matching the selector will be collected.
-            - Logic: (pattern1 OR pattern2) AND !(pattern3 or pattern4)
-            - Pattern syntax: [matcher](https://github.com/netdata/go.d.plugin/tree/master/pkg/matcher#supported-format).
-            - Syntax:
-              ```yaml
-              per_user_stats:
-                includes:
-                  - pattern1
-                  - pattern2
-                excludes:
-                  - pattern3
-                  - pattern4
-              ```
+          details: "Metrics of databases matching the selector will be collected.\n
+            - Logic: (pattern1 OR pattern2) AND !(pattern3 or pattern4)\n- Pattern
+            syntax: [matcher](https://github.com/netdata/go.d.plugin/tree/master/pkg/matcher#supported-format).\n
+            - Syntax:\n  ```yaml\n  per_user_stats:\n    includes:\n      - pattern1\n\
+            \      - pattern2\n    excludes:\n      - pattern3\n      - pattern4\n\
+            \  ```\n"
+          default_value: ''
     examples:
       folding:
         title: Config
@@ -89,31 +60,18 @@ setup:
       list:
         - name: TCP socket
           description: An example configuration.
-          data: |
-            jobs:
-              - name: local
-                uri: mongodb://netdata:password@localhost:27017
+          config: "jobs:\n  - name: local\n    uri: mongodb://netdata:password@localhost:27017\n"
         - name: With databases metrics
           description: An example configuration.
-          data: |
-            jobs:
-              - name: local
-                uri: mongodb://netdata:password@localhost:27017
-                databases:
-                  includes:
-                    - "* *"
+          config: "jobs:\n  - name: local\n    uri: mongodb://netdata:password@localhost:27017\n\
+            \    databases:\n      includes:\n        - \"* *\"\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-            
-            Local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                uri: mongodb://netdata:password@localhost:27017
-
-              - name: remote
-                uri: mongodb://netdata:password@203.0.113.0:27017
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nLocal and remote instances.\n"
+          config: "jobs:\n  - name: local\n    uri: mongodb://netdata:password@localhost:27017\n\
+            \n  - name: remote\n    uri: mongodb://netdata:password@203.0.113.0:27017\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -121,12 +79,11 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: |
-    - WireTiger metrics are available only if [WiredTiger](https://docs.mongodb.com/v6.0/core/wiredtiger/) is used as the
-      storage engine.
-    - Sharding metrics are available on shards only
-      for [mongos](https://www.mongodb.com/docs/manual/reference/program/mongos/).
-  scope:
+  description: "- WireTiger metrics are available only if [WiredTiger](https://docs.mongodb.com/v6.0/core/wiredtiger/)
+    is used as the\n  storage engine.\n- Sharding metrics are available on shards
+    only\n  for [mongos](https://www.mongodb.com/docs/manual/reference/program/mongos/).\n"
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -138,6 +95,7 @@ metrics:
             - name: reads
             - name: writes
             - name: commands
+          chart_type: line
         - name: mongodb.operations_latency_time
           description: Operations Latency
           unit: milliseconds
@@ -145,6 +103,7 @@ metrics:
             - name: reads
             - name: writes
             - name: commands
+          chart_type: line
         - name: mongodb.operations_by_type_rate
           description: Operations by type
           unit: operations/s
@@ -155,6 +114,7 @@ metrics:
             - name: delete
             - name: getmore
             - name: command
+          chart_type: line
         - name: mongodb.document_operations_rate
           description: Document operations
           unit: operations/s
@@ -163,48 +123,57 @@ metrics:
             - name: deleted
             - name: returned
             - name: updated
+          chart_type: stacked
         - name: mongodb.scanned_indexes_rate
           description: Scanned indexes
           unit: indexes/s
           dimensions:
             - name: scanned
+          chart_type: line
         - name: mongodb.scanned_documents_rate
           description: Scanned documents
           unit: documents/s
           dimensions:
             - name: scanned
+          chart_type: line
         - name: mongodb.active_clients_count
           description: Connected clients
           unit: clients
           dimensions:
             - name: readers
             - name: writers
+          chart_type: line
         - name: mongodb.queued_operations_count
           description: Queued operations because of a lock
           unit: operations
           dimensions:
             - name: reads
             - name: writes
+          chart_type: line
         - name: mongodb.cursors_open_count
           description: Open cursors
           unit: cursors
           dimensions:
             - name: open
+          chart_type: line
         - name: mongodb.cursors_open_no_timeout_count
           description: Open cursors with disabled timeout
           unit: cursors
           dimensions:
             - name: open_no_timeout
+          chart_type: line
         - name: mongodb.cursors_opened_rate
           description: Opened cursors rate
           unit: cursors/s
           dimensions:
             - name: opened
+          chart_type: line
         - name: mongodb.cursors_timed_out_rate
           description: Timed-out cursors
           unit: cursors/s
           dimensions:
             - name: timed_out
+          chart_type: line
         - name: mongodb.cursors_by_lifespan_count
           description: Cursors lifespan
           unit: cursors
@@ -216,6 +185,7 @@ metrics:
             - name: 30s_1m
             - name: 1m_10m
             - name: ge_10m
+          chart_type: stacked
         - name: mongodb.transactions_count
           description: Current transactions
           unit: transactions
@@ -224,6 +194,7 @@ metrics:
             - name: inactive
             - name: open
             - name: prepared
+          chart_type: line
         - name: mongodb.transactions_rate
           description: Transactions rate
           unit: transactions/s
@@ -232,12 +203,14 @@ metrics:
             - name: aborted
             - name: committed
             - name: prepared
+          chart_type: line
         - name: mongodb.connections_usage
           description: Connections usage
           unit: connections
           dimensions:
             - name: available
             - name: used
+          chart_type: stacked
         - name: mongodb.connections_by_state_count
           description: Connections By State
           unit: connections
@@ -247,11 +220,13 @@ metrics:
             - name: exhaust_is_master
             - name: exhaust_hello
             - name: awaiting_topology_changes
+          chart_type: line
         - name: mongodb.connections_rate
           description: Connections Rate
           unit: connections/s
           dimensions:
             - name: created
+          chart_type: line
         - name: mongodb.asserts_rate
           description: Raised assertions
           unit: asserts/s
@@ -262,42 +237,50 @@ metrics:
             - name: user
             - name: tripwire
             - name: rollovers
+          chart_type: stacked
         - name: mongodb.network_traffic_rate
           description: Network traffic
           unit: bytes/s
           dimensions:
             - name: in
             - name: out
+          chart_type: stacked
         - name: mongodb.network_requests_rate
           description: Network Requests
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: mongodb.network_slow_dns_resolutions_rate
           description: Slow DNS resolution operations
           unit: resolutions/s
           dimensions:
             - name: slow_dns
+          chart_type: line
         - name: mongodb.network_slow_ssl_handshakes_rate
           description: Slow SSL handshake operations
           unit: handshakes/s
           dimensions:
             - name: slow_ssl
+          chart_type: line
         - name: mongodb.memory_resident_size
           description: Used resident memory
           unit: bytes
           dimensions:
             - name: used
+          chart_type: line
         - name: mongodb.memory_virtual_size
           description: Used virtual memory
           unit: bytes
           dimensions:
             - name: used
+          chart_type: line
         - name: mongodb.memory_page_faults_rate
           description: Memory page faults
           unit: pgfaults/s
           dimensions:
             - name: pgfaults
+          chart_type: line
         - name: mongodb.memory_tcmalloc_stats
           description: TCMalloc statistics
           unit: bytes
@@ -308,58 +291,68 @@ metrics:
             - name: thread_cache_freelists
             - name: pageheap_freelist
             - name: pageheap_unmapped
+          chart_type: line
         - name: mongodb.wiredtiger_concurrent_read_transactions_usage
           description: Wired Tiger concurrent read transactions usage
           unit: transactions
           dimensions:
             - name: available
             - name: used
+          chart_type: stacked
         - name: mongodb.wiredtiger_concurrent_write_transactions_usage
           description: Wired Tiger concurrent write transactions usage
           unit: transactions
           dimensions:
             - name: available
             - name: used
+          chart_type: stacked
         - name: mongodb.wiredtiger_cache_usage
           description: Wired Tiger cache usage
           unit: bytes
           dimensions:
             - name: used
+          chart_type: line
         - name: mongodb.wiredtiger_cache_dirty_space_size
           description: Wired Tiger cache dirty space size
           unit: bytes
           dimensions:
             - name: dirty
+          chart_type: line
         - name: mongodb.wiredtiger_cache_io_rate
           description: Wired Tiger IO activity
           unit: pages/s
           dimensions:
             - name: read
             - name: written
+          chart_type: line
         - name: mongodb.wiredtiger_cache_evictions_rate
           description: Wired Tiger cache evictions
           unit: pages/s
           dimensions:
             - name: unmodified
             - name: modified
+          chart_type: stacked
         - name: mongodb.sharding_nodes_count
           description: Sharding Nodes
           unit: nodes
           dimensions:
             - name: shard_aware
             - name: shard_unaware
+          chart_type: stacked
         - name: mongodb.sharding_sharded_databases_count
           description: Sharded databases
           unit: databases
           dimensions:
             - name: partitioned
             - name: unpartitioned
+          chart_type: stacked
         - name: mongodb.sharding_sharded_collections_count
           description: Sharded collections
           unit: collections
           dimensions:
             - name: partitioned
             - name: unpartitioned
+          chart_type: stacked
     - name: lock type
       description: These metrics refer to the lock type.
       labels:
@@ -374,6 +367,7 @@ metrics:
             - name: exclusive
             - name: intent_shared
             - name: intent_exclusive
+          chart_type: line
     - name: commit type
       description: These metrics refer to the commit type.
       labels:
@@ -386,11 +380,13 @@ metrics:
           dimensions:
             - name: success
             - name: fail
+          chart_type: line
         - name: mongodb.transactions_commits_duration_time
           description: Transactions successful commits duration
           unit: milliseconds
           dimensions:
             - name: commits
+          chart_type: line
     - name: database
       description: These metrics refer to the database.
       labels:
@@ -402,36 +398,43 @@ metrics:
           unit: collections
           dimensions:
             - name: collections
+          chart_type: line
         - name: mongodb.database_indexes_count
           description: Database indexes
           unit: indexes
           dimensions:
             - name: indexes
+          chart_type: line
         - name: mongodb.database_views_count
           description: Database views
           unit: views
           dimensions:
             - name: views
+          chart_type: line
         - name: mongodb.database_documents_count
           description: Database documents
           unit: documents
           dimensions:
             - name: documents
+          chart_type: line
         - name: mongodb.database_data_size
           description: Database data size
           unit: bytes
           dimensions:
             - name: data_size
+          chart_type: line
         - name: mongodb.database_storage_size
           description: Database storage size
           unit: bytes
           dimensions:
             - name: storage_size
+          chart_type: line
         - name: mongodb.database_index_size
           description: Database index size
           unit: bytes
           dimensions:
             - name: index_size
+          chart_type: line
     - name: replica set member
       description: These metrics refer to the replica set member.
       labels:
@@ -452,32 +455,38 @@ metrics:
             - name: down
             - name: rollback
             - name: removed
+          chart_type: line
         - name: mongodb.repl_set_member_health_status
           description: Replica Set member health status
           unit: status
           dimensions:
             - name: up
             - name: down
+          chart_type: line
         - name: mongodb.repl_set_member_replication_lag_time
           description: Replica Set member replication lag
           unit: milliseconds
           dimensions:
             - name: replication_lag
+          chart_type: line
         - name: mongodb.repl_set_member_heartbeat_latency_time
           description: Replica Set member heartbeat latency
           unit: milliseconds
           dimensions:
             - name: heartbeat_latency
+          chart_type: line
         - name: mongodb.repl_set_member_ping_rtt_time
           description: Replica Set member ping RTT
           unit: milliseconds
           dimensions:
             - name: ping_rtt
+          chart_type: line
         - name: mongodb.repl_set_member_uptime
           description: Replica Set member uptime
           unit: seconds
           dimensions:
             - name: uptime
+          chart_type: line
     - name: shard
       description: These metrics refer to the shard.
       labels:
@@ -489,3 +498,4 @@ metrics:
           unit: chunks
           dimensions:
             - name: chunks
+          chart_type: line

--- a/modules/nginxplus/metadata.yaml
+++ b/modules/nginxplus/metadata.yaml
@@ -2,94 +2,94 @@ name: nginxplus
 title: NGINX Plus collector
 overview:
   application:
-    description: |
-      [NGINX Plus](https://www.nginx.com/products/nginx/) is a software load balancer, API gateway, and reverse proxy built on
-      top of NGINX.
+    description: "[NGINX Plus](https://www.nginx.com/products/nginx/) is a software
+      load balancer, API gateway, and reverse proxy built on\ntop of NGINX.\n"
   collector:
-    description: |
-      This collector will monitor one or more NGINX Plus servers, depending on your configuration.
+    description: "This collector will monitor one or more NGINX Plus servers, depending
+      on your configuration.\n"
 setup:
   prerequisites:
     list:
       - title: Enable API
-        text: |
-          See [Configure the API](https://docs.nginx.com/nginx/admin-guide/monitoring/live-activity-monitoring/#configuring-the-api).
+        description: "See [Configure the API](https://docs.nginx.com/nginx/admin-guide/monitoring/live-activity-monitoring/#configuring-the-api).\n"
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: http://127.0.0.1
           required: true
+          default_value: http://127.0.0.1
         - name: timeout
           description: HTTP request timeout.
-          default: 1
           required: false
+          default_value: 1
         - name: username
           description: Username for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: password
           description: Password for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_url
           description: Proxy URL.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_username
           description: Username for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_password
           description: Password for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: method
           description: HTTP request method.
-          default: "GET"
           required: false
+          default_value: GET
         - name: body
           description: HTTP request body.
-          default: ""
           required: false
+          default_value: ''
         - name: headers
           description: HTTP request headers.
-          default: ""
           required: false
+          default_value: ''
         - name: not_follow_redirects
-          description: Redirect handling policy. Controls whether the client follows redirects.
-          default: no
+          description: Redirect handling policy. Controls whether the client follows
+            redirects.
           required: false
+          default_value: no
         - name: tls_skip_verify
-          description: Server certificate chain and hostname validation policy. Controls whether the client performs this check.
-          default: no
+          description: Server certificate chain and hostname validation policy. Controls
+            whether the client performs this check.
           required: false
+          default_value: no
         - name: tls_ca
-          description: Certification authority that the client uses when verifying the server's certificates.
-          default: ""
+          description: Certification authority that the client uses when verifying
+            the server's certificates.
           required: false
+          default_value: ''
         - name: tls_cert
           description: Client TLS certificate.
-          default: ""
           required: false
+          default_value: ''
         - name: tls_key
           description: Client TLS key.
-          default: ""
           required: false
+          default_value: ''
     examples:
       folding:
         title: Config
@@ -97,37 +97,22 @@ setup:
       list:
         - name: Basic
           description: A basic example configuration.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1\n"
         - name: HTTP authentication
           description: Basic HTTP authentication.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1
-                username: username
-                password: password
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1\n    username:
+            username\n    password: password\n"
         - name: HTTPS with self-signed certificate
           description: NGINX Plus with enabled HTTPS and self-signed certificate.
-          data: |
-            jobs:
-              - name: local
-                url: https://127.0.0.1
-                tls_skip_verify: yes
+          config: "jobs:\n  - name: local\n    url: https://127.0.0.1\n    tls_skip_verify:
+            yes\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-
-            Collecting metrics from local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1
-            
-              - name: remote
-                url: http://192.0.2.1
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nCollecting metrics from local and remote instances.\n"
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1\n\n  - name:
+            remote\n    url: http://192.0.2.1\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -135,8 +120,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -147,18 +133,21 @@ metrics:
           dimensions:
             - name: accepted
             - name: dropped
+          chart_type: line
         - name: nginxplus.client_connections_count
           description: Client connections
           unit: connections
           dimensions:
             - name: active
             - name: idle
+          chart_type: line
         - name: nginxplus.ssl_handshakes_rate
           description: SSL handshakes rate
           unit: handshakes/s
           dimensions:
             - name: successful
             - name: failed
+          chart_type: line
         - name: nginxplus.ssl_handshakes_failures_rate
           description: SSL handshakes failures rate
           unit: failures/s
@@ -167,6 +156,7 @@ metrics:
             - name: no_common_cipher
             - name: timeout
             - name: peer_rejected_cert
+          chart_type: stacked
         - name: nginxplus.ssl_verification_errors_rate
           description: SSL verification errors rate
           unit: errors/s
@@ -176,26 +166,31 @@ metrics:
             - name: revoked_cert
             - name: hostname_mismatch
             - name: other
+          chart_type: stacked
         - name: nginxplus.ssl_session_reuses_rate
           description: Session reuses during SSL handshak
           unit: reuses/s
           dimensions:
             - name: ssl_session
+          chart_type: line
         - name: nginxplus.http_requests_rate
           description: HTTP requests rate
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: nginxplus.http_requests_count
           description: HTTP requests
           unit: requests
           dimensions:
             - name: requests
+          chart_type: line
         - name: nginxplus.uptime
           description: Uptime
           unit: seconds
           dimensions:
             - name: uptime
+          chart_type: line
     - name: http server zone
       description: These metrics refer to the HTTP server zone.
       labels:
@@ -207,6 +202,7 @@ metrics:
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: nginxplus.http_server_zone_responses_per_code_class_rate
           description: HTTP Server Zone responses rate
           unit: responses/s
@@ -216,22 +212,26 @@ metrics:
             - name: 3xx
             - name: 4xx
             - name: 5xx
+          chart_type: stacked
         - name: nginxplus.http_server_zone_traffic_rate
           description: HTTP Server Zone traffic
           unit: bytes/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: area
         - name: nginxplus.http_server_zone_requests_processing_count
           description: HTTP Server Zone currently processed requests
           unit: requests
           dimensions:
             - name: processing
+          chart_type: line
         - name: nginxplus.http_server_zone_requests_discarded_rate
           description: HTTP Server Zone requests discarded rate
           unit: requests/s
           dimensions:
             - name: discarded
+          chart_type: line
     - name: http location zone
       description: These metrics refer to the HTTP location zone.
       labels:
@@ -243,6 +243,7 @@ metrics:
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: nginxplus.http_location_zone_responses_per_code_class_rate
           description: HTTP Location Zone responses rate
           unit: responses/s
@@ -252,17 +253,20 @@ metrics:
             - name: 3xx
             - name: 4xx
             - name: 5xx
+          chart_type: stacked
         - name: nginxplus.http_location_zone_traffic_rate
           description: HTTP Location Zone traffic rate
           unit: bytes/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: area
         - name: nginxplus.http_location_zone_requests_discarded_rate
           description: HTTP Location Zone requests discarded rate
           unit: requests/s
           dimensions:
             - name: discarded
+          chart_type: line
     - name: http upstream
       description: These metrics refer to the HTTP upstream.
       labels:
@@ -276,16 +280,19 @@ metrics:
           unit: peers
           dimensions:
             - name: peers
+          chart_type: line
         - name: nginxplus.http_upstream_zombies_count
           description: HTTP Upstream zombies
           unit: servers
           dimensions:
             - name: zombie
+          chart_type: line
         - name: nginxplus.http_upstream_keepalive_count
           description: HTTP Upstream keepalive
           unit: connections
           dimensions:
             - name: keepalive
+          chart_type: line
     - name: http upstream server
       description: These metrics refer to the HTTP upstream server.
       labels:
@@ -303,6 +310,7 @@ metrics:
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: nginxplus.http_upstream_server_responses_per_code_class_rate
           description: HTTP Upstream Server responses
           unit: responses/s
@@ -312,22 +320,26 @@ metrics:
             - name: 3xx
             - name: 4xx
             - name: 5xx
+          chart_type: stacked
         - name: nginxplus.http_upstream_server_response_time
           description: HTTP Upstream Server average response time
           unit: milliseconds
           dimensions:
             - name: response
+          chart_type: line
         - name: nginxplus.http_upstream_server_response_header_time
           description: HTTP Upstream Server average response header time
           unit: milliseconds
           dimensions:
             - name: header
+          chart_type: line
         - name: nginxplus.http_upstream_server_traffic_rate
           description: HTTP Upstream Server traffic rate
           unit: bytes/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: area
         - name: nginxplus.http_upstream_server_state
           description: HTTP Upstream Server state
           unit: state
@@ -338,16 +350,19 @@ metrics:
             - name: unavail
             - name: checking
             - name: unhealthy
+          chart_type: line
         - name: nginxplus.http_upstream_server_connections_count
           description: HTTP Upstream Server connections
           unit: connections
           dimensions:
             - name: active
+          chart_type: line
         - name: nginxplus.http_upstream_server_downtime
           description: HTTP Upstream Server downtime
           unit: seconds
           dimensions:
             - name: downtime
+          chart_type: line
     - name: http cache
       description: These metrics refer to the HTTP cache.
       labels:
@@ -360,6 +375,7 @@ metrics:
           dimensions:
             - name: warm
             - name: cold
+          chart_type: line
         - name: nginxplus.http_cache_iops
           description: HTTP Cache size
           unit: responses/s
@@ -367,6 +383,7 @@ metrics:
             - name: served
             - name: written
             - name: bypass
+          chart_type: line
         - name: nginxplus.http_cache_io
           description: HTTP Cache IOPS
           unit: bytes/s
@@ -374,11 +391,13 @@ metrics:
             - name: served
             - name: written
             - name: bypass
+          chart_type: line
         - name: nginxplus.http_cache_size
           description: HTTP Cache IO
           unit: bytes
           dimensions:
             - name: size
+          chart_type: line
     - name: stream server zone
       description: These metrics refer to the Stream server zone.
       labels:
@@ -390,6 +409,7 @@ metrics:
           unit: connections/s
           dimensions:
             - name: accepted
+          chart_type: line
         - name: nginxplus.stream_server_zone_sessions_per_code_class_rate
           description: Stream Server Zone sessions rate
           unit: sessions/s
@@ -397,22 +417,26 @@ metrics:
             - name: 2xx
             - name: 4xx
             - name: 5xx
+          chart_type: stacked
         - name: nginxplus.stream_server_zone_traffic_rate
           description: Stream Server Zone traffic rate
           unit: bytes/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: area
         - name: nginxplus.stream_server_zone_connections_processing_count
           description: Stream Server Zone connections processed
           unit: connections
           dimensions:
             - name: processing
+          chart_type: line
         - name: nginxplus.stream_server_zone_connections_discarded_rate
           description: Stream Server Zone connections discarded
           unit: connections/s
           dimensions:
             - name: discarded
+          chart_type: line
     - name: stream upstream
       description: These metrics refer to the Stream upstream.
       labels:
@@ -426,11 +450,13 @@ metrics:
           unit: peers
           dimensions:
             - name: peers
+          chart_type: line
         - name: nginxplus.stream_upstream_zombies_count
           description: Stream Upstream zombies
           unit: servers
           dimensions:
             - name: zombie
+          chart_type: line
     - name: stream upstream server
       description: These metrics refer to the Stream upstream server.
       labels:
@@ -448,12 +474,14 @@ metrics:
           unit: connections/s
           dimensions:
             - name: forwarded
+          chart_type: line
         - name: nginxplus.stream_upstream_server_traffic_rate
           description: Stream Upstream Server traffic rate
           unit: bytes/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: area
         - name: nginxplus.stream_upstream_server_state
           description: Stream Upstream Server state
           unit: state
@@ -463,16 +491,19 @@ metrics:
             - name: unavail
             - name: checking
             - name: unhealthy
+          chart_type: line
         - name: nginxplus.stream_upstream_server_downtime
           description: Stream Upstream Server downtime
           unit: seconds
           dimensions:
             - name: downtime
+          chart_type: line
         - name: nginxplus.stream_upstream_server_connections_count
           description: Stream Upstream Server connections
           unit: connections
           dimensions:
             - name: active
+          chart_type: line
     - name: resolver zone
       description: These metrics refer to the resolver zone.
       labels:
@@ -486,6 +517,7 @@ metrics:
             - name: name
             - name: srv
             - name: addr
+          chart_type: stacked
         - name: nginxplus.resolver_zone_responses_rate
           description: Resolver responses rate
           unit: responses/s
@@ -498,3 +530,4 @@ metrics:
             - name: refused
             - name: timedout
             - name: unknown
+          chart_type: stacked

--- a/modules/nginxvts/metadata.yaml
+++ b/modules/nginxvts/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -13,11 +68,13 @@ metrics:
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: nginxvts.active_connections
           description: Active connections
           unit: connections
           dimensions:
             - name: active
+          chart_type: line
         - name: nginxvts.connections_total
           description: Total connections
           unit: connections/s
@@ -27,27 +84,32 @@ metrics:
             - name: waiting
             - name: accepted
             - name: handled
+          chart_type: line
         - name: nginxvts.uptime
           description: Uptime
           unit: seconds
           dimensions:
             - name: uptime
+          chart_type: line
         - name: nginxvts.shm_usage
           description: Shared memory size
           unit: bytes
           dimensions:
             - name: max
             - name: used
+          chart_type: line
         - name: nginxvts.shm_used_node
           description: Number of node using shared memory
           unit: nodes
           dimensions:
             - name: used
+          chart_type: line
         - name: nginxvts.server_requests_total
           description: Total number of client requests
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: nginxvts.server_responses_total
           description: Total number of responses by code class
           unit: responses/s
@@ -57,12 +119,14 @@ metrics:
             - name: 3xx
             - name: 4xx
             - name: 5xx
+          chart_type: line
         - name: nginxvts.server_traffic_total
           description: Total amount of data transferred to and from the server
           unit: bytes/s
           dimensions:
             - name: in
             - name: out
+          chart_type: line
         - name: nginxvts.server_cache_total
           description: Total server cache
           unit: events/s
@@ -75,3 +139,4 @@ metrics:
             - name: revalidated
             - name: hit
             - name: scarce
+          chart_type: line

--- a/modules/ntpd/metadata.yaml
+++ b/modules/ntpd/metadata.yaml
@@ -2,45 +2,44 @@ name: ntpd
 title: NTP daemon collector
 overview:
   application:
-    description: |
-      The NTPd (Network Time Protocol daemon) is an operating system program that maintains the system time in synchronization
-      with time-servers using the Network Time Protocol.
+    description: "The NTPd (Network Time Protocol daemon) is an operating system program
+      that maintains the system time in synchronization\nwith time-servers using the
+      Network Time Protocol.\n"
   collector:
-    description: |
-      This collector monitors the system variables of the local `ntpd` daemon (optional incl. variables of the polled peers)
-      using the NTP Control Message Protocol via UDP socket, similar to `ntpq`,
-      the [standard NTP query program](https://doc.ntp.org/current-stable/ntpq.html).
+    description: "This collector monitors the system variables of the local `ntpd`
+      daemon (optional incl. variables of the polled peers)\nusing the NTP Control
+      Message Protocol via UDP socket, similar to `ntpq`,\nthe [standard NTP query
+      program](https://doc.ntp.org/current-stable/ntpq.html).\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: address
           description: Server address in IP:PORT format.
-          default: 127.0.0.1:123
           required: true
+          default_value: 127.0.0.1:123
         - name: timeout
           description: Connection/read/write timeout.
-          default: 3
           required: false
+          default_value: 3
         - name: collect_peers
           description: Determines whether peer metrics will be collected.
-          default: no
           required: false
+          default_value: no
     examples:
       folding:
         title: Config
@@ -48,29 +47,18 @@ setup:
       list:
         - name: Basic
           description: A basic example configuration.
-          data: |
-            jobs:
-              - name: local
-                address: 127.0.0.1:123
+          config: "jobs:\n  - name: local\n    address: 127.0.0.1:123\n"
         - name: With peers metrics
           description: Collect peers metrics.
-          data: |
-            jobs:
-              - name: local
-                address: 127.0.0.1:123
-                collect_peers: yes
+          config: "jobs:\n  - name: local\n    address: 127.0.0.1:123\n    collect_peers:
+            yes\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-
-            Collecting metrics from local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                address: 127.0.0.1:123
-            
-              - name: remote
-                address: 203.0.113.0:123
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nCollecting metrics from local and remote instances.\n"
+          config: "jobs:\n  - name: local\n    address: 127.0.0.1:123\n\n  - name:
+            remote\n    address: 203.0.113.0:123\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -78,8 +66,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -89,116 +78,138 @@ metrics:
           unit: milliseconds
           dimensions:
             - name: offset
+          chart_type: area
         - name: ntpd.sys_jitter
           description: Combined system jitter and clock jitter
           unit: milliseconds
           dimensions:
             - name: system
             - name: clock
+          chart_type: line
         - name: ntpd.sys_frequency
           description: Frequency offset relative to hardware clock
           unit: ppm
           dimensions:
             - name: frequency
+          chart_type: area
         - name: ntpd.sys_wander
           description: Clock frequency wander
           unit: ppm
           dimensions:
             - name: clock
+          chart_type: area
         - name: ntpd.sys_rootdelay
           description: Total roundtrip delay to the primary reference clock
           unit: milliseconds
           dimensions:
             - name: delay
+          chart_type: area
         - name: ntpd.sys_rootdisp
           description: Total root dispersion to the primary reference clock
           unit: milliseconds
           dimensions:
             - name: dispersion
+          chart_type: area
         - name: ntpd.sys_stratum
           description: Stratum
           unit: stratum
           dimensions:
             - name: stratum
+          chart_type: line
         - name: ntpd.sys_tc
           description: Time constant and poll exponent
           unit: log2
           dimensions:
             - name: current
             - name: minimum
+          chart_type: line
         - name: ntpd.sys_precision
           description: Precision
           unit: log2
           dimensions:
             - name: precision
+          chart_type: line
     - name: peer
       description: These metrics refer to the NTPd peer.
       labels:
         - name: peer_address
-          description: "peer's source IP address"
+          description: peer's source IP address
       metrics:
         - name: ntpd.peer_offset
           description: Peer offset
           unit: milliseconds
           dimensions:
             - name: offset
+          chart_type: line
         - name: ntpd.peer_delay
           description: Peer delay
           unit: milliseconds
           dimensions:
             - name: delay
+          chart_type: line
         - name: ntpd.peer_dispersion
           description: Peer dispersion
           unit: milliseconds
           dimensions:
             - name: dispersion
+          chart_type: line
         - name: ntpd.peer_jitter
           description: Peer jitter
           unit: milliseconds
           dimensions:
             - name: jitter
+          chart_type: line
         - name: ntpd.peer_xleave
           description: Peer interleave delay
           unit: milliseconds
           dimensions:
             - name: xleave
+          chart_type: line
         - name: ntpd.peer_rootdelay
           description: Peer roundtrip delay to the primary reference clock
           unit: milliseconds
           dimensions:
             - name: rootdelay
+          chart_type: line
         - name: ntpd.peer_rootdisp
           description: Peer root dispersion to the primary reference clock
           unit: milliseconds
           dimensions:
             - name: dispersion
+          chart_type: line
         - name: ntpd.peer_stratum
           description: Peer stratum
           unit: stratum
           dimensions:
             - name: stratum
+          chart_type: line
         - name: ntpd.peer_hmode
           description: Peer host mode
           unit: hmode
           dimensions:
             - name: hmode
+          chart_type: line
         - name: ntpd.peer_pmode
           description: Peer mode
           unit: pmode
           dimensions:
             - name: pmode
+          chart_type: line
         - name: ntpd.peer_hpoll
           description: Peer host poll exponent
           unit: log2
           dimensions:
             - name: hpoll
+          chart_type: line
         - name: ntpd.peer_ppoll
           description: Peer poll exponent
           unit: log2
           dimensions:
             - name: ppoll
+          chart_type: line
         - name: ntpd.peer_precision
           description: Peer precision
           unit: log2
           dimensions:
             - name: precision
+          chart_type: line

--- a/modules/nvidia_smi/metadata.yaml
+++ b/modules/nvidia_smi/metadata.yaml
@@ -2,53 +2,52 @@ name: nvidia_smi
 title: Nvidia GPU collector
 overview:
   application:
-    description: ""
+    description: ''
   collector:
-    description: |
-      This collector monitors GPUs performance metrics using
-      the [nvidia-smi](https://developer.nvidia.com/nvidia-system-management-interface) CLI tool.
-
-      > **Warning**: under development, [loop mode](https://github.com/netdata/netdata/issues/14522) not implemented yet.
+    description: "This collector monitors GPUs performance metrics using\nthe [nvidia-smi](https://developer.nvidia.com/nvidia-system-management-interface)
+      CLI tool.\n\n> **Warning**: under development, [loop mode](https://github.com/netdata/netdata/issues/14522)
+      not implemented yet.\n"
 setup:
   prerequisites:
     list:
       - title: Enable in go.d.conf.
-        text: |
-          This collector is disabled by default. You need to explicitly enable it in the `go.d.conf` file.
+        description: "This collector is disabled by default. You need to explicitly
+          enable it in the `go.d.conf` file.\n"
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 10
           required: false
+          default_value: 10
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: binary_path
-          description: Path to nvidia_smi binary. The default is "nvidia_smi" and the executable is looked for in the directories specified in the PATH environment variable.
-          default: nvidia_smi
+          description: Path to nvidia_smi binary. The default is "nvidia_smi" and
+            the executable is looked for in the directories specified in the PATH
+            environment variable.
           required: false
+          default_value: nvidia_smi
         - name: timeout
           description: nvidia_smi binary execution timeout.
-          default: 2
           required: false
+          default_value: 2
         - name: use_csv_format
-          description: Used format when requesting GPU information. XML is used if set to 'no'.
-          default: yes
+          description: Used format when requesting GPU information. XML is used if
+            set to 'no'.
           required: false
-          details: |
-            This module supports data collection in CSV and XML formats. The default is CSV.
-
-            - XML provides more metrics, but requesting GPU information consumes more CPU, especially if there are multiple GPUs
-              in the system.
-            - CSV provides fewer metrics, but is much lighter than XML in terms of CPU usage.
+          details: "This module supports data collection in CSV and XML formats. The
+            default is CSV.\n\n- XML provides more metrics, but requesting GPU information
+            consumes more CPU, especially if there are multiple GPUs\n  in the system.\n
+            - CSV provides fewer metrics, but is much lighter than XML in terms of
+            CPU usage.\n"
+          default_value: yes
     examples:
       folding:
         title: Config
@@ -56,16 +55,13 @@ setup:
       list:
         - name: XML format
           description: Use XML format when requesting GPU information.
-          data: |
-            jobs:
-              - name: nvidia_smi
-                use_csv_format: no
+          config: "jobs:\n  - name: nvidia_smi\n    use_csv_format: no\n"
         - name: Custom binary path
-          description: The executable is not in the directories specified in the PATH environment variable.
-          data: |
-            jobs:
-              - name: nvidia_smi
-                binary_path: /usr/local/sbin/nvidia_smi
+          description: The executable is not in the directories specified in the PATH
+            environment variable.
+          config: "jobs:\n  - name: nvidia_smi\n    binary_path: /usr/local/sbin/nvidia_smi\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -73,11 +69,11 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
+  description: ''
   availability:
     - XML
     - CSV
-  scope:
+  scopes:
     - name: gpu
       description: These metrics refer to the GPU.
       labels:
@@ -94,6 +90,7 @@ metrics:
           dimensions:
             - name: rx
             - name: tx
+          chart_type: line
         - name: nvidia_smi.gpu_pcie_bandwidth_utilization
           availability:
             - XML
@@ -102,6 +99,7 @@ metrics:
           dimensions:
             - name: rx
             - name: tx
+          chart_type: line
         - name: nvidia_smi.gpu_fan_speed_perc
           availability:
             - XML
@@ -110,6 +108,7 @@ metrics:
           unit: '%'
           dimensions:
             - name: fan_speed
+          chart_type: line
         - name: nvidia_smi.gpu_utilization
           availability:
             - XML
@@ -118,6 +117,7 @@ metrics:
           unit: '%'
           dimensions:
             - name: gpu
+          chart_type: line
         - name: nvidia_smi.gpu_memory_utilization
           availability:
             - XML
@@ -126,6 +126,7 @@ metrics:
           unit: '%'
           dimensions:
             - name: memory
+          chart_type: line
         - name: nvidia_smi.gpu_decoder_utilization
           availability:
             - XML
@@ -133,6 +134,7 @@ metrics:
           unit: '%'
           dimensions:
             - name: decoder
+          chart_type: line
         - name: nvidia_smi.gpu_encoder_utilization
           availability:
             - XML
@@ -140,6 +142,7 @@ metrics:
           unit: '%'
           dimensions:
             - name: encoder
+          chart_type: line
         - name: nvidia_smi.gpu_frame_buffer_memory_usage
           availability:
             - XML
@@ -150,6 +153,7 @@ metrics:
             - name: free
             - name: used
             - name: reserved
+          chart_type: stacked
         - name: nvidia_smi.gpu_bar1_memory_usage
           availability:
             - XML
@@ -158,6 +162,7 @@ metrics:
           dimensions:
             - name: free
             - name: used
+          chart_type: stacked
         - name: nvidia_smi.gpu_temperature
           availability:
             - XML
@@ -166,6 +171,7 @@ metrics:
           unit: Celsius
           dimensions:
             - name: temperature
+          chart_type: line
         - name: nvidia_smi.gpu_voltage
           availability:
             - XML
@@ -173,6 +179,7 @@ metrics:
           unit: V
           dimensions:
             - name: voltage
+          chart_type: line
         - name: nvidia_smi.gpu_clock_freq
           availability:
             - XML
@@ -184,6 +191,7 @@ metrics:
             - name: video
             - name: sm
             - name: mem
+          chart_type: line
         - name: nvidia_smi.gpu_power_draw
           availability:
             - XML
@@ -192,6 +200,7 @@ metrics:
           unit: Watts
           dimensions:
             - name: power_draw
+          chart_type: line
         - name: nvidia_smi.gpu_performance_state
           availability:
             - XML
@@ -200,6 +209,7 @@ metrics:
           unit: state
           dimensions:
             - name: P0-P15
+          chart_type: line
         - name: nvidia_smi.gpu_mig_mode_current_status
           availability:
             - XML
@@ -208,6 +218,7 @@ metrics:
           dimensions:
             - name: enabled
             - name: disabled
+          chart_type: line
         - name: nvidia_smi.gpu_mig_devices_count
           availability:
             - XML
@@ -215,6 +226,7 @@ metrics:
           unit: devices
           dimensions:
             - name: mig
+          chart_type: line
     - name: mig
       description: These metrics refer to the Multi-Instance GPU (MIG).
       labels:
@@ -234,6 +246,7 @@ metrics:
             - name: free
             - name: used
             - name: reserved
+          chart_type: stacked
         - name: nvidia_smi.gpu_mig_bar1_memory_usage
           availability:
             - XML
@@ -242,3 +255,4 @@ metrics:
           dimensions:
             - name: free
             - name: used
+          chart_type: stacked

--- a/modules/nvme/metadata.yaml
+++ b/modules/nvme/metadata.yaml
@@ -2,62 +2,60 @@ name: nvme
 title: NVMe devices collector
 overview:
   application:
-    description: |
-      NVMe (nonvolatile memory express) is a new storage access and transport protocol for flash and next-generation
-      solid-state drives (SSDs) that delivers the highest throughput and fastest response times yet for all types of
-      enterprise workloads.
+    description: "NVMe (nonvolatile memory express) is a new storage access and transport
+      protocol for flash and next-generation\nsolid-state drives (SSDs) that delivers
+      the highest throughput and fastest response times yet for all types of\nenterprise
+      workloads.\n"
   collector:
-    description: |
-      This collector monitors the health of NVMe devices using the command line
-      tool [nvme](https://github.com/linux-nvme/nvme-cli#nvme-cli), which can only be run by the root user. It uses `sudo` and
-      assumes it is set up so that the netdata user can execute `nvme` as root without a password.
+    description: "This collector monitors the health of NVMe devices using the command
+      line\ntool [nvme](https://github.com/linux-nvme/nvme-cli#nvme-cli), which can
+      only be run by the root user. It uses `sudo` and\nassumes it is set up so that
+      the netdata user can execute `nvme` as root without a password.\n"
 setup:
   prerequisites:
     list:
       - title: Install nvme-cli
-        text: |
-          See [Distro Support](https://github.com/linux-nvme/nvme-cli#distro-support). Install `nvme-cli` using your distribution's package manager.
+        description: "See [Distro Support](https://github.com/linux-nvme/nvme-cli#distro-support).
+          Install `nvme-cli` using your distribution's package manager.\n"
       - title: Allow netdata to execute nvme
-        text: |
-          Add the netdata user to `/etc/sudoers` (use `which nvme` to find the full path to the binary):
-          ```bash
-          netdata ALL=(root) NOPASSWD: /usr/sbin/nvme
-          ```
+        description: "Add the netdata user to `/etc/sudoers` (use `which nvme` to
+          find the full path to the binary):\n```bash\nnetdata ALL=(root) NOPASSWD:
+          /usr/sbin/nvme\n```\n"
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 10
           required: false
+          default_value: 10
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: binary_path
-          description: Path to nvme binary. The default is "nvme" and the executable is looked for in the directories specified in the PATH environment variable.
-          default: nvme
+          description: Path to nvme binary. The default is "nvme" and the executable
+            is looked for in the directories specified in the PATH environment variable.
           required: false
+          default_value: nvme
         - name: timeout
           description: nvme binary execution timeout.
-          default: 2
           required: false
+          default_value: 2
     examples:
       folding:
         title: Config
         enabled: true
       list:
         - name: Custom binary path
-          description: The executable is not in the directories specified in the PATH environment variable.
-          data: |
-            jobs:
-              - name: nvme
-                binary_path: /usr/local/sbin/nvme
+          description: The executable is not in the directories specified in the PATH
+            environment variable.
+          config: "jobs:\n  - name: nvme\n    binary_path: /usr/local/sbin/nvme\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -65,8 +63,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: device
       description: These metrics refer to the NVME device.
       labels:
@@ -78,32 +77,38 @@ metrics:
           unit: '%'
           dimensions:
             - name: used
+          chart_type: line
         - name: nvme.device_available_spare_perc
           description: Remaining spare capacity
           unit: '%'
           dimensions:
             - name: spare
+          chart_type: line
         - name: nvme.device_composite_temperature
           description: Composite temperature
           unit: celsius
           dimensions:
             - name: temperature
+          chart_type: line
         - name: nvme.device_io_transferred_count
           description: Amount of data transferred to and from device
           unit: bytes
           dimensions:
             - name: read
             - name: written
+          chart_type: area
         - name: nvme.device_power_cycles_count
           description: Power cycles
           unit: cycles
           dimensions:
             - name: power
+          chart_type: line
         - name: nvme.device_power_on_time
           description: Power-on time
           unit: seconds
           dimensions:
             - name: power-on
+          chart_type: line
         - name: nvme.device_critical_warnings_state
           description: Critical warnings state
           unit: state
@@ -114,48 +119,58 @@ metrics:
             - name: read_only
             - name: volatile_mem_backup_failed
             - name: persistent_memory_read_only
+          chart_type: line
         - name: nvme.device_unsafe_shutdowns_count
           description: Unsafe shutdowns
           unit: shutdowns
           dimensions:
             - name: unsafe
+          chart_type: line
         - name: nvme.device_media_errors_rate
           description: Media and data integrity errors
           unit: errors/s
           dimensions:
             - name: media
+          chart_type: line
         - name: nvme.device_error_log_entries_rate
           description: Error log entries
           unit: entries/s
           dimensions:
             - name: error_log
+          chart_type: line
         - name: nvme.device_warning_composite_temperature_time
           description: Warning composite temperature time
           unit: seconds
           dimensions:
             - name: wctemp
+          chart_type: line
         - name: nvme.device_critical_composite_temperature_time
           description: Critical composite temperature time
           unit: seconds
           dimensions:
             - name: cctemp
+          chart_type: line
         - name: nvme.device_thermal_mgmt_temp1_transitions_rate
           description: Thermal management temp1 transitions
           unit: transitions/s
           dimensions:
             - name: temp1
+          chart_type: line
         - name: nvme.device_thermal_mgmt_temp2_transitions_rate
           description: Thermal management temp2 transitions
           unit: transitions/s
           dimensions:
             - name: temp2
+          chart_type: line
         - name: nvme.device_thermal_mgmt_temp1_time
           description: Thermal management temp1 time
           unit: seconds
           dimensions:
             - name: temp1
+          chart_type: line
         - name: nvme.device_thermal_mgmt_temp2_time
           description: Thermal management temp2 time
           unit: seconds
           dimensions:
             - name: temp2
+          chart_type: line

--- a/modules/openvpn/metadata.yaml
+++ b/modules/openvpn/metadata.yaml
@@ -2,76 +2,65 @@ name: openvpn
 title: OpenVPN collector
 overview:
   application:
-    description: |
-      [OpenVPN](https://openvpn.net/) is an open-source commercial software that implements virtual private network
-      techniques to create secure point-to-point or site-to-site connections in routed or bridged configurations and remote
-      access facilities.
+    description: "[OpenVPN](https://openvpn.net/) is an open-source commercial software
+      that implements virtual private network\ntechniques to create secure point-to-point
+      or site-to-site connections in routed or bridged configurations and remote\n
+      access facilities.\n"
   collector:
-    description: |
-      This collector monitors one or more OpenVPN servers, depending on your configuration.
-
-      It uses OpenVPN [Management Interface](https://openvpn.net/community-resources/management-interface/) to collect metrics.
+    description: "This collector monitors one or more OpenVPN servers, depending on
+      your configuration.\n\nIt uses OpenVPN [Management Interface](https://openvpn.net/community-resources/management-interface/)
+      to collect metrics.\n"
 setup:
   prerequisites:
     list:
       - title: Enable in go.d.conf.
-        text: |
-          This collector is disabled by default. You need to explicitly enable it in [go.d.conf](https://github.com/netdata/go.d.plugin/blob/master/config/go.d.conf).
-          
-          From the documentation for the OpenVPN Management Interface:
-          > Currently, the OpenVPN daemon can at most support a single management client any one time.
-
-          It is disabled to not break other tools which use `Management Interface`.
+        description: "This collector is disabled by default. You need to explicitly
+          enable it in [go.d.conf](https://github.com/netdata/go.d.plugin/blob/master/config/go.d.conf).\n
+          \nFrom the documentation for the OpenVPN Management Interface:\n> Currently,
+          the OpenVPN daemon can at most support a single management client any one
+          time.\n\nIt is disabled to not break other tools which use `Management Interface`.\n"
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: address
           description: Server address in IP:PORT format.
-          default: 127.0.0.1:7505
           required: true
+          default_value: 127.0.0.1:7505
         - name: per_user_stats
           description: User selector. Determines which user metrics will be collected.
-          default: ""
           required: false
-          details: |
-            Metrics of users matching the selector will be collected.
-            - Logic: (pattern1 OR pattern2) AND !(pattern3 or pattern4)
-            - Pattern syntax: [matcher](https://github.com/netdata/go.d.plugin/tree/master/pkg/matcher#supported-format).
-            - Syntax:
-              ```yaml
-              per_user_stats:
-                includes:
-                  - pattern1
-                  - pattern2
-                excludes:
-                  - pattern3
-                  - pattern4
-              ```
+          details: "Metrics of users matching the selector will be collected.\n- Logic:
+            (pattern1 OR pattern2) AND !(pattern3 or pattern4)\n- Pattern syntax:
+            [matcher](https://github.com/netdata/go.d.plugin/tree/master/pkg/matcher#supported-format).\n
+            - Syntax:\n  ```yaml\n  per_user_stats:\n    includes:\n      - pattern1\n\
+            \      - pattern2\n    excludes:\n      - pattern3\n      - pattern4\n\
+            \  ```\n"
+          default_value: ''
         - name: connect_timeout
-          description: Connection timeout in seconds. The timeout includes name resolution, if required.
-          default: 2
+          description: Connection timeout in seconds. The timeout includes name resolution,
+            if required.
           required: false
+          default_value: 2
         - name: read_timeout
           description: Read timeout in seconds. Sets deadline for read calls.
-          default: 2
           required: false
+          default_value: 2
         - name: write_timeout
           description: Write timeout in seconds. Sets deadline for write calls.
-          default: 2
           required: false
+          default_value: 2
     examples:
       folding:
         title: Config
@@ -79,31 +68,18 @@ setup:
       list:
         - name: Basic
           description: A basic example configuration.
-          data: |
-            jobs:
-              - name: local
-                address: 127.0.0.1:7505
+          config: "jobs:\n  - name: local\n    address: 127.0.0.1:7505\n"
         - name: With user metrics
           description: Collect metrics of all users.
-          data: |
-            jobs:
-              - name: local
-                address: 127.0.0.1:7505
-                per_user_stats:
-                  includes:
-                    - "* *"
+          config: "jobs:\n  - name: local\n    address: 127.0.0.1:7505\n    per_user_stats:\n\
+            \      includes:\n        - \"* *\"\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-
-            Collecting metrics from local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                address: 127.0.0.1:7505
-            
-              - name: remote
-                address: 203.0.113.0:7505
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nCollecting metrics from local and remote instances.\n"
+          config: "jobs:\n  - name: local\n    address: 127.0.0.1:7505\n\n  - name:
+            remote\n    address: 203.0.113.0:7505\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -111,8 +87,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -122,12 +99,14 @@ metrics:
           unit: clients
           dimensions:
             - name: clients
+          chart_type: line
         - name: openvpn.total_traffic
           description: Total Traffic
           unit: kilobits/s
           dimensions:
             - name: in
             - name: out
+          chart_type: area
     - name: user
       description: These metrics refer to the VPN user.
       labels:
@@ -140,8 +119,10 @@ metrics:
           dimensions:
             - name: in
             - name: out
+          chart_type: area
         - name: openvpn.user_connection_time
           description: User Connection Time
           unit: seconds
           dimensions:
             - name: time
+          chart_type: line

--- a/modules/openvpn_status_log/metadata.yaml
+++ b/modules/openvpn_status_log/metadata.yaml
@@ -2,54 +2,45 @@ name: openvpn_status_log
 title: OpenVPN collector
 overview:
   application:
-    description: |
-      [OpenVPN](https://openvpn.net/) is an open-source commercial software that implements virtual private network
-      techniques to create secure point-to-point or site-to-site connections in routed or bridged configurations and remote
-      access facilities.
+    description: "[OpenVPN](https://openvpn.net/) is an open-source commercial software
+      that implements virtual private network\ntechniques to create secure point-to-point
+      or site-to-site connections in routed or bridged configurations and remote\n
+      access facilities.\n"
   collector:
-    description: |
-      This collector parses server log files and provides summary and per user metrics.
+    description: "This collector parses server log files and provides summary and
+      per user metrics.\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: log_path
           description: Path to status log.
-          default: /var/log/openvpn/status.log
           required: true
+          default_value: /var/log/openvpn/status.log
         - name: per_user_stats
           description: User selector. Determines which user metrics will be collected.
-          default: ""
           required: false
-          details: |
-            Metrics of users matching the selector will be collected.
-            - Logic: (pattern1 OR pattern2) AND !(pattern3 or pattern4)
-            - Pattern syntax: [matcher](https://github.com/netdata/go.d.plugin/tree/master/pkg/matcher#supported-format).
-            - Syntax:
-              ```yaml
-              per_user_stats:
-                includes:
-                  - pattern1
-                  - pattern2
-                excludes:
-                  - pattern3
-                  - pattern4
-              ```
+          details: "Metrics of users matching the selector will be collected.\n- Logic:
+            (pattern1 OR pattern2) AND !(pattern3 or pattern4)\n- Pattern syntax:
+            [matcher](https://github.com/netdata/go.d.plugin/tree/master/pkg/matcher#supported-format).\n
+            - Syntax:\n  ```yaml\n  per_user_stats:\n    includes:\n      - pattern1\n\
+            \      - pattern2\n    excludes:\n      - pattern3\n      - pattern4\n\
+            \  ```\n"
+          default_value: ''
     examples:
       folding:
         title: Config
@@ -57,12 +48,10 @@ setup:
       list:
         - name: With user metrics
           description: Collect metrics of all users.
-          data: |
-            jobs:
-              - name: local
-                per_user_stats:
-                  includes:
-                    - "* *"
+          config: "jobs:\n  - name: local\n    per_user_stats:\n      includes:\n\
+            \        - \"* *\"\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -70,8 +59,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -81,12 +71,14 @@ metrics:
           unit: clients
           dimensions:
             - name: clients
+          chart_type: line
         - name: openvpn.total_traffic
           description: Total Traffic
           unit: kilobits/s
           dimensions:
             - name: in
             - name: out
+          chart_type: area
     - name: user
       description: These metrics refer to the VPN user.
       labels:
@@ -99,8 +91,10 @@ metrics:
           dimensions:
             - name: in
             - name: out
+          chart_type: area
         - name: openvpn.user_connection_time
           description: User Connection Time
           unit: seconds
           dimensions:
             - name: time
+          chart_type: line

--- a/modules/pgbouncer/metadata.yaml
+++ b/modules/pgbouncer/metadata.yaml
@@ -2,74 +2,50 @@ name: pgbouncer
 title: PgBouncer collector
 overview:
   application:
-    description: |
-      [PgBouncer](https://www.pgbouncer.org/) is an open-source connection pooler
-      for [PostgreSQL](https://www.postgresql.org/).
+    description: "[PgBouncer](https://www.pgbouncer.org/) is an open-source connection
+      pooler\nfor [PostgreSQL](https://www.postgresql.org/).\n"
   collector:
-    description: |
-      This collector monitors one or more PgBouncer servers, depending on your configuration.
-
-      Executed queries:
-
-      - `SHOW VERSION;`
-      - `SHOW CONFIG;`
-      - `SHOW DATABASES;`
-      - `SHOW STATS;`
-      - `SHOW POOLS;`
-
-      Information about the queries can be found in the [PgBouncer Documentation](http://pgbouncer.org/usage.html).
+    description: "This collector monitors one or more PgBouncer servers, depending
+      on your configuration.\n\nExecuted queries:\n\n- `SHOW VERSION;`\n- `SHOW CONFIG;`\n
+      - `SHOW DATABASES;`\n- `SHOW STATS;`\n- `SHOW POOLS;`\n\nInformation about the
+      queries can be found in the [PgBouncer Documentation](http://pgbouncer.org/usage.html).\n"
 setup:
   prerequisites:
     list:
       - title: Create netdata user
-        text: |
-          Create a user with `stats_users` permissions to query your PgBouncer instance.
-          
-          To create the `netdata` user:
-          
-          - Add `netdata` user to the `pgbouncer.ini` file:
-          
-            ```text
-            stats_users = netdata
-            ```
-          
-          - Add a password for the `netdata` user to the `userlist.txt` file:
-          
-            ```text
-            "netdata" "<PASSWORD>"
-            ```
-          
-          - To verify the credentials, run the following command
-          
-            ```bash
-            psql -h localhost -U netdata -p 6432 pgbouncer -c "SHOW VERSION;" >/dev/null 2>&1 && echo OK || echo FAIL
-            ```
-          
-            When it prompts for a password, enter the password you added to `userlist.txt`.
+        description: "Create a user with `stats_users` permissions to query your PgBouncer
+          instance.\n\nTo create the `netdata` user:\n\n- Add `netdata` user to the
+          `pgbouncer.ini` file:\n\n  ```text\n  stats_users = netdata\n  ```\n\n-
+          Add a password for the `netdata` user to the `userlist.txt` file:\n\n  ```text\n\
+          \  \"netdata\" \"<PASSWORD>\"\n  ```\n\n- To verify the credentials, run
+          the following command\n\n  ```bash\n  psql -h localhost -U netdata -p 6432
+          pgbouncer -c \"SHOW VERSION;\" >/dev/null 2>&1 && echo OK || echo FAIL\n\
+          \  ```\n\n  When it prompts for a password, enter the password you added
+          to `userlist.txt`.\n"
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 5
           required: false
+          default_value: 5
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: dsn
-          description: PgBouncer server DSN (Data Source Name). See [DSN syntax](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING).
-          default: postgres://postgres:postgres@127.0.0.1:6432/pgbouncer
+          description: PgBouncer server DSN (Data Source Name). See [DSN 
+            syntax](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING).
           required: true
+          default_value: postgres://postgres:postgres@127.0.0.1:6432/pgbouncer
         - name: timeout
           description: Query timeout in seconds.
-          default: 1
           required: false
+          default_value: 1
     examples:
       folding:
         title: Config
@@ -77,28 +53,18 @@ setup:
       list:
         - name: TCP socket
           description: An example configuration.
-          data: |
-            jobs:
-              - name: local
-                dsn: 'postgres://postgres:postgres@127.0.0.1:6432/pgbouncer'
+          config: "jobs:\n  - name: local\n    dsn: 'postgres://postgres:postgres@127.0.0.1:6432/pgbouncer'\n"
         - name: Unix socket
           description: An example configuration.
-          data: |
-            jobs:
-              - name: local
-                dsn: 'host=/tmp dbname=pgbouncer user=postgres port=6432'
+          config: "jobs:\n  - name: local\n    dsn: 'host=/tmp dbname=pgbouncer user=postgres
+            port=6432'\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-            
-            Local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                dsn: 'postgres://postgres:postgres@127.0.0.1:6432/pgbouncer'
-
-              - name: remote
-                dsn: 'postgres://postgres:postgres@203.0.113.10:6432/pgbouncer'
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nLocal and remote instances.\n"
+          config: "jobs:\n  - name: local\n    dsn: 'postgres://postgres:postgres@127.0.0.1:6432/pgbouncer'\n\
+            \n  - name: remote\n    dsn: 'postgres://postgres:postgres@203.0.113.10:6432/pgbouncer'\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -106,8 +72,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -117,6 +84,7 @@ metrics:
           unit: percentage
           dimensions:
             - name: used
+          chart_type: line
     - name: database
       description: These metrics refer to the database.
       labels:
@@ -132,6 +100,7 @@ metrics:
             - name: active
             - name: waiting
             - name: cancel_req
+          chart_type: line
         - name: pgbouncer.db_server_connections
           description: Database server connections
           unit: connections
@@ -141,54 +110,65 @@ metrics:
             - name: used
             - name: tested
             - name: login
+          chart_type: line
         - name: pgbouncer.db_server_connections_utilization
           description: Database server connections utilization
           unit: percentage
           dimensions:
             - name: used
+          chart_type: line
         - name: pgbouncer.db_clients_wait_time
           description: Database clients wait time
           unit: seconds
           dimensions:
             - name: time
+          chart_type: line
         - name: pgbouncer.db_client_max_wait_time
           description: Database client max wait time
           unit: seconds
           dimensions:
             - name: time
+          chart_type: line
         - name: pgbouncer.db_transactions
           description: Database pooled SQL transactions
           unit: transactions/s
           dimensions:
             - name: transactions
+          chart_type: line
         - name: pgbouncer.db_transactions_time
           description: Database transactions time
           unit: seconds
           dimensions:
             - name: time
+          chart_type: line
         - name: pgbouncer.db_transaction_avg_time
           description: Database transaction average time
           unit: seconds
           dimensions:
             - name: time
+          chart_type: line
         - name: pgbouncer.db_queries
           description: Database pooled SQL queries
           unit: queries/s
           dimensions:
             - name: queries
+          chart_type: line
         - name: pgbouncer.db_queries_time
           description: Database queries time
           unit: seconds
           dimensions:
             - name: time
+          chart_type: line
         - name: pgbouncer.db_query_avg_time
           description: Database query average time
           unit: seconds
           dimensions:
             - name: time
+          chart_type: line
         - name: pgbouncer.db_network_io
           description: Database traffic
           unit: B/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: area

--- a/modules/phpdaemon/metadata.yaml
+++ b/modules/phpdaemon/metadata.yaml
@@ -2,168 +2,118 @@ name: phpdaemon
 title: phpDaemon collector
 overview:
   application:
-    description: |
-      [phpDaemon](https://github.com/kakserpom/phpdaemon) is an asynchronous server-side framework for Web and network
-      applications implemented in PHP using libevent.
+    description: "[phpDaemon](https://github.com/kakserpom/phpdaemon) is an asynchronous
+      server-side framework for Web and network\napplications implemented in PHP using
+      libevent.\n"
   collector:
-    description: |
-      This collector monitors metrics from one or more phpDaemon instances, depending on your configuration.
+    description: "This collector monitors metrics from one or more phpDaemon instances,
+      depending on your configuration.\n"
 setup:
   prerequisites:
     list:
       - title: Enable phpDaemon's HTTP server
-        text: |
-          Statistics expected to be in JSON format.
-          
-          <details>
-          <summary>phpDaemon configuration</summary>
-
-          Instruction from [@METAJIJI](https://github.com/METAJIJI).
-
-          For enable `phpd` statistics on http, you must enable the http server and write an application.
-
-          Application is important, because standalone
-          application [ServerStatus.php](https://github.com/kakserpom/phpdaemon/blob/master/PHPDaemon/Applications/ServerStatus.php)
-          provides statistics in html format and unusable for `netdata`.
-          
-          ```php
-          // /opt/phpdaemon/conf/phpd.conf
-
-          path /opt/phpdaemon/conf/AppResolver.php;
-          Pool:HTTPServer {
-              privileged;
-              listen '127.0.0.1';
-              port 8509;
-          }
-          ```
-          
-          ```php
-          // /opt/phpdaemon/conf/AppResolver.php
-
-          <?php
-          
-          class MyAppResolver extends \PHPDaemon\Core\AppResolver {
-              public function getRequestRoute($req, $upstream) {
-                  if (preg_match('~^/(ServerStatus|FullStatus)/~', $req->attrs->server['DOCUMENT_URI'], $m)) {
-                      return $m[1];
-                  }
-              }
-          }
-          
-          return new MyAppResolver;
-          ```
-          
-          ```php
-          /opt/phpdaemon/conf/PHPDaemon/Applications/FullStatus.php
-
-          <?php
-          namespace PHPDaemon\Applications;
-          
-          class FullStatus extends \PHPDaemon\Core\AppInstance {
-              public function beginRequest($req, $upstream) {
-                  return new FullStatusRequest($this, $upstream, $req);
-              }
-          }
-          ```
-          
-          ```php
-          // /opt/phpdaemon/conf/PHPDaemon/Applications/FullStatusRequest.php
-          
-          <?php
-          namespace PHPDaemon\Applications;
-          
-          use PHPDaemon\Core\Daemon;
-          use PHPDaemon\HTTPRequest\Generic;
-          
-          class FullStatusRequest extends Generic {
-              public function run() {
-                  $stime = microtime(true);
-                  $this->header('Content-Type: application/javascript; charset=utf-8');
-          
-                  $stat = Daemon::getStateOfWorkers();
-                  $stat['uptime'] = time() - Daemon::$startTime;
-                  echo json_encode($stat);
-              }
-          }
-          ```
-
-          </details>
+        description: "Statistics expected to be in JSON format.\n\n<details>\n<summary>phpDaemon
+          configuration</summary>\n\nInstruction from [@METAJIJI](https://github.com/METAJIJI).\n
+          \nFor enable `phpd` statistics on http, you must enable the http server
+          and write an application.\n\nApplication is important, because standalone\n
+          application [ServerStatus.php](https://github.com/kakserpom/phpdaemon/blob/master/PHPDaemon/Applications/ServerStatus.php)\n
+          provides statistics in html format and unusable for `netdata`.\n\n```php\n
+          // /opt/phpdaemon/conf/phpd.conf\n\npath /opt/phpdaemon/conf/AppResolver.php;\n
+          Pool:HTTPServer {\n    privileged;\n    listen '127.0.0.1';\n    port 8509;\n
+          }\n```\n\n```php\n// /opt/phpdaemon/conf/AppResolver.php\n\n<?php\n\nclass
+          MyAppResolver extends \\PHPDaemon\\Core\\AppResolver {\n    public function
+          getRequestRoute($req, $upstream) {\n        if (preg_match('~^/(ServerStatus|FullStatus)/~',
+          $req->attrs->server['DOCUMENT_URI'], $m)) {\n            return $m[1];\n\
+          \        }\n    }\n}\n\nreturn new MyAppResolver;\n```\n\n```php\n/opt/phpdaemon/conf/PHPDaemon/Applications/FullStatus.php\n
+          \n<?php\nnamespace PHPDaemon\\Applications;\n\nclass FullStatus extends
+          \\PHPDaemon\\Core\\AppInstance {\n    public function beginRequest($req,
+          $upstream) {\n        return new FullStatusRequest($this, $upstream, $req);\n\
+          \    }\n}\n```\n\n```php\n// /opt/phpdaemon/conf/PHPDaemon/Applications/FullStatusRequest.php\n
+          \n<?php\nnamespace PHPDaemon\\Applications;\n\nuse PHPDaemon\\Core\\Daemon;\n
+          use PHPDaemon\\HTTPRequest\\Generic;\n\nclass FullStatusRequest extends
+          Generic {\n    public function run() {\n        $stime = microtime(true);\n\
+          \        $this->header('Content-Type: application/javascript; charset=utf-8');\n\
+          \n        $stat = Daemon::getStateOfWorkers();\n        $stat['uptime']
+          = time() - Daemon::$startTime;\n        echo json_encode($stat);\n    }\n\
+          }\n```\n\n</details>\n"
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: http://127.0.0.1:8509/FullStatus
           required: true
+          default_value: http://127.0.0.1:8509/FullStatus
         - name: timeout
           description: HTTP request timeout.
-          default: 2
           required: false
+          default_value: 2
         - name: username
           description: Username for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: password
           description: Password for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_url
           description: Proxy URL.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_username
           description: Username for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_password
           description: Password for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: method
           description: HTTP request method.
-          default: "GET"
           required: false
+          default_value: GET
         - name: body
           description: HTTP request body.
-          default: ""
           required: false
+          default_value: ''
         - name: headers
           description: HTTP request headers.
-          default: ""
           required: false
+          default_value: ''
         - name: not_follow_redirects
-          description: Redirect handling policy. Controls whether the client follows redirects.
-          default: no
+          description: Redirect handling policy. Controls whether the client follows
+            redirects.
           required: false
+          default_value: no
         - name: tls_skip_verify
-          description: Server certificate chain and hostname validation policy. Controls whether the client performs this check.
-          default: no
+          description: Server certificate chain and hostname validation policy. Controls
+            whether the client performs this check.
           required: false
+          default_value: no
         - name: tls_ca
-          description: Certification authority that the client uses when verifying the server's certificates.
-          default: ""
+          description: Certification authority that the client uses when verifying
+            the server's certificates.
           required: false
+          default_value: ''
         - name: tls_cert
           description: Client TLS certificate.
-          default: ""
           required: false
+          default_value: ''
         - name: tls_key
           description: Client TLS key.
-          default: ""
           required: false
+          default_value: ''
     examples:
       folding:
         title: Config
@@ -171,37 +121,22 @@ setup:
       list:
         - name: Basic
           description: A basic example configuration.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8509/FullStatus
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8509/FullStatus\n"
         - name: HTTP authentication
           description: HTTP authentication.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8509/FullStatus
-                username: username
-                password: password
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8509/FullStatus\n\
+            \    username: username\n    password: password\n"
         - name: HTTPS with self-signed certificate
           description: HTTPS with self-signed certificate.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8509/FullStatus
-                tls_skip_verify: yes
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8509/FullStatus\n\
+            \    tls_skip_verify: yes\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-
-            Collecting metrics from local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8509/FullStatus
-            
-              - name: remote
-                url: http://192.0.2.1:8509/FullStatus
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nCollecting metrics from local and remote instances.\n"
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8509/FullStatus\n\
+            \n  - name: remote\n    url: http://192.0.2.1:8509/FullStatus\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -209,8 +144,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -221,6 +157,7 @@ metrics:
           dimensions:
             - name: alive
             - name: shutdown
+          chart_type: line
         - name: phpdaemon.alive_workers
           description: Alive Workers State
           unit: workers
@@ -228,6 +165,7 @@ metrics:
             - name: idle
             - name: busy
             - name: reloading
+          chart_type: line
         - name: phpdaemon.idle_workers
           description: Idle Workers State
           unit: workers
@@ -235,8 +173,10 @@ metrics:
             - name: preinit
             - name: init
             - name: initialized
+          chart_type: line
         - name: phpdaemon.uptime
           description: Uptime
           unit: seconds
           dimensions:
             - name: time
+          chart_type: line

--- a/modules/phpfpm/metadata.yaml
+++ b/modules/phpfpm/metadata.yaml
@@ -2,106 +2,108 @@ name: phpfpm
 title: PHP-FPM collector
 overview:
   application:
-    description: |
-      [PHP-FPM](https://php-fpm.org/) is an alternative PHP FastCGI implementation with some additional features useful for
-      sites of any size, especially busier sites.
+    description: "[PHP-FPM](https://php-fpm.org/) is an alternative PHP FastCGI implementation
+      with some additional features useful for\nsites of any size, especially busier
+      sites.\n"
   collector:
-    description: |
-      This collector monitors one or more PHP-FPM instances, depending on your configuration..
+    description: "This collector monitors one or more PHP-FPM instances, depending
+      on your configuration..\n"
 setup:
   prerequisites:
     list:
       - title: Enable status page
-        text: |
-          Uncomment the `pm.status_path = /status` variable in the `php-fpm` config file.
+        description: "Uncomment the `pm.status_path = /status` variable in the `php-fpm`
+          config file.\n"
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: http://127.0.0.1/status?full&json
           required: true
+          default_value: http://127.0.0.1/status?full&json
         - name: socket
           description: Server Unix socket.
-          default: ""
           required: false
+          default_value: ''
         - name: address
           description: Server address in IP:PORT format.
-          default: ""
           required: false
+          default_value: ''
         - name: fcgi_path
           description: Status path.
-          default: /status
           required: false
+          default_value: /status
         - name: timeout
           description: HTTP request timeout.
-          default: 1
           required: false
+          default_value: 1
         - name: username
           description: Username for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: password
           description: Password for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_url
           description: Proxy URL.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_username
           description: Username for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_password
           description: Password for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: method
           description: HTTP request method.
-          default: "GET"
           required: false
+          default_value: GET
         - name: body
           description: HTTP request body.
-          default: ""
           required: false
+          default_value: ''
         - name: headers
           description: HTTP request headers.
-          default: ""
           required: false
+          default_value: ''
         - name: not_follow_redirects
-          description: Redirect handling policy. Controls whether the client follows redirects.
-          default: no
+          description: Redirect handling policy. Controls whether the client follows
+            redirects.
           required: false
+          default_value: no
         - name: tls_skip_verify
-          description: Server certificate chain and hostname validation policy. Controls whether the client performs this check.
-          default: no
+          description: Server certificate chain and hostname validation policy. Controls
+            whether the client performs this check.
           required: false
+          default_value: no
         - name: tls_ca
-          description: Certification authority that the client uses when verifying the server's certificates.
-          default: ""
+          description: Certification authority that the client uses when verifying
+            the server's certificates.
           required: false
+          default_value: ''
         - name: tls_cert
           description: Client TLS certificate.
-          default: ""
           required: false
+          default_value: ''
         - name: tls_key
           description: Client TLS key.
-          default: ""
           required: false
+          default_value: ''
     examples:
       folding:
         title: Config
@@ -109,34 +111,20 @@ setup:
       list:
         - name: HTTP
           description: Collecting data from a local instance over HTTP.
-          data: |
-            jobs:
-              - name: local
-                url: http://localhost/status?full&json
+          config: "jobs:\n  - name: local\n    url: http://localhost/status?full&json\n"
         - name: Unix socket
           description: Collecting data from a local instance over Unix socket.
-          data: |
-            jobs:
-              - name: local
-                socket: '/tmp/php-fpm.sock'
+          config: "jobs:\n  - name: local\n    socket: '/tmp/php-fpm.sock'\n"
         - name: TCP socket
           description: Collecting data from a local instance over TCP socket.
-          data: |
-            jobs:
-              - name: local
-                address: 127.0.0.1:9000
+          config: "jobs:\n  - name: local\n    address: 127.0.0.1:9000\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-
-            Collecting metrics from local and remote instances.
-          data: |
-            jobs:
-                - name: local
-                  url: http://localhost/status?full&json
-            
-                - name: remote
-                  url: http://203.0.113.10/status?full&json
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nCollecting metrics from local and remote instances.\n"
+          config: "jobs:\n    - name: local\n      url: http://localhost/status?full&json\n\
+            \n    - name: remote\n      url: http://203.0.113.10/status?full&json\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -144,8 +132,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -157,17 +146,20 @@ metrics:
             - name: active
             - name: max_active
             - name: idle
+          chart_type: line
         - name: phpfpm.requests
           description: Requests
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: phpfpm.performance
           description: Performance
           unit: status
           dimensions:
             - name: max_children_reached
             - name: slow_requests
+          chart_type: line
         - name: phpfpm.request_duration
           description: Requests Duration Among All Idle Processes
           unit: milliseconds
@@ -175,6 +167,7 @@ metrics:
             - name: min
             - name: max
             - name: avg
+          chart_type: line
         - name: phpfpm.request_cpu
           description: Last Request CPU Usage Among All Idle Processes
           unit: percentage
@@ -182,6 +175,7 @@ metrics:
             - name: min
             - name: max
             - name: avg
+          chart_type: line
         - name: phpfpm.request_mem
           description: Last Request Memory Usage Among All Idle Processes
           unit: KB
@@ -189,3 +183,4 @@ metrics:
             - name: min
             - name: max
             - name: avg
+          chart_type: line

--- a/modules/pihole/metadata.yaml
+++ b/modules/pihole/metadata.yaml
@@ -2,98 +2,99 @@ name: pihole
 title: Pi-hole collector
 overview:
   application:
-    description: |
-      [Pi-hole](https://pi-hole.net) is a Linux network-level advertisement and Internet tracker blocking application which
-      acts as a DNS sinkhole, intended for use on a private network.
+    description: "[Pi-hole](https://pi-hole.net) is a Linux network-level advertisement
+      and Internet tracker blocking application which\nacts as a DNS sinkhole, intended
+      for use on a private network.\n"
   collector:
-    description: |
-      This collector monitors one or more Pi-hole instances using [PHP API](https://github.com/pi-hole/AdminLTE).
-      
-      The data provided by the API is for the last 24 hours. All collected values refer to this time period and not to the
-      module's collection interval.
+    description: "This collector monitors one or more Pi-hole instances using [PHP
+      API](https://github.com/pi-hole/AdminLTE).\n\nThe data provided by the API is
+      for the last 24 hours. All collected values refer to this time period and not
+      to the\nmodule's collection interval.\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 5
           required: false
+          default_value: 5
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: http://127.0.0.1
           required: true
+          default_value: http://127.0.0.1
         - name: setup_vars_path
           description: Path to setupVars.conf. This file is used to get the web password.
-          default: /etc/pihole/setupVars.conf
           required: false
+          default_value: /etc/pihole/setupVars.conf
         - name: timeout
           description: HTTP request timeout.
-          default: 5
           required: false
+          default_value: 5
         - name: username
           description: Username for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: password
           description: Password for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_url
           description: Proxy URL.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_username
           description: Username for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_password
           description: Password for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: method
           description: HTTP request method.
-          default: "GET"
           required: false
+          default_value: GET
         - name: body
           description: HTTP request body.
-          default: ""
           required: false
+          default_value: ''
         - name: headers
           description: HTTP request headers.
-          default: ""
           required: false
+          default_value: ''
         - name: not_follow_redirects
-          description: Redirect handling policy. Controls whether the client follows redirects.
-          default: no
+          description: Redirect handling policy. Controls whether the client follows
+            redirects.
           required: false
+          default_value: no
         - name: tls_skip_verify
-          description: Server certificate chain and hostname validation policy. Controls whether the client performs this check.
-          default: no
+          description: Server certificate chain and hostname validation policy. Controls
+            whether the client performs this check.
           required: false
+          default_value: no
         - name: tls_ca
-          description: Certification authority that the client uses when verifying the server's certificates.
-          default: ""
+          description: Certification authority that the client uses when verifying
+            the server's certificates.
           required: false
+          default_value: ''
         - name: tls_cert
           description: Client TLS certificate.
-          default: ""
           required: false
+          default_value: ''
         - name: tls_key
           description: Client TLS key.
-          default: ""
           required: false
+          default_value: ''
     examples:
       folding:
         title: Config
@@ -101,31 +102,18 @@ setup:
       list:
         - name: Basic
           description: A basic example configuration.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1\n"
         - name: HTTPS with self-signed certificate
           description: Remote instance with enabled HTTPS and self-signed certificate.
-          data: |
-            jobs:
-              - name: local
-                url: https://203.0.113.11
-                tls_skip_verify: yes
-                password: 1ebd33f882f9aa5fac26a7cb74704742f91100228eb322e41b7bd6e6aeb8f74b
+          config: "jobs:\n  - name: local\n    url: https://203.0.113.11\n    tls_skip_verify:
+            yes\n    password: 1ebd33f882f9aa5fac26a7cb74704742f91100228eb322e41b7bd6e6aeb8f74b\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-
-            Collecting metrics from local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1
-            
-              - name: remote
-                url: http://203.0.113.10
-                password: 1ebd33f882f9aa5fac26a7cb74704742f91100228eb322e41b7bd6e6aeb8f74b
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nCollecting metrics from local and remote instances.\n"
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1\n\n  - name:
+            remote\n    url: http://203.0.113.10\n    password: 1ebd33f882f9aa5fac26a7cb74704742f91100228eb322e41b7bd6e6aeb8f74b\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -133,8 +121,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -144,6 +133,7 @@ metrics:
           unit: queries
           dimensions:
             - name: queries
+          chart_type: line
         - name: pihole.dns_queries
           description: DNS Queries
           unit: queries
@@ -151,6 +141,7 @@ metrics:
             - name: cached
             - name: blocked
             - name: forwarded
+          chart_type: stacked
         - name: pihole.dns_queries_percentage
           description: DNS Queries Percentage
           unit: percentage
@@ -158,27 +149,32 @@ metrics:
             - name: cached
             - name: blocked
             - name: forwarded
+          chart_type: stacked
         - name: pihole.unique_clients
           description: Unique Clients
           unit: clients
           dimensions:
             - name: unique
+          chart_type: line
         - name: pihole.domains_on_blocklist
           description: Domains On Blocklist
           unit: domains
           dimensions:
             - name: blocklist
+          chart_type: line
         - name: pihole.blocklist_last_update
           description: Blocklist Last Update
           unit: seconds
           dimensions:
             - name: ago
+          chart_type: line
         - name: pihole.unwanted_domains_blocking_status
           description: Unwanted Domains Blocking Status
           unit: status
           dimensions:
             - name: enabled
             - name: disabled
+          chart_type: line
         - name: pihole.dns_queries_types
           description: DNS Queries Per Type
           unit: percentage
@@ -190,6 +186,7 @@ metrics:
             - name: soa
             - name: srv
             - name: txt
+          chart_type: stacked
         - name: pihole.dns_queries_forwarded_destination
           description: DNS Queries Per Destination
           unit: percentage
@@ -197,3 +194,4 @@ metrics:
             - name: cached
             - name: blocked
             - name: other
+          chart_type: stacked

--- a/modules/pika/metadata.yaml
+++ b/modules/pika/metadata.yaml
@@ -2,73 +2,70 @@ name: pika
 title: Pika collector
 overview:
   application:
-    description: |
-      [Pika](https://github.com/Qihoo360/pika#introduction%E4%B8%AD%E6%96%87) is a persistent huge storage service,
-      compatible with the vast majority of redis interfaces (details), including string, hash, list, zset, set and management
-      interfaces.
+    description: "[Pika](https://github.com/Qihoo360/pika#introduction%E4%B8%AD%E6%96%87)
+      is a persistent huge storage service,\ncompatible with the vast majority of
+      redis interfaces (details), including string, hash, list, zset, set and management\n\
+      interfaces.\n"
   collector:
-    description: |
-      This collector monitors one or more Pika instances, depending on your configuration.
-
-      It collects information and statistics about the server executing the following commands:
-
-      - [`INFO ALL`](https://github.com/Qihoo360/pika/wiki/pika-info%E4%BF%A1%E6%81%AF%E8%AF%B4%E6%98%8E)
+    description: "This collector monitors one or more Pika instances, depending on
+      your configuration.\n\nIt collects information and statistics about the server
+      executing the following commands:\n\n- [`INFO ALL`](https://github.com/Qihoo360/pika/wiki/pika-info%E4%BF%A1%E6%81%AF%E8%AF%B4%E6%98%8E)\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 5
           required: false
+          default_value: 5
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: address
           description: Pika server address.
-          default: redis://@localhost:9221
           required: true
-          details: |
-            There are two connection types: by tcp socket and by unix socket.
-
-            - Tcp connection: `redis://<user>:<password>@<host>:<port>/<db_number>`
-            - Unix connection: `unix://<user>:<password>@</path/to/redis.sock>?db=<db_number>`
+          details: "There are two connection types: by tcp socket and by unix socket.\n
+            \n- Tcp connection: `redis://<user>:<password>@<host>:<port>/<db_number>`\n
+            - Unix connection: `unix://<user>:<password>@</path/to/redis.sock>?db=<db_number>`\n"
+          default_value: redis://@localhost:9221
         - name: timeout
-          description: Dial (establishing new connections), read (socket reads) and write (socket writes) timeout in seconds.
-          default: 1
+          description: Dial (establishing new connections), read (socket reads) and
+            write (socket writes) timeout in seconds.
           required: false
+          default_value: 1
         - name: username
           description: Username used for authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: password
           description: Password used for authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: tls_skip_verify
-          description: Server certificate chain and hostname validation policy. Controls whether the client performs this check.
-          default: no
+          description: Server certificate chain and hostname validation policy. Controls
+            whether the client performs this check.
           required: false
+          default_value: no
         - name: tls_ca
-          description: Certificate authority that client use when verifying server certificates.
-          default: ""
+          description: Certificate authority that client use when verifying server
+            certificates.
           required: false
+          default_value: ''
         - name: tls_cert
           description: Client tls certificate.
-          default: ""
           required: false
+          default_value: ''
         - name: tls_key
           description: Client tls key.
-          default: ""
           required: false
+          default_value: ''
     examples:
       folding:
         title: Config
@@ -76,28 +73,17 @@ setup:
       list:
         - name: TCP socket
           description: An example configuration.
-          data: |
-            jobs:
-              - name: local
-                address: 'redis://@localhost:9221'
+          config: "jobs:\n  - name: local\n    address: 'redis://@localhost:9221'\n"
         - name: TCP socket with password
           description: An example configuration.
-          data: |
-            jobs:
-              - name: local
-                address: 'redis://:password@127.0.0.1:9221'
+          config: "jobs:\n  - name: local\n    address: 'redis://:password@127.0.0.1:9221'\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-            
-            Local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                address: 'redis://:password@127.0.0.1:9221'
-
-              - name: remote
-                address: 'redis://user:password@203.0.113.0:9221'
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nLocal and remote instances.\n"
+          config: "jobs:\n  - name: local\n    address: 'redis://:password@127.0.0.1:9221'\n\
+            \n  - name: remote\n    address: 'redis://user:password@203.0.113.0:9221'\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -105,8 +91,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -116,108 +103,130 @@ metrics:
           unit: connections
           dimensions:
             - name: accepted
+          chart_type: line
         - name: pika.clients
           description: Clients
           unit: clients
           dimensions:
             - name: connected
+          chart_type: line
         - name: pika.memory
           description: Memory usage
           unit: bytes
           dimensions:
             - name: used
+          chart_type: area
         - name: pika.connected_replicas
           description: Connected replicas
           unit: replicas
           dimensions:
             - name: connected
+          chart_type: line
         - name: pika.commands
           description: Processed commands
           unit: commands/s
           dimensions:
             - name: processed
+          chart_type: line
         - name: pika.commands_calls
           description: Calls per command
           unit: calls/s
           dimensions:
             - name: a dimension per command
+          chart_type: stacked
         - name: pika.database_strings_keys
           description: Strings type keys per database
           unit: keys
           dimensions:
             - name: a dimension per database
+          chart_type: stacked
         - name: pika.database_strings_expires_keys
           description: Strings type expires keys per database
           unit: keys
           dimensions:
             - name: a dimension per database
+          chart_type: stacked
         - name: pika.database_strings_invalid_keys
           description: Strings type invalid keys per database
           unit: keys
           dimensions:
             - name: a dimension per database
+          chart_type: stacked
         - name: pika.database_hashes_keys
           description: Hashes type keys per database
           unit: keys
           dimensions:
             - name: a dimension per database
+          chart_type: stacked
         - name: pika.database_hashes_expires_keys
           description: Hashes type expires keys per database
           unit: keys
           dimensions:
             - name: a dimension per database
+          chart_type: stacked
         - name: pika.database_hashes_invalid_keys
           description: Hashes type invalid keys per database
           unit: keys
           dimensions:
             - name: a dimension per database
+          chart_type: stacked
         - name: pika.database_lists_keys
           description: Lists type keys per database
           unit: keys
           dimensions:
             - name: a dimension per database
+          chart_type: stacked
         - name: pika.database_lists_expires_keys
           description: Lists type expires keys per database
           unit: keys
           dimensions:
             - name: a dimension per database
+          chart_type: stacked
         - name: pika.database_lists_invalid_keys
           description: Lists type invalid keys per database
           unit: keys
           dimensions:
             - name: a dimension per database
+          chart_type: stacked
         - name: pika.database_zsets_keys
           description: Zsets type keys per database
           unit: keys
           dimensions:
             - name: a dimension per database
+          chart_type: stacked
         - name: pika.database_zsets_expires_keys
           description: Zsets type expires keys per database
           unit: keys
           dimensions:
             - name: a dimension per database
+          chart_type: stacked
         - name: pika.database_zsets_invalid_keys
           description: Zsets type invalid keys per database
           unit: keys
           dimensions:
             - name: a dimension per database
+          chart_type: stacked
         - name: pika.database_sets_keys
           description: Sets type keys per database
           unit: keys
           dimensions:
             - name: a dimension per database
+          chart_type: stacked
         - name: pika.database_sets_expires_keys
           description: Sets type expires keys per database
           unit: keys
           dimensions:
             - name: a dimension per database
+          chart_type: stacked
         - name: pika.database_sets_invalid_keys
           description: Sets invalid keys per database
           unit: keys
           dimensions:
             - name: a dimension per database
+          chart_type: stacked
         - name: pika.uptime
           description: Uptime
           unit: seconds
           dimensions:
             - name: uptime
+          chart_type: line

--- a/modules/ping/metadata.yaml
+++ b/modules/ping/metadata.yaml
@@ -2,64 +2,53 @@ name: ping
 title: Ping collector
 overview:
   application:
-    description: ""
+    description: ''
   collector:
-    description: |
-      This module measures round-tripe time and packet loss by sending ping messages to network hosts.
-      
-      There are two operational modes:
-
-      - privileged (send raw ICMP ping, default). Requires
-        CAP_NET_RAW [capability](https://man7.org/linux/man-pages/man7/capabilities.7.html) or root privileges:
-        > **Note**: set automatically during Netdata installation.
-
-        ```bash
-        sudo setcap CAP_NET_RAW=eip <INSTALL_PREFIX>/usr/libexec/netdata/plugins.d/go.d.plugin
-        ```
-
-      - unprivileged (send UDP ping, Linux only).
-        Requires configuring [ping_group_range](https://www.man7.org/linux/man-pages/man7/icmp.7.html):
-
-        ```bash
-        sudo sysctl -w net.ipv4.ping_group_range="0 2147483647"
-        ```
-        To persist the change add `net.ipv4.ping_group_range="0 2147483647"` to `/etc/sysctl.conf` and
-        execute `sudo sysctl -p`.
+    description: "This module measures round-tripe time and packet loss by sending
+      ping messages to network hosts.\n\nThere are two operational modes:\n\n- privileged
+      (send raw ICMP ping, default). Requires\n  CAP_NET_RAW [capability](https://man7.org/linux/man-pages/man7/capabilities.7.html)
+      or root privileges:\n  > **Note**: set automatically during Netdata installation.\n\
+      \n  ```bash\n  sudo setcap CAP_NET_RAW=eip <INSTALL_PREFIX>/usr/libexec/netdata/plugins.d/go.d.plugin\n\
+      \  ```\n\n- unprivileged (send UDP ping, Linux only).\n  Requires configuring
+      [ping_group_range](https://www.man7.org/linux/man-pages/man7/icmp.7.html):\n\
+      \n  ```bash\n  sudo sysctl -w net.ipv4.ping_group_range=\"0 2147483647\"\n \
+      \ ```\n  To persist the change add `net.ipv4.ping_group_range=\"0 2147483647\"\
+      ` to `/etc/sysctl.conf` and\n  execute `sudo sysctl -p`.\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 5
           required: false
+          default_value: 5
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: hosts
           description: Network hosts.
-          default: ""
           required: true
+          default_value: ''
         - name: privileged
-          description: Ping packets type. "no" means send an "unprivileged" UDP ping,  "yes" - raw ICMP ping.
-          default: yes
+          description: Ping packets type. "no" means send an "unprivileged" UDP ping,  "yes"
+            - raw ICMP ping.
           required: false
+          default_value: yes
         - name: packets
           description: Number of ping packets to send.
-          default: 5
           required: false
+          default_value: 5
         - name: interval
           description: Timeout between sending ping packets.
-          default: 100ms
           required: false
+          default_value: 100ms
     examples:
       folding:
         title: Config
@@ -67,38 +56,20 @@ setup:
       list:
         - name: IPv4 hosts
           description: An example configuration.
-          data: |
-            jobs:
-              - name: example
-                hosts:
-                  - 192.0.2.0
-                  - 192.0.2.1
+          config: "jobs:\n  - name: example\n    hosts:\n      - 192.0.2.0\n     \
+            \ - 192.0.2.1\n"
         - name: Unprivileged mode
           description: An example configuration.
-          data: |
-            jobs:
-              - name: example
-                privileged: no
-                hosts:
-                  - 192.0.2.0
-                  - 192.0.2.1
+          config: "jobs:\n  - name: example\n    privileged: no\n    hosts:\n    \
+            \  - 192.0.2.0\n      - 192.0.2.1\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-            
-            Multiple instances.
-          data: |
-            jobs:
-              - name: example1
-                hosts:
-                  - 192.0.2.0
-                  - 192.0.2.1
-            
-              - name: example2
-                packets: 10
-                hosts:
-                  - 192.0.2.3
-                  - 192.0.2.4
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nMultiple instances.\n"
+          config: "jobs:\n  - name: example1\n    hosts:\n      - 192.0.2.0\n    \
+            \  - 192.0.2.1\n\n  - name: example2\n    packets: 10\n    hosts:\n  \
+            \    - 192.0.2.3\n      - 192.0.2.4\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -106,8 +77,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: host
       description: These metrics refer to the remote host.
       labels:
@@ -121,19 +93,23 @@ metrics:
             - name: min
             - name: max
             - name: avg
+          chart_type: line
         - name: ping.host_std_dev_rtt
           description: Ping round-trip time standard deviation
           unit: milliseconds
           dimensions:
             - name: std_dev
+          chart_type: line
         - name: ping.host_packet_loss
           description: Ping packet loss
           unit: percentage
           dimensions:
             - name: loss
+          chart_type: line
         - name: ping.host_packets
           description: Ping packets transferred
           unit: packets
           dimensions:
             - name: received
             - name: sent
+          chart_type: line

--- a/modules/portcheck/metadata.yaml
+++ b/modules/portcheck/metadata.yaml
@@ -2,41 +2,40 @@ name: portcheck
 title: TCP endpoint collector
 overview:
   application:
-    description: ""
+    description: ''
   collector:
-    description: |
-      This collector monitors one or more TCP services availability and response time.
+    description: "This collector monitors one or more TCP services availability and
+      response time.\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 5
           required: false
+          default_value: 5
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: host
           description: Remote host address in IPv4, IPv6 format, or DNS name.
-          default: ""
           required: true
+          default_value: ''
         - name: ports
           description: Remote host ports. Must be specified in numeric format.
-          default: ""
           required: true
+          default_value: ''
         - name: timeout
           description: HTTP request timeout.
-          default: 2
           required: false
+          default_value: 2
     examples:
       folding:
         title: Config
@@ -44,40 +43,20 @@ setup:
       list:
         - name: Check SSH and telnet
           description: An example configuration.
-          data: |
-            jobs:
-              - name: server1
-                host: 127.0.0.1
-                ports:
-                  - 22
-                  - 23
+          config: "jobs:\n  - name: server1\n    host: 127.0.0.1\n    ports:\n   \
+            \   - 22\n      - 23\n"
         - name: Check webserver with IPv6 address
           description: An example configuration.
-          data: |
-            jobs:
-              - name: server2
-                host: "[2001:DB8::1]"
-                ports:
-                  - 80
-                  - 8080
+          config: "jobs:\n  - name: server2\n    host: \"[2001:DB8::1]\"\n    ports:\n\
+            \      - 80\n      - 8080\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-            
-            Multiple instances.
-          data: |
-            jobs:
-              - name: server1
-                host: 127.0.0.1
-                ports:
-                  - 22
-                  - 23
-            
-              - name: server2
-                host: 203.0.113.10
-                ports:
-                  - 22
-                  - 23
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nMultiple instances.\n"
+          config: "jobs:\n  - name: server1\n    host: 127.0.0.1\n    ports:\n   \
+            \   - 22\n      - 23\n\n  - name: server2\n    host: 203.0.113.10\n  \
+            \  ports:\n      - 22\n      - 23\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -85,8 +64,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: tcp endpoint
       description: These metrics refer to the TCP endpoint.
       labels:
@@ -102,13 +82,16 @@ metrics:
             - name: success
             - name: failed
             - name: timeout
+          chart_type: line
         - name: portcheck.state_duration
           description: Current State Duration
           unit: seconds
           dimensions:
             - name: time
+          chart_type: line
         - name: portcheck.latency
           description: TCP Connection Latency
           unit: ms
           dimensions:
             - name: time
+          chart_type: line

--- a/modules/powerdns/metadata.yaml
+++ b/modules/powerdns/metadata.yaml
@@ -2,103 +2,100 @@ name: powerdns
 title: PowerDNS Authoritative Server collector
 overview:
   application:
-    description: |
-      [PowerDNS Authoritative Server](https://doc.powerdns.com/authoritative/) is a versatile nameserver which supports a
-      large number of backends.
+    description: "[PowerDNS Authoritative Server](https://doc.powerdns.com/authoritative/)
+      is a versatile nameserver which supports a\nlarge number of backends.\n"
   collector:
-    description: |
-      This collector monitors one or more PowerDNS Authoritative Server instances, depending on your configuration.
-      
-      It collects metrics from [the internal webserver](https://doc.powerdns.com/authoritative/http-api/index.html#webserver).
-      
-      Used endpoints:
-      
-      - [`/api/v1/servers/localhost/statistics`](https://doc.powerdns.com/authoritative/http-api/statistics.html)
+    description: "This collector monitors one or more PowerDNS Authoritative Server
+      instances, depending on your configuration.\n\nIt collects metrics from [the
+      internal webserver](https://doc.powerdns.com/authoritative/http-api/index.html#webserver).\n
+      \nUsed endpoints:\n\n- [`/api/v1/servers/localhost/statistics`](https://doc.powerdns.com/authoritative/http-api/statistics.html)\n"
 setup:
   prerequisites:
     list:
       - title: Enable webserver
-        text: |
-          Follow [webserver](https://doc.powerdns.com/authoritative/http-api/index.html#webserver) documentation.
+        description: "Follow [webserver](https://doc.powerdns.com/authoritative/http-api/index.html#webserver)
+          documentation.\n"
       - title: Enable HTTP API
-        text: |
-          Follow [HTTP API](https://doc.powerdns.com/authoritative/http-api/index.html#enabling-the-api) documentation.
+        description: "Follow [HTTP API](https://doc.powerdns.com/authoritative/http-api/index.html#enabling-the-api)
+          documentation.\n"
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: http://127.0.0.1:8081
           required: true
+          default_value: http://127.0.0.1:8081
         - name: timeout
           description: HTTP request timeout.
-          default: 1
           required: false
+          default_value: 1
         - name: username
           description: Username for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: password
           description: Password for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_url
           description: Proxy URL.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_username
           description: Username for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_password
           description: Password for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: method
           description: HTTP request method.
-          default: "GET"
           required: false
+          default_value: GET
         - name: body
           description: HTTP request body.
-          default: ""
           required: false
+          default_value: ''
         - name: headers
           description: HTTP request headers.
-          default: ""
           required: false
+          default_value: ''
         - name: not_follow_redirects
-          description: Redirect handling policy. Controls whether the client follows redirects.
-          default: no
+          description: Redirect handling policy. Controls whether the client follows
+            redirects.
           required: false
+          default_value: no
         - name: tls_skip_verify
-          description: Server certificate chain and hostname validation policy. Controls whether the client performs this check.
-          default: no
+          description: Server certificate chain and hostname validation policy. Controls
+            whether the client performs this check.
           required: false
+          default_value: no
         - name: tls_ca
-          description: Certification authority that the client uses when verifying the server's certificates.
-          default: ""
+          description: Certification authority that the client uses when verifying
+            the server's certificates.
           required: false
+          default_value: ''
         - name: tls_cert
           description: Client TLS certificate.
-          default: ""
           required: false
+          default_value: ''
         - name: tls_key
           description: Client TLS key.
-          default: ""
           required: false
+          default_value: ''
     examples:
       folding:
         title: Config
@@ -106,30 +103,18 @@ setup:
       list:
         - name: Basic
           description: An example configuration.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8081
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8081\n"
         - name: HTTP authentication
           description: Basic HTTP authentication.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8081
-                username: admin
-                password: password
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8081\n    username:
+            admin\n    password: password\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-            
-            Local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8081
-
-              - name: remote
-                url: http://203.0.113.0:8081
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nLocal and remote instances.\n"
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8081\n\n  - name:
+            remote\n    url: http://203.0.113.0:8081\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -137,8 +122,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -149,12 +135,14 @@ metrics:
           dimensions:
             - name: udp
             - name: tcp
+          chart_type: line
         - name: powerdns.questions_out
           description: Outgoing questions
           unit: questions/s
           dimensions:
             - name: udp
             - name: tcp
+          chart_type: line
         - name: powerdns.cache_usage
           description: Cache Usage
           unit: events/s
@@ -163,6 +151,7 @@ metrics:
             - name: query-cache-miss
             - name: packetcache-hit
             - name: packetcache-miss
+          chart_type: line
         - name: powerdns.cache_size
           description: Cache Size
           unit: entries
@@ -171,8 +160,10 @@ metrics:
             - name: packet-cache
             - name: key-cache
             - name: meta-cache
+          chart_type: line
         - name: powerdns.latency
           description: Answer latency
           unit: microseconds
           dimensions:
             - name: latency
+          chart_type: line

--- a/modules/powerdns_recursor/metadata.yaml
+++ b/modules/powerdns_recursor/metadata.yaml
@@ -2,104 +2,100 @@ name: powerdns_recursor
 title: PowerDNS Recursor collector
 overview:
   application:
-    description: |
-      [PowerDNS Recursor](https://doc.powerdns.com/recursor/) is a high-performance DNS recursor with built-in scripting
-      capabilities.
+    description: "[PowerDNS Recursor](https://doc.powerdns.com/recursor/) is a high-performance
+      DNS recursor with built-in scripting\ncapabilities.\n"
   collector:
-    description: |
-      This collector monitors one or more `PowerDNS Recursor` instances, depending on your configuration.
-
-      It collects metrics
-      from [the internal webserver](https://doc.powerdns.com/recursor/http-api/index.html#built-in-webserver-and-http-api).
-
-      Used endpoints:
-
-      - [`/api/v1/servers/localhost/statistics`](https://doc.powerdns.com/recursor/common/api/endpoint-statistics.html)
+    description: "This collector monitors one or more `PowerDNS Recursor` instances,
+      depending on your configuration.\n\nIt collects metrics\nfrom [the internal
+      webserver](https://doc.powerdns.com/recursor/http-api/index.html#built-in-webserver-and-http-api).\n
+      \nUsed endpoints:\n\n- [`/api/v1/servers/localhost/statistics`](https://doc.powerdns.com/recursor/common/api/endpoint-statistics.html)\n"
 setup:
   prerequisites:
     list:
       - title: Enable webserver
-        text: |
-          Follow [webserver](https://doc.powerdns.com/recursor/http-api/index.html#webserver) documentation.
+        description: "Follow [webserver](https://doc.powerdns.com/recursor/http-api/index.html#webserver)
+          documentation.\n"
       - title: Enable HTTP API
-        text: |
-          Follow [HTTP API](https://doc.powerdns.com/recursor/http-api/index.html#enabling-the-api) documentation.
+        description: "Follow [HTTP API](https://doc.powerdns.com/recursor/http-api/index.html#enabling-the-api)
+          documentation.\n"
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 5
           required: false
+          default_value: 5
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: http://127.0.0.1:8081
           required: true
+          default_value: http://127.0.0.1:8081
         - name: timeout
           description: HTTP request timeout.
-          default: 1
           required: false
+          default_value: 1
         - name: username
           description: Username for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: password
           description: Password for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_url
           description: Proxy URL.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_username
           description: Username for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_password
           description: Password for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: method
           description: HTTP request method.
-          default: "GET"
           required: false
+          default_value: GET
         - name: body
           description: HTTP request body.
-          default: ""
           required: false
+          default_value: ''
         - name: headers
           description: HTTP request headers.
-          default: ""
           required: false
+          default_value: ''
         - name: not_follow_redirects
-          description: Redirect handling policy. Controls whether the client follows redirects.
-          default: no
+          description: Redirect handling policy. Controls whether the client follows
+            redirects.
           required: false
+          default_value: no
         - name: tls_skip_verify
-          description: Server certificate chain and hostname validation policy. Controls whether the client performs this check.
-          default: no
+          description: Server certificate chain and hostname validation policy. Controls
+            whether the client performs this check.
           required: false
+          default_value: no
         - name: tls_ca
-          description: Certification authority that the client uses when verifying the server's certificates.
-          default: ""
+          description: Certification authority that the client uses when verifying
+            the server's certificates.
           required: false
+          default_value: ''
         - name: tls_cert
           description: Client TLS certificate.
-          default: ""
           required: false
+          default_value: ''
         - name: tls_key
           description: Client TLS key.
-          default: ""
           required: false
+          default_value: ''
     examples:
       folding:
         title: Config
@@ -107,30 +103,18 @@ setup:
       list:
         - name: Basic
           description: An example configuration.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8081
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8081\n"
         - name: HTTP authentication
           description: Basic HTTP authentication.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8081
-                username: admin
-                password: password
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8081\n    username:
+            admin\n    password: password\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-            
-            Local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8081
-
-              - name: remote
-                url: http://203.0.113.0:8081
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nLocal and remote instances.\n"
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8081\n\n  - name:
+            remote\n    url: http://203.0.113.0:8081\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -138,8 +122,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -151,6 +136,7 @@ metrics:
             - name: total
             - name: tcp
             - name: ipv6
+          chart_type: line
         - name: powerdns_recursor.questions_out
           description: Outgoing questions
           unit: questions/s
@@ -159,6 +145,7 @@ metrics:
             - name: tcp
             - name: ipv6
             - name: throttled
+          chart_type: line
         - name: powerdns_recursor.answer_time
           description: Queries answered within a time range
           unit: queries/s
@@ -168,6 +155,7 @@ metrics:
             - name: 10-100ms
             - name: 100-1000ms
             - name: slow
+          chart_type: line
         - name: powerdns_recursor.timeouts
           description: Timeouts on outgoing UDP queries
           unit: timeouts/s
@@ -175,6 +163,7 @@ metrics:
             - name: total
             - name: ipv4
             - name: ipv6
+          chart_type: line
         - name: powerdns_recursor.drops
           description: Drops
           unit: drops/s
@@ -184,6 +173,7 @@ metrics:
             - name: too-old-drops
             - name: truncated-drops
             - name: empty-queries
+          chart_type: line
         - name: powerdns_recursor.cache_usage
           description: Cache Usage
           unit: events/s
@@ -192,6 +182,7 @@ metrics:
             - name: cache-misses
             - name: packet-cache-hits
             - name: packet-cache-misses
+          chart_type: line
         - name: powerdns_recursor.cache_size
           description: Cache Size
           unit: entries
@@ -199,3 +190,4 @@ metrics:
             - name: cache
             - name: packet-cache
             - name: negative-cache
+          chart_type: line

--- a/modules/proxysql/metadata.yaml
+++ b/modules/proxysql/metadata.yaml
@@ -2,42 +2,42 @@ name: proxysql
 title: ProxySQL collector
 overview:
   application:
-    description: |
-      [ProxySQL](https://www.proxysql.com/) is an open-source proxy for mySQL.
+    description: "[ProxySQL](https://www.proxysql.com/) is an open-source proxy for
+      mySQL.\n"
   collector:
-    description: |
-      This module monitors one or more ProxySQL servers, depending on your configuration.
+    description: "This module monitors one or more ProxySQL servers, depending on
+      your configuration.\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 5
           required: false
+          default_value: 5
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: dsn
           description: Data Source Name. See [DSN syntax](https://github.com/go-sql-driver/mysql#dsn-data-source-name).
-          default: "stats:stats@tcp(127.0.0.1:6032)/"
           required: true
+          default_value: stats:stats@tcp(127.0.0.1:6032)/
         - name: my.cnf
-          description: Specifies my.cnf file to read connection parameters from under the [client] section.
-          default: ""
+          description: Specifies my.cnf file to read connection parameters from under
+            the [client] section.
           required: false
+          default_value: ''
         - name: timeout
           description: Query timeout in seconds.
-          default: 1
           required: false
+          default_value: 1
     examples:
       folding:
         title: Config
@@ -45,28 +45,17 @@ setup:
       list:
         - name: TCP socket
           description: An example configuration.
-          data: |
-            jobs:
-              - name: local
-                dsn: stats:stats@tcp(127.0.0.1:6032)/
+          config: "jobs:\n  - name: local\n    dsn: stats:stats@tcp(127.0.0.1:6032)/\n"
         - name: my.cnf
           description: An example configuration.
-          data: |
-            jobs:
-              - name: local
-                my.cnf: '/etc/my.cnf'
+          config: "jobs:\n  - name: local\n    my.cnf: '/etc/my.cnf'\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-            
-            Local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                dsn: stats:stats@tcp(127.0.0.1:6032)/
-
-              - name: remote
-                dsn: stats:stats@tcp(203.0.113.0:6032)/
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nLocal and remote instances.\n"
+          config: "jobs:\n  - name: local\n    dsn: stats:stats@tcp(127.0.0.1:6032)/\n\
+            \n  - name: remote\n    dsn: stats:stats@tcp(203.0.113.0:6032)/\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -74,8 +63,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -87,17 +77,20 @@ metrics:
             - name: connected
             - name: non_idle
             - name: hostgroup_locked
+          chart_type: line
         - name: proxysql.client_connections_rate
           description: Client connections rate
           unit: connections/s
           dimensions:
             - name: created
             - name: aborted
+          chart_type: line
         - name: proxysql.server_connections_count
           description: Server connections
           unit: connections
           dimensions:
             - name: connected
+          chart_type: line
         - name: proxysql.server_connections_rate
           description: Server connections rate
           unit: connections/s
@@ -105,33 +98,39 @@ metrics:
             - name: created
             - name: aborted
             - name: delayed
+          chart_type: line
         - name: proxysql.backends_traffic
           description: Backends traffic
           unit: B/s
           dimensions:
             - name: recv
             - name: sent
+          chart_type: line
         - name: proxysql.clients_traffic
           description: Clients traffic
           unit: B/s
           dimensions:
             - name: recv
             - name: sent
+          chart_type: line
         - name: proxysql.active_transactions_count
           description: Client connections that are currently processing a transaction
           unit: connections
           dimensions:
             - name: client
+          chart_type: line
         - name: proxysql.questions_rate
           description: Client requests / statements executed
           unit: questions/s
           dimensions:
             - name: questions
+          chart_type: line
         - name: proxysql.slow_queries_rate
           description: Slow queries
           unit: queries/s
           dimensions:
             - name: slow
+          chart_type: line
         - name: proxysql.queries_rate
           description: Queries rate
           unit: queries/s
@@ -147,12 +146,14 @@ metrics:
             - name: frontend_init_db
             - name: frontend_set_names
             - name: frontend_use_db
+          chart_type: stacked
         - name: proxysql.backend_statements_count
           description: Statements available across all backend connections
           unit: statements
           dimensions:
             - name: total
             - name: unique
+          chart_type: line
         - name: proxysql.backend_statements_rate
           description: Statements executed against the backends
           unit: statements/s
@@ -160,12 +161,14 @@ metrics:
             - name: prepare
             - name: execute
             - name: close
+          chart_type: stacked
         - name: proxysql.client_statements_count
           description: Statements that are in use by clients
           unit: statements
           dimensions:
             - name: total
             - name: unique
+          chart_type: line
         - name: proxysql.client_statements_rate
           description: Statements executed by clients
           unit: statements/s
@@ -173,27 +176,32 @@ metrics:
             - name: prepare
             - name: execute
             - name: close
+          chart_type: stacked
         - name: proxysql.cached_statements_count
           description: Global prepared statements
           unit: statements
           dimensions:
             - name: cached
+          chart_type: line
         - name: proxysql.query_cache_entries_count
           description: Query Cache entries
           unit: entries
           dimensions:
             - name: entries
+          chart_type: line
         - name: proxysql.query_cache_memory_used
           description: Query Cache memory used
           unit: B
           dimensions:
             - name: used
+          chart_type: line
         - name: proxysql.query_cache_io
           description: Query Cache I/O
           unit: B/s
           dimensions:
             - name: in
             - name: out
+          chart_type: line
         - name: proxysql.query_cache_requests_rate
           description: Query Cache requests
           unit: requests/s
@@ -201,41 +209,48 @@ metrics:
             - name: read
             - name: write
             - name: read_success
+          chart_type: line
         - name: proxysql.mysql_monitor_workers_count
           description: MySQL monitor workers
           unit: threads
           dimensions:
             - name: workers
             - name: auxiliary
+          chart_type: line
         - name: proxysql.mysql_monitor_workers_rate
           description: MySQL monitor workers rate
           unit: workers/s
           dimensions:
             - name: started
+          chart_type: line
         - name: proxysql.mysql_monitor_connect_checks_rate
           description: MySQL monitor connect checks
           unit: checks/s
           dimensions:
             - name: succeed
             - name: failed
+          chart_type: line
         - name: proxysql.mysql_monitor_ping_checks_rate
           description: MySQL monitor ping checks
           unit: checks/s
           dimensions:
             - name: succeed
             - name: failed
+          chart_type: line
         - name: proxysql.mysql_monitor_read_only_checks_rate
           description: MySQL monitor read only checks
           unit: checks/s
           dimensions:
             - name: succeed
             - name: failed
+          chart_type: line
         - name: proxysql.mysql_monitor_replication_lag_checks_rate
           description: MySQL monitor replication lag checks
           unit: checks/s
           dimensions:
             - name: succeed
             - name: failed
+          chart_type: line
         - name: proxysql.jemalloc_memory_used
           description: Jemalloc used memory
           unit: B
@@ -246,6 +261,7 @@ metrics:
             - name: metadata
             - name: resident
             - name: retained
+          chart_type: stacked
         - name: proxysql.memory_used
           description: Memory used
           unit: B
@@ -261,11 +277,13 @@ metrics:
             - name: mysql_threads
             - name: admin_threads
             - name: cluster_threads
+          chart_type: stacked
         - name: proxysql.uptime
           description: Uptime
           unit: seconds
           dimensions:
             - name: uptime
+          chart_type: line
     - name: command
       description: These metrics refer to the SQL command.
       labels:
@@ -277,11 +295,13 @@ metrics:
           unit: seconds
           dimensions:
             - name: uptime
+          chart_type: line
         - name: proxysql.mysql_command_execution_time
           description: MySQL command execution time
           unit: microseconds
           dimensions:
             - name: time
+          chart_type: line
         - name: proxysql.mysql_command_execution_duration
           description: MySQL command execution duration histogram
           unit: microseconds
@@ -298,6 +318,7 @@ metrics:
             - name: 5s
             - name: 10s
             - name: +Inf
+          chart_type: stacked
     - name: user
       description: These metrics refer to the user.
       labels:
@@ -309,11 +330,13 @@ metrics:
           unit: percentage
           dimensions:
             - name: used
+          chart_type: line
         - name: proxysql.mysql_user_connections_count
           description: MySQL user connections used
           unit: connections
           dimensions:
             - name: used
+          chart_type: line
     - name: backend
       description: These metrics refer to the backend server.
       labels:
@@ -330,31 +353,37 @@ metrics:
             - name: shunned
             - name: offline_soft
             - name: offline_hard
+          chart_type: line
         - name: proxysql.backend_connections_usage
           description: Backend connections usage
           unit: connections
           dimensions:
             - name: free
             - name: used
+          chart_type: line
         - name: proxysql.backend_connections_rate
           description: Backend connections established
           unit: connections/s
           dimensions:
             - name: succeed
             - name: failed
+          chart_type: line
         - name: proxysql.backend_queries_rate
           description: Backend queries
           unit: queries/s
           dimensions:
             - name: queries
+          chart_type: line
         - name: proxysql.backend_traffic
           description: Backend traffic
           unit: B/s
           dimensions:
             - name: recv
             - name: send
+          chart_type: line
         - name: proxysql.backend_latency
           description: Backend latency
           unit: microseconds
           dimensions:
             - name: latency
+          chart_type: line

--- a/modules/pulsar/metadata.yaml
+++ b/modules/pulsar/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -17,34 +72,40 @@ metrics:
             - name: subscriptions
             - name: producers
             - name: consumers
+          chart_type: line
         - name: pulsar.messages_rate
           description: Messages Rate
           unit: messages/s
           dimensions:
             - name: publish
             - name: dispatch
+          chart_type: line
         - name: pulsar.throughput_rate
           description: Throughput Rate
           unit: KiB/s
           dimensions:
             - name: publish
             - name: dispatch
+          chart_type: area
         - name: pulsar.storage_size
           description: Storage Size
           unit: KiB
           dimensions:
             - name: used
+          chart_type: line
         - name: pulsar.storage_operations_rate
           description: Storage Read/Write Operations Rate
           unit: message batches/s
           dimensions:
             - name: read
             - name: write
+          chart_type: area
         - name: pulsar.msg_backlog
           description: Messages Backlog Size
           unit: messages
           dimensions:
             - name: backlog
+          chart_type: line
         - name: pulsar.storage_write_latency
           description: Storage Write Latency
           unit: entries/s
@@ -59,6 +120,7 @@ metrics:
             - name: <=200ms
             - name: <=1s
             - name: '>1s'
+          chart_type: stacked
         - name: pulsar.entry_size
           description: Entry Size
           unit: entries/s
@@ -72,38 +134,45 @@ metrics:
             - name: <=100KB
             - name: <=1MB
             - name: '>1MB'
+          chart_type: stacked
         - name: pulsar.subscription_delayed
           description: Subscriptions Delayed for Dispatching
           unit: message batches
           dimensions:
             - name: delayed
+          chart_type: line
         - name: pulsar.subscription_msg_rate_redeliver
           description: Subscriptions Redelivered Message Rate
           unit: messages/s
           dimensions:
             - name: redelivered
+          chart_type: line
         - name: pulsar.subscription_blocked_on_unacked_messages
           description: Subscriptions Blocked On Unacked Messages
           unit: subscriptions
           dimensions:
             - name: blocked
+          chart_type: line
         - name: pulsar.replication_rate
           description: Replication Rate
           unit: messages/s
           dimensions:
             - name: in
             - name: out
+          chart_type: line
         - name: pulsar.replication_throughput_rate
           description: Replication Throughput Rate
           unit: KiB/s
           dimensions:
             - name: in
             - name: out
+          chart_type: line
         - name: pulsar.replication_backlog
           description: Replication Backlog
           unit: messages
           dimensions:
             - name: backlog
+          chart_type: line
     - name: namespace
       description: TBD
       labels: []
@@ -116,34 +185,40 @@ metrics:
             - name: subscriptions
             - name: producers
             - name: consumers
+          chart_type: line
         - name: pulsar.namespace_messages_rate
           description: Messages Rate
           unit: messages/s
           dimensions:
             - name: publish
             - name: dispatch
+          chart_type: line
         - name: pulsar.namespace_throughput_rate
           description: Throughput Rate
           unit: KiB/s
           dimensions:
             - name: publish
             - name: dispatch
+          chart_type: area
         - name: pulsar.namespace_storage_size
           description: Storage Size
           unit: KiB
           dimensions:
             - name: used
+          chart_type: line
         - name: pulsar.namespace_storage_operations_rate
           description: Storage Read/Write Operations Rate
           unit: message batches/s
           dimensions:
             - name: read
             - name: write
+          chart_type: area
         - name: pulsar.namespace_msg_backlog
           description: Messages Backlog Size
           unit: messages
           dimensions:
             - name: backlog
+          chart_type: line
         - name: pulsar.namespace_storage_write_latency
           description: Storage Write Latency
           unit: entries/s
@@ -158,6 +233,7 @@ metrics:
             - name: <=200ms
             - name: <=1s
             - name: '>1s'
+          chart_type: stacked
         - name: pulsar.namespace_entry_size
           description: Entry Size
           unit: entries/s
@@ -171,130 +247,156 @@ metrics:
             - name: <=100KB
             - name: <=1MB
             - name: '>1MB'
+          chart_type: stacked
         - name: pulsar.namespace_subscription_delayed
           description: Subscriptions Delayed for Dispatching
           unit: message batches
           dimensions:
             - name: delayed
+          chart_type: line
         - name: pulsar.namespace_subscription_msg_rate_redeliver
           description: Subscriptions Redelivered Message Rate
           unit: messages/s
           dimensions:
             - name: redelivered
+          chart_type: line
         - name: pulsar.namespace_subscription_blocked_on_unacked_messages
           description: Subscriptions Blocked On Unacked Messages
           unit: subscriptions
           dimensions:
             - name: blocked
+          chart_type: line
         - name: pulsar.namespace_replication_rate
           description: Replication Rate
           unit: messages/s
           dimensions:
             - name: in
             - name: out
+          chart_type: line
         - name: pulsar.namespace_replication_throughput_rate
           description: Replication Throughput Rate
           unit: KiB/s
           dimensions:
             - name: in
             - name: out
+          chart_type: line
         - name: pulsar.namespace_replication_backlog
           description: Replication Backlog
           unit: messages
           dimensions:
             - name: backlog
+          chart_type: line
         - name: pulsar.topic_producers
           description: Topic Producers
           unit: producers
           dimensions:
             - name: a dimension per topic
+          chart_type: stacked
         - name: pulsar.topic_subscriptions
           description: Topic Subscriptions
           unit: subscriptions
           dimensions:
             - name: a dimension per topic
+          chart_type: stacked
         - name: pulsar.topic_consumers
           description: Topic Consumers
           unit: consumers
           dimensions:
             - name: a dimension per topic
+          chart_type: stacked
         - name: pulsar.topic_messages_rate_in
           description: Topic Publish Messages Rate
           unit: publishes/s
           dimensions:
             - name: a dimension per topic
+          chart_type: stacked
         - name: pulsar.topic_messages_rate_out
           description: Topic Dispatch Messages Rate
           unit: dispatches/s
           dimensions:
             - name: a dimension per topic
+          chart_type: stacked
         - name: pulsar.topic_throughput_rate_in
           description: Topic Publish Throughput Rate
           unit: KiB/s
           dimensions:
             - name: a dimension per topic
+          chart_type: stacked
         - name: pulsar.topic_throughput_rate_out
           description: Topic Dispatch Throughput Rate
           unit: KiB/s
           dimensions:
             - name: a dimension per topic
+          chart_type: stacked
         - name: pulsar.topic_storage_size
           description: Topic Storage Size
           unit: KiB
           dimensions:
             - name: a dimension per topic
+          chart_type: stacked
         - name: pulsar.topic_storage_read_rate
           description: Topic Storage Read Rate
           unit: message batches/s
           dimensions:
             - name: a dimension per topic
+          chart_type: stacked
         - name: pulsar.topic_storage_write_rate
           description: Topic Storage Write Rate
           unit: message batches/s
           dimensions:
             - name: a dimension per topic
+          chart_type: stacked
         - name: pulsar.topic_msg_backlog
           description: Topic Messages Backlog Size
           unit: messages
           dimensions:
             - name: a dimension per topic
+          chart_type: stacked
         - name: pulsar.topic_subscription_delayed
           description: Topic Subscriptions Delayed for Dispatching
           unit: message batches
           dimensions:
             - name: a dimension per topic
+          chart_type: stacked
         - name: pulsar.topic_subscription_msg_rate_redeliver
           description: Topic Subscriptions Redelivered Message Rate
           unit: messages/s
           dimensions:
             - name: a dimension per topic
+          chart_type: stacked
         - name: pulsar.topic_subscription_blocked_on_unacked_messages
           description: Topic Subscriptions Blocked On Unacked Messages
           unit: blocked subscriptions
           dimensions:
             - name: a dimension per topic
+          chart_type: stacked
         - name: pulsar.topic_replication_rate_in
           description: Topic Replication Rate From Remote Cluster
           unit: messages/s
           dimensions:
             - name: a dimension per topic
+          chart_type: stacked
         - name: pulsar.topic_replication_rate_out
           description: Topic Replication Rate To Remote Cluster
           unit: messages/s
           dimensions:
             - name: a dimension per topic
+          chart_type: stacked
         - name: pulsar.topic_replication_throughput_rate_in
           description: Topic Replication Throughput Rate From Remote Cluster
           unit: messages/s
           dimensions:
             - name: a dimension per topic
+          chart_type: stacked
         - name: pulsar.topic_replication_throughput_rate_out
           description: Topic Replication Throughput Rate To Remote Cluster
           unit: messages/s
           dimensions:
             - name: a dimension per topic
+          chart_type: stacked
         - name: pulsar.topic_replication_backlog
           description: Topic Replication Backlog
           unit: messages
           dimensions:
             - name: a dimension per topic
+          chart_type: stacked

--- a/modules/rabbitmq/metadata.yaml
+++ b/modules/rabbitmq/metadata.yaml
@@ -2,106 +2,105 @@ name: rabbitmq
 title: RabbitMQ collector
 overview:
   application:
-    description: |
-      [RabbitMQ](https://www.rabbitmq.com/) is an open-source message broker.
+    description: "[RabbitMQ](https://www.rabbitmq.com/) is an open-source message
+      broker.\n"
   collector:
-    description: |
-      This collector monitors one or more RabbitMQ instances, depending on your configuration.
-  
-      It collects data using an HTTP-based API provided by the [management plugin](https://www.rabbitmq.com/management.html).
-      The following endpoints are used:
-
-      - `/api/overview`
-      - `/api/node/{node_name}`
-      - `/api/vhosts`
-      - `/api/queues` (disabled by default)
+    description: "This collector monitors one or more RabbitMQ instances, depending
+      on your configuration.\n\nIt collects data using an HTTP-based API provided
+      by the [management plugin](https://www.rabbitmq.com/management.html).\nThe following
+      endpoints are used:\n\n- `/api/overview`\n- `/api/node/{node_name}`\n- `/api/vhosts`\n
+      - `/api/queues` (disabled by default)\n"
 setup:
   prerequisites:
     list:
       - title: Enable management plugin.
-        text: |
-          The management plugin is included in the RabbitMQ distribution, but disabled.
-          To enable see [Management Plugin](https://www.rabbitmq.com/management.html#getting-started) documentation.
+        description: "The management plugin is included in the RabbitMQ distribution,
+          but disabled.\nTo enable see [Management Plugin](https://www.rabbitmq.com/management.html#getting-started)
+          documentation.\n"
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: http://localhost:15672
           required: true
+          default_value: http://localhost:15672
         - name: collect_queues_metrics
-          description: Collect stats per vhost per queues. Enabling this can introduce serious overhead on both Netdata and RabbitMQ if many queues are configured and used.
-          default: no
+          description: Collect stats per vhost per queues. Enabling this can introduce
+            serious overhead on both Netdata and RabbitMQ if many queues are configured
+            and used.
           required: false
+          default_value: no
         - name: timeout
           description: HTTP request timeout.
-          default: 1
           required: false
+          default_value: 1
         - name: username
           description: Username for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: password
           description: Password for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_url
           description: Proxy URL.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_username
           description: Username for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_password
           description: Password for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: method
           description: HTTP request method.
-          default: "GET"
           required: false
+          default_value: GET
         - name: body
           description: HTTP request body.
-          default: ""
           required: false
+          default_value: ''
         - name: headers
           description: HTTP request headers.
-          default: ""
           required: false
+          default_value: ''
         - name: not_follow_redirects
-          description: Redirect handling policy. Controls whether the client follows redirects.
-          default: no
+          description: Redirect handling policy. Controls whether the client follows
+            redirects.
           required: false
+          default_value: no
         - name: tls_skip_verify
-          description: Server certificate chain and hostname validation policy. Controls whether the client performs this check.
-          default: no
+          description: Server certificate chain and hostname validation policy. Controls
+            whether the client performs this check.
           required: false
+          default_value: no
         - name: tls_ca
-          description: Certification authority that the client uses when verifying the server's certificates.
-          default: ""
+          description: Certification authority that the client uses when verifying
+            the server's certificates.
           required: false
+          default_value: ''
         - name: tls_cert
           description: Client TLS certificate.
-          default: ""
           required: false
+          default_value: ''
         - name: tls_key
           description: Client TLS key.
-          default: ""
           required: false
+          default_value: ''
     examples:
       folding:
         title: Config
@@ -109,30 +108,18 @@ setup:
       list:
         - name: Basic
           description: An example configuration.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:15672
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:15672\n"
         - name: Basic HTTP auth
           description: Local server with basic HTTP authentication.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:15672
-                username: admin
-                password: password
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:15672\n    username:
+            admin\n    password: password\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-
-            Local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:15672
-            
-              - name: remote
-                url: http://192.0.2.0:15672
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nLocal and remote instances.\n"
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:15672\n\n  -
+            name: remote\n    url: http://192.0.2.0:15672\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -140,8 +127,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -152,6 +140,7 @@ metrics:
           dimensions:
             - name: ready
             - name: unacknowledged
+          chart_type: stacked
         - name: rabbitmq.messages_rate
           description: Messages
           unit: messages/s
@@ -168,6 +157,7 @@ metrics:
             - name: deliver_get
             - name: redeliver
             - name: return_unroutable
+          chart_type: line
         - name: rabbitmq.objects_count
           description: Objects
           unit: messages
@@ -177,18 +167,21 @@ metrics:
             - name: connections
             - name: queues
             - name: exchanges
+          chart_type: line
         - name: rabbitmq.connection_churn_rate
           description: Connection churn
           unit: operations/s
           dimensions:
             - name: created
             - name: closed
+          chart_type: line
         - name: rabbitmq.channel_churn_rate
           description: Channel churn
           unit: operations/s
           dimensions:
             - name: created
             - name: closed
+          chart_type: line
         - name: rabbitmq.queue_churn_rate
           description: Queue churn
           unit: operations/s
@@ -196,39 +189,46 @@ metrics:
             - name: created
             - name: deleted
             - name: declared
+          chart_type: line
         - name: rabbitmq.file_descriptors_count
           description: File descriptors
           unit: fd
           dimensions:
             - name: available
             - name: used
+          chart_type: stacked
         - name: rabbitmq.sockets_count
           description: Used sockets
           unit: sockets
           dimensions:
             - name: available
             - name: used
+          chart_type: stacked
         - name: rabbitmq.erlang_processes_count
           description: Erlang processes
           unit: processes
           dimensions:
             - name: available
             - name: used
+          chart_type: stacked
         - name: rabbitmq.erlang_run_queue_processes_count
           description: Erlang run queue
           unit: processes
           dimensions:
             - name: length
+          chart_type: line
         - name: rabbitmq.memory_usage
           description: Memory
           unit: bytes
           dimensions:
             - name: used
+          chart_type: line
         - name: rabbitmq.disk_space_free_size
           description: Free disk space
           unit: bytes
           dimensions:
             - name: free
+          chart_type: line
     - name: vhost
       description: These metrics refer to the virtual host.
       labels:
@@ -241,6 +241,7 @@ metrics:
           dimensions:
             - name: ready
             - name: unacknowledged
+          chart_type: line
         - name: rabbitmq.vhost_messages_rate
           description: Vhost messages rate
           unit: messages/s
@@ -257,6 +258,7 @@ metrics:
             - name: deliver_get
             - name: redeliver
             - name: return_unroutable
+          chart_type: line
     - name: queue
       description: These metrics refer to the virtual host queue.
       labels:
@@ -273,6 +275,7 @@ metrics:
             - name: unacknowledged
             - name: paged_out
             - name: persistent
+          chart_type: line
         - name: rabbitmq.queue_messages_rate
           description: Queue messages rate
           unit: messages/s
@@ -289,3 +292,4 @@ metrics:
             - name: deliver_get
             - name: redeliver
             - name: return_unroutable
+          chart_type: line

--- a/modules/scaleio/metadata.yaml
+++ b/modules/scaleio/metadata.yaml
@@ -2,98 +2,95 @@ name: scaleio
 title: ScaleIO collector
 overview:
   application:
-    description: |
-      [Dell EMC ScaleIO](https://www.dellemc.com/en-us/storage/data-storage/software-defined-storage.htm) is a
-      software-defined storage product from Dell EMC that creates a server-based storage area network from local application
-      server storage using existing customer hardware or EMC servers.
+    description: "[Dell EMC ScaleIO](https://www.dellemc.com/en-us/storage/data-storage/software-defined-storage.htm)
+      is a\nsoftware-defined storage product from Dell EMC that creates a server-based
+      storage area network from local application\nserver storage using existing customer
+      hardware or EMC servers.\n"
   collector:
-    description: |
-      This collector monitors one or more ScaleIO (VxFlex OS) instances via VxFlex OS Gateway API.
-
-      It collects metrics for the following ScaleIO components:
-
-      - System
-      - Storage Pool
-      - Sdc
+    description: "This collector monitors one or more ScaleIO (VxFlex OS) instances
+      via VxFlex OS Gateway API.\n\nIt collects metrics for the following ScaleIO
+      components:\n\n- System\n- Storage Pool\n- Sdc\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 5
           required: false
+          default_value: 5
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: https://127.0.0.1:80
           required: true
+          default_value: https://127.0.0.1:80
         - name: timeout
           description: HTTP request timeout.
-          default: 1
           required: false
+          default_value: 1
         - name: username
           description: Username for basic HTTP authentication.
-          default: ""
           required: true
+          default_value: ''
         - name: password
           description: Password for basic HTTP authentication.
-          default: ""
           required: true
+          default_value: ''
         - name: proxy_url
           description: Proxy URL.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_username
           description: Username for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_password
           description: Password for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: method
           description: HTTP request method.
-          default: "GET"
           required: false
+          default_value: GET
         - name: body
           description: HTTP request body.
-          default: ""
           required: false
+          default_value: ''
         - name: headers
           description: HTTP request headers.
-          default: ""
           required: false
+          default_value: ''
         - name: not_follow_redirects
-          description: Redirect handling policy. Controls whether the client follows redirects.
-          default: no
+          description: Redirect handling policy. Controls whether the client follows
+            redirects.
           required: false
+          default_value: no
         - name: tls_skip_verify
-          description: Server certificate chain and hostname validation policy. Controls whether the client performs this check.
-          default: no
+          description: Server certificate chain and hostname validation policy. Controls
+            whether the client performs this check.
           required: false
+          default_value: no
         - name: tls_ca
-          description: Certification authority that the client uses when verifying the server's certificates.
-          default: ""
+          description: Certification authority that the client uses when verifying
+            the server's certificates.
           required: false
+          default_value: ''
         - name: tls_cert
           description: Client TLS certificate.
-          default: ""
           required: false
+          default_value: ''
         - name: tls_key
           description: Client TLS key.
-          default: ""
           required: false
+          default_value: ''
     examples:
       folding:
         title: Config
@@ -101,31 +98,18 @@ setup:
       list:
         - name: Basic
           description: An example configuration.
-          data: |
-            jobs:
-              - name: local
-                url: https://127.0.0.1
-                username: admin
-                password: password
-                tls_skip_verify: yes  # self-signed certificate
+          config: "jobs:\n  - name: local\n    url: https://127.0.0.1\n    username:
+            admin\n    password: password\n    tls_skip_verify: yes  # self-signed
+            certificate\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-            
-            Local and remote instance.
-          data: |
-            jobs:
-              - name: local
-                url: https://127.0.0.1
-                username: admin
-                password: password
-                tls_skip_verify: yes  # self-signed certificate
-
-              - name: remote
-                url: https://203.0.113.10
-                username: admin
-                password: password
-                tls_skip_verify: yes
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nLocal and remote instance.\n"
+          config: "jobs:\n  - name: local\n    url: https://127.0.0.1\n    username:
+            admin\n    password: password\n    tls_skip_verify: yes  # self-signed
+            certificate\n\n  - name: remote\n    url: https://203.0.113.10\n    username:
+            admin\n    password: password\n    tls_skip_verify: yes\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -133,8 +117,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -144,11 +129,13 @@ metrics:
           unit: KiB
           dimensions:
             - name: total
+          chart_type: line
         - name: scaleio.system_capacity_in_use
           description: Capacity In Use
           unit: KiB
           dimensions:
             - name: in_use
+          chart_type: line
         - name: scaleio.system_capacity_usage
           description: Capacity Usage
           unit: KiB
@@ -159,11 +146,13 @@ metrics:
             - name: snapshot
             - name: spare
             - name: unused
+          chart_type: stacked
         - name: scaleio.system_capacity_available_volume_allocation
           description: Available For Volume Allocation
           unit: KiB
           dimensions:
             - name: available
+          chart_type: line
         - name: scaleio.system_capacity_health_state
           description: Capacity Health State
           unit: KiB
@@ -173,60 +162,71 @@ metrics:
             - name: in_maintenance
             - name: failed
             - name: unavailable
+          chart_type: stacked
         - name: scaleio.system_workload_primary_bandwidth_total
           description: Primary Backend Bandwidth Total (Read and Write)
           unit: KiB/s
           dimensions:
             - name: total
+          chart_type: line
         - name: scaleio.system_workload_primary_bandwidth
           description: Primary Backend Bandwidth
           unit: KiB/s
           dimensions:
             - name: read
             - name: write
+          chart_type: area
         - name: scaleio.system_workload_primary_iops_total
           description: Primary Backend IOPS Total (Read and Write)
           unit: iops/s
           dimensions:
             - name: total
+          chart_type: line
         - name: scaleio.system_workload_primary_iops
           description: Primary Backend IOPS
           unit: iops/s
           dimensions:
             - name: read
             - name: write
+          chart_type: area
         - name: scaleio.system_workload_primary_io_size_total
           description: Primary Backend I/O Size Total (Read and Write)
           unit: KiB
           dimensions:
             - name: io_size
+          chart_type: line
         - name: scaleio.system_rebalance
           description: Rebalance
           unit: KiB/s
           dimensions:
             - name: read
             - name: write
+          chart_type: area
         - name: scaleio.system_rebalance_left
           description: Rebalance Pending Capacity
           unit: KiB
           dimensions:
             - name: left
+          chart_type: line
         - name: scaleio.system_rebalance_time_until_finish
           description: Rebalance Approximate Time Until Finish
           unit: seconds
           dimensions:
             - name: time
+          chart_type: line
         - name: scaleio.system_rebuild
           description: Rebuild Bandwidth Total (Forward, Backward and Normal)
           unit: KiB/s
           dimensions:
             - name: read
             - name: write
+          chart_type: area
         - name: scaleio.system_rebuild_left
           description: Rebuild Pending Capacity Total (Forward, Backward and Normal)
           unit: KiB
           dimensions:
             - name: left
+          chart_type: line
         - name: scaleio.system_defined_components
           description: Components
           unit: components
@@ -241,18 +241,21 @@ metrics:
             - name: storage_pools
             - name: volumes
             - name: vtrees
+          chart_type: line
         - name: scaleio.system_components_volumes_by_type
           description: Volumes By Type
           unit: volumes
           dimensions:
             - name: thick
             - name: thin
+          chart_type: stacked
         - name: scaleio.system_components_volumes_by_mapping
           description: Volumes By Mapping
           unit: volumes
           dimensions:
             - name: mapped
             - name: unmapped
+          chart_type: stacked
     - name: storage pool
       description: These metrics refer to the storage pool.
       labels: []
@@ -262,11 +265,13 @@ metrics:
           unit: KiB
           dimensions:
             - name: total
+          chart_type: line
         - name: scaleio.storage_pool_capacity_in_use
           description: Capacity In Use
           unit: KiB
           dimensions:
             - name: in_use
+          chart_type: line
         - name: scaleio.storage_pool_capacity_usage
           description: Capacity Usage
           unit: KiB
@@ -277,16 +282,19 @@ metrics:
             - name: snapshot
             - name: spare
             - name: unused
+          chart_type: stacked
         - name: scaleio.storage_pool_capacity_utilization
           description: Capacity Utilization
           unit: percentage
           dimensions:
             - name: used
+          chart_type: line
         - name: scaleio.storage_pool_capacity_available_volume_allocation
           description: Available For Volume Allocation
           unit: KiB
           dimensions:
             - name: available
+          chart_type: line
         - name: scaleio.storage_pool_capacity_health_state
           description: Capacity Health State
           unit: KiB
@@ -296,6 +304,7 @@ metrics:
             - name: in_maintenance
             - name: failed
             - name: unavailable
+          chart_type: stacked
         - name: scaleio.storage_pool_components
           description: Components
           unit: components
@@ -304,6 +313,7 @@ metrics:
             - name: snapshots
             - name: volumes
             - name: vtrees
+          chart_type: line
     - name: sdc
       description: These metrics refer to the SDC (ScaleIO Data Client).
       labels: []
@@ -313,26 +323,31 @@ metrics:
           unit: boolean
           dimensions:
             - name: connected
+          chart_type: line
         - name: scaleio.sdc_bandwidth
           description: Bandwidth
           unit: KiB/s
           dimensions:
             - name: read
             - name: write
+          chart_type: area
         - name: scaleio.sdc_iops
           description: IOPS
           unit: iops/s
           dimensions:
             - name: read
             - name: write
+          chart_type: area
         - name: scaleio.sdc_io_size
           description: IOPS Size
           unit: KiB
           dimensions:
             - name: read
             - name: write
+          chart_type: area
         - name: scaleio.sdc_num_of_mapped_volumed
           description: Mapped Volumes
           unit: volumes
           dimensions:
             - name: mapped
+          chart_type: line

--- a/modules/solr/metadata.yaml
+++ b/modules/solr/metadata.yaml
@@ -2,94 +2,92 @@ name: solr
 title: Solr collector
 overview:
   application:
-    description: |
-      [Solr](https://lucene.apache.org/solr/) is an open-source enterprise-search platform, written in Java, from the Apache
-      Lucene project.
+    description: "[Solr](https://lucene.apache.org/solr/) is an open-source enterprise-search
+      platform, written in Java, from the Apache\nLucene project.\n"
   collector:
-    description: |
-      This module will monitor one or more Solr instances, depending on your configuration.
+    description: "This module will monitor one or more Solr instances, depending on
+      your configuration.\n"
 setup:
   prerequisites:
     list:
       - title: Solr version 6.4+
-        text: |
-          This collector does not work with Solr versions lower 6.4.
+        description: "This collector does not work with Solr versions lower 6.4.\n"
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: All options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
-          required: no
+          required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
-          required: no
+          required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: "`http://127.0.0.1:8983`"
-          required: yes
+          required: true
+          default_value: '`http://127.0.0.1:8983`'
         - name: timeout
           description: HTTP request timeout.
-          default: 1
-          required: no
+          required: false
+          default_value: 1
         - name: username
           description: Username for basic HTTP authentication.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: password
           description: Password for basic HTTP authentication.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: proxy_url
           description: Proxy URL.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: proxy_username
           description: Username for proxy basic HTTP authentication.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: proxy_password
           description: Password for proxy basic HTTP authentication.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: method
           description: HTTP request method.
-          default: "GET"
-          required: no
+          required: false
+          default_value: GET
         - name: body
           description: HTTP request body.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: headers
           description: HTTP request headers.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: not_follow_redirects
           description: Whether to not follow redirects from the server.
-          default: no
-          required: no
+          required: false
+          default_value: no
         - name: tls_skip_verify
           description: Whether to skip verifying server's certificate chain and hostname.
-          default: no
-          required: no
+          required: false
+          default_value: no
         - name: tls_ca
-          description: Certificate authority that client use when verifying server certificates.
-          default: "-"
-          required: no
+          description: Certificate authority that client use when verifying server
+            certificates.
+          required: false
+          default_value: '-'
         - name: tls_cert
           description: Client tls certificate.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: tls_key
           description: Client tls key.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
     examples:
       list:
         - name: Basic
@@ -97,36 +95,27 @@ setup:
           folding:
             title: Example
             enabled: true
-          data: |
-            jobs:
-              - name: local
-              url: http://localhost:8983
+          config: "jobs:\n  - name: local\n  url: http://localhost:8983\n"
         - name: Basic HTTP auth
           description: Local Solr instance with basic HTTP authentication.
           folding:
             title: Example
             enabled: true
-          data: |
-            jobs:
-              - name: local
-                url: http://localhost:8983
-                username: foo
-                password: bar
+          config: "jobs:\n  - name: local\n    url: http://localhost:8983\n    username:
+            foo\n    password: bar\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-            
-            Local and remote instances.
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nLocal and remote instances.\n"
           folding:
             title: Example
             enabled: true
-          data: |
-            jobs:
-              - name: local
-                url: http://localhost:8983
-            
-              - name: remote
-                url: http://203.0.113.10:8983
+          config: "jobs:\n  - name: local\n    url: http://localhost:8983\n\n  - name:
+            remote\n    url: http://203.0.113.10:8983\n"
+      folding:
+        title: Config options
+        enabled: true
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -135,7 +124,8 @@ metrics:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -145,11 +135,13 @@ metrics:
           unit: requests/s
           dimensions:
             - name: search
+          chart_type: line
         - name: solr.search_errors
           description: Search Errors
           unit: errors/s
           dimensions:
             - name: errors
+          chart_type: line
         - name: solr.search_errors_by_type
           description: Search Errors By Type
           unit: errors/s
@@ -157,11 +149,13 @@ metrics:
             - name: client
             - name: server
             - name: timeouts
+          chart_type: line
         - name: solr.search_requests_processing_time
           description: Search Requests Processing Time
           unit: milliseconds
           dimensions:
             - name: time
+          chart_type: line
         - name: solr.search_requests_timings
           description: Search Requests Timings
           unit: milliseconds
@@ -170,6 +164,7 @@ metrics:
             - name: median
             - name: mean
             - name: max
+          chart_type: line
         - name: solr.search_requests_processing_time_percentile
           description: Search Requests Processing Time Percentile
           unit: milliseconds
@@ -178,16 +173,19 @@ metrics:
             - name: p95
             - name: p99
             - name: p999
+          chart_type: line
         - name: solr.update_requests
           description: Update Requests
           unit: requests/s
           dimensions:
             - name: search
+          chart_type: line
         - name: solr.update_errors
           description: Update Errors
           unit: errors/s
           dimensions:
             - name: errors
+          chart_type: line
         - name: solr.update_errors_by_type
           description: Update Errors By Type
           unit: errors/s
@@ -195,11 +193,13 @@ metrics:
             - name: client
             - name: server
             - name: timeouts
+          chart_type: line
         - name: solr.update_requests_processing_time
           description: Update Requests Processing Time
           unit: milliseconds
           dimensions:
             - name: time
+          chart_type: line
         - name: solr.update_requests_timings
           description: Update Requests Timings
           unit: milliseconds
@@ -208,6 +208,7 @@ metrics:
             - name: median
             - name: mean
             - name: max
+          chart_type: line
         - name: solr.update_requests_processing_time_percentile
           description: Update Requests Processing Time Percentile
           unit: milliseconds
@@ -216,3 +217,4 @@ metrics:
             - name: p95
             - name: p99
             - name: p999
+          chart_type: line

--- a/modules/springboot2/metadata.yaml
+++ b/modules/springboot2/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -17,12 +72,14 @@ metrics:
             - name: 3xx
             - name: 4xx
             - name: 5xx
+          chart_type: stacked
         - name: springboot2.thread
           description: Threads
           unit: threads
           dimensions:
             - name: daemon
             - name: total
+          chart_type: area
         - name: springboot2.heap
           description: Overview
           unit: B
@@ -31,26 +88,31 @@ metrics:
             - name: eden
             - name: survivor
             - name: old
+          chart_type: stacked
         - name: springboot2.heap_eden
           description: Eden Space
           unit: B
           dimensions:
             - name: used
             - name: commited
+          chart_type: area
         - name: springboot2.heap_survivor
           description: Survivor Space
           unit: B
           dimensions:
             - name: used
             - name: commited
+          chart_type: area
         - name: springboot2.heap_old
           description: Old Space
           unit: B
           dimensions:
             - name: used
             - name: commited
+          chart_type: area
         - name: springboot2.uptime
           description: TThe uptime of the Java virtual machine
           unit: seconds
           dimensions:
             - name: uptime
+          chart_type: line

--- a/modules/squidlog/metadata.yaml
+++ b/modules/squidlog/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -13,11 +68,13 @@ metrics:
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: squidlog.excluded_requests
           description: Excluded Requests
           unit: requests/s
           dimensions:
             - name: unmatched
+          chart_type: line
         - name: squidlog.type_requests
           description: Requests By Type
           unit: requests/s
@@ -26,6 +83,7 @@ metrics:
             - name: bad
             - name: redirect
             - name: error
+          chart_type: stacked
         - name: squidlog.http_status_code_class_responses
           description: Responses By HTTP Status Code Class
           unit: responses/s
@@ -35,16 +93,19 @@ metrics:
             - name: 3xx
             - name: 4xx
             - name: 5xx
+          chart_type: stacked
         - name: squidlog.http_status_code_responses
           description: Responses By HTTP Status Code
           unit: responses/s
           dimensions:
             - name: a dimension per HTTP response code
+          chart_type: stacked
         - name: squidlog.bandwidth
           description: Bandwidth
           unit: kilobits/s
           dimensions:
             - name: sent
+          chart_type: line
         - name: squidlog.response_time
           description: Response Time
           unit: milliseconds
@@ -52,58 +113,70 @@ metrics:
             - name: min
             - name: max
             - name: avg
+          chart_type: line
         - name: squidlog.uniq_clients
           description: Unique Clients
           unit: clients
           dimensions:
             - name: clients
+          chart_type: line
         - name: squidlog.cache_result_code_requests
           description: Requests By Cache Result Code
           unit: requests/s
           dimensions:
             - name: a dimension per cache result code
+          chart_type: stacked
         - name: squidlog.cache_result_code_transport_tag_requests
           description: Requests By Cache Result Delivery Transport Tag
           unit: requests/s
           dimensions:
             - name: a dimension per cache result delivery transport tag
+          chart_type: stacked
         - name: squidlog.cache_result_code_handling_tag_requests
           description: Requests By Cache Result Handling Tag
           unit: requests/s
           dimensions:
             - name: a dimension per cache result handling tag
+          chart_type: stacked
         - name: squidlog.cache_code_object_tag_requests
           description: Requests By Cache Result Produced Object Tag
           unit: requests/s
           dimensions:
             - name: a dimension per cache result produced object tag
+          chart_type: stacked
         - name: squidlog.cache_code_load_source_tag_requests
           description: Requests By Cache Result Load Source Tag
           unit: requests/s
           dimensions:
             - name: a dimension per cache result load source tag
+          chart_type: stacked
         - name: squidlog.cache_code_error_tag_requests
           description: Requests By Cache Result Errors Tag
           unit: requests/s
           dimensions:
             - name: a dimension per cache result error tag
+          chart_type: stacked
         - name: squidlog.http_method_requests
           description: Requests By HTTP Method
           unit: requests/s
           dimensions:
             - name: a dimension per HTTP method
+          chart_type: stacked
         - name: squidlog.mime_type_requests
           description: Requests By MIME Type
           unit: requests/s
           dimensions:
             - name: a dimension per MIME type
+          chart_type: stacked
         - name: squidlog.hier_code_requests
           description: Requests By Hierarchy Code
           unit: requests/s
           dimensions:
             - name: a dimension per hierarchy code
+          chart_type: stacked
         - name: squidlog.server_address_forwarded_requests
           description: Forwarded Requests By Server Address
           unit: requests/s
           dimensions:
             - name: a dimension per server address
+          chart_type: stacked

--- a/modules/supervisord/metadata.yaml
+++ b/modules/supervisord/metadata.yaml
@@ -2,47 +2,40 @@ name: supervisord
 title: Supervisord collector
 overview:
   application:
-    description: |
-      [Supervisor](http://supervisord.org/) is a client/server system that allows its users to monitor and control a number of
-      processes on UNIX-like operating systems.
+    description: "[Supervisor](http://supervisord.org/) is a client/server system
+      that allows its users to monitor and control a number of\nprocesses on UNIX-like
+      operating systems.\n"
   collector:
-    description: |
-      This collector monitors one or more Supervisor instances, depending on your configuration.
-
-      It can collect metrics from
-      both [unix socket](http://supervisord.org/configuration.html?highlight=unix_http_server#unix-http-server-section-values)
-      and [internal http server](http://supervisord.org/configuration.html?highlight=unix_http_server#inet-http-server-section-settings)
-
-      Used methods:
-
-      - [`supervisor.getAllProcessInfo`](http://supervisord.org/api.html#supervisor.rpcinterface.SupervisorNamespaceRPCInterface.getAllProcessInfo)
+    description: "This collector monitors one or more Supervisor instances, depending
+      on your configuration.\n\nIt can collect metrics from\nboth [unix socket](http://supervisord.org/configuration.html?highlight=unix_http_server#unix-http-server-section-values)\n
+      and [internal http server](http://supervisord.org/configuration.html?highlight=unix_http_server#inet-http-server-section-settings)\n
+      \nUsed methods:\n\n- [`supervisor.getAllProcessInfo`](http://supervisord.org/api.html#supervisor.rpcinterface.SupervisorNamespaceRPCInterface.getAllProcessInfo)\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: http://127.0.0.1:9001/RPC2
           required: true
+          default_value: http://127.0.0.1:9001/RPC2
         - name: timeout
           description: System bus requests timeout.
-          default: 1
           required: false
+          default_value: 1
     examples:
       folding:
         title: Config
@@ -50,27 +43,17 @@ setup:
       list:
         - name: HTTP
           description: Collect metrics via HTTP.
-          data: |
-            jobs:
-              - name: local
-                url: 'http://127.0.0.1:9001/RPC2'
+          config: "jobs:\n  - name: local\n    url: 'http://127.0.0.1:9001/RPC2'\n"
         - name: Socket
           description: Collect metrics via Unix socket.
-          data: |
-            - name: local
-              url: 'unix:///run/supervisor.sock'
+          config: "- name: local\n  url: 'unix:///run/supervisor.sock'\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-
-            Collect metrics from local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                url: 'http://127.0.0.1:9001/RPC2'
-
-              - name: remote
-                url: 'http://192.0.2.1:9001/RPC2'
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nCollect metrics from local and remote instances.\n"
+          config: "jobs:\n  - name: local\n    url: 'http://127.0.0.1:9001/RPC2'\n\
+            \n  - name: remote\n    url: 'http://192.0.2.1:9001/RPC2'\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -78,8 +61,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -90,6 +74,7 @@ metrics:
           dimensions:
             - name: running
             - name: non-running
+          chart_type: stacked
     - name: process group
       description: These metrics refer to the process group.
       labels: []
@@ -100,23 +85,28 @@ metrics:
           dimensions:
             - name: running
             - name: non-running
+          chart_type: stacked
         - name: supervisord.process_state_code
           description: State code
           unit: code
           dimensions:
             - name: a dimension per process
+          chart_type: line
         - name: supervisord.process_exit_status
           description: Exit status
           unit: exit status
           dimensions:
             - name: a dimension per process
+          chart_type: line
         - name: supervisord.process_uptime
           description: Uptime
           unit: seconds
           dimensions:
             - name: a dimension per process
+          chart_type: line
         - name: supervisord.process_downtime
           description: Downtime
           unit: seconds
           dimensions:
             - name: a dimension per process
+          chart_type: line

--- a/modules/systemdunits/metadata.yaml
+++ b/modules/systemdunits/metadata.yaml
@@ -2,38 +2,37 @@ name: systemdunits
 title: Systemd units state collector
 overview:
   application:
-    description: |
-      [Systemd](https://www.freedesktop.org/wiki/Software/systemd/) is a suite of basic building blocks for a Linux system.
+    description: "[Systemd](https://www.freedesktop.org/wiki/Software/systemd/) is
+      a suite of basic building blocks for a Linux system.\n"
   collector:
-    description: |
-      This collector monitors Systemd units state. Works only on Linux systems.
+    description: "This collector monitors Systemd units state. Works only on Linux
+      systems.\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: include
           description: Systemd units filter. Pattern syntax is [shell file name pattern](https://golang.org/pkg/path/filepath/#Match).
-          default: "*.service"
           required: false
+          default_value: '*.service'
         - name: timeout
           description: System bus requests timeout.
-          default: 1
           required: false
+          default_value: 1
     examples:
       folding:
         title: Config
@@ -41,39 +40,21 @@ setup:
       list:
         - name: Service units
           description: Collect state of all service type units.
-          data: |
-            jobs:
-              - name: service
-                include:
-                  - '*.service'
+          config: "jobs:\n  - name: service\n    include:\n      - '*.service'\n"
         - name: One specific unit
           description: Collect state of one specific unit.
-          data: |
-            jobs:
-              - name: my-specific-service
-                include:
-                  - 'my-specific.service'
+          config: "jobs:\n  - name: my-specific-service\n    include:\n      - 'my-specific.service'\n"
         - name: All unit types
           description: Collect state of all units.
-          data: |
-            jobs:
-              - name: my-specific-service-unit
-                include:
-                  - '*'
+          config: "jobs:\n  - name: my-specific-service-unit\n    include:\n     \
+            \ - '*'\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-
-            Collect state of all service and socket type units.
-          data: |
-            jobs:
-              - name: service
-                include:
-                  - '*.service'
-
-              - name: socket
-                include:
-                  - '*.socket'
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nCollect state of all service and socket type units.\n"
+          config: "jobs:\n  - name: service\n    include:\n      - '*.service'\n\n\
+            \  - name: socket\n    include:\n      - '*.socket'\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -81,8 +62,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: unit
       description: These metrics refer to the systemd unit.
       labels:
@@ -98,6 +80,7 @@ metrics:
             - name: activating
             - name: deactivating
             - name: failed
+          chart_type: line
         - name: systemd.socket_unit_state
           description: Socket Unit State
           unit: state
@@ -107,6 +90,7 @@ metrics:
             - name: activating
             - name: deactivating
             - name: failed
+          chart_type: line
         - name: systemd.target_unit_state
           description: Target Unit State
           unit: state
@@ -116,6 +100,7 @@ metrics:
             - name: activating
             - name: deactivating
             - name: failed
+          chart_type: line
         - name: systemd.path_unit_state
           description: Path Unit State
           unit: state
@@ -125,6 +110,7 @@ metrics:
             - name: activating
             - name: deactivating
             - name: failed
+          chart_type: line
         - name: systemd.device_unit_state
           description: Device Unit State
           unit: state
@@ -134,6 +120,7 @@ metrics:
             - name: activating
             - name: deactivating
             - name: failed
+          chart_type: line
         - name: systemd.mount_unit_state
           description: Mount Unit State
           unit: state
@@ -143,6 +130,7 @@ metrics:
             - name: activating
             - name: deactivating
             - name: failed
+          chart_type: line
         - name: systemd.automount_unit_state
           description: Automount Unit State
           unit: state
@@ -152,6 +140,7 @@ metrics:
             - name: activating
             - name: deactivating
             - name: failed
+          chart_type: line
         - name: systemd.swap_unit_state
           description: Swap Unit State
           unit: state
@@ -161,6 +150,7 @@ metrics:
             - name: activating
             - name: deactivating
             - name: failed
+          chart_type: line
         - name: systemd.timer_unit_state
           description: Timer Unit State
           unit: state
@@ -170,6 +160,7 @@ metrics:
             - name: activating
             - name: deactivating
             - name: failed
+          chart_type: line
         - name: systemd.scope_unit_state
           description: Scope Unit State
           unit: state
@@ -179,6 +170,7 @@ metrics:
             - name: activating
             - name: deactivating
             - name: failed
+          chart_type: line
         - name: systemd.slice_unit_state
           description: Slice Unit State
           unit: state
@@ -188,3 +180,4 @@ metrics:
             - name: activating
             - name: deactivating
             - name: failed
+          chart_type: line

--- a/modules/tengine/metadata.yaml
+++ b/modules/tengine/metadata.yaml
@@ -2,94 +2,95 @@ name: tengine
 title: Tengine collector
 overview:
   application:
-    description: |
-      [Tengine](https://tengine.taobao.org/) is a web server originated by Taobao and is based on the [NGINX](https://nginx.org/en/).
+    description: "[Tengine](https://tengine.taobao.org/) is a web server originated
+      by Taobao and is based on the [NGINX](https://nginx.org/en/).\n"
   collector:
-    description: |
-      This collector monitors one or more Tengine instances, depending on your configuration.
+    description: "This collector monitors one or more Tengine instances, depending
+      on your configuration.\n"
 setup:
   prerequisites:
     list:
       - title: Enable ngx_http_reqstat_module module.
-        text: |
-          See [ngx_http_reqstat_module](https://tengine.taobao.org/document/http_reqstat.html) documentation.
-          The default line format is the only supported format.
+        description: "See [ngx_http_reqstat_module](https://tengine.taobao.org/document/http_reqstat.html)
+          documentation.\nThe default line format is the only supported format.\n"
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: http://127.0.0.1/us
           required: true
+          default_value: http://127.0.0.1/us
         - name: timeout
           description: HTTP request timeout.
-          default: 2
           required: false
+          default_value: 2
         - name: username
           description: Username for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: password
           description: Password for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_url
           description: Proxy URL.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_username
           description: Username for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_password
           description: Password for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: method
           description: HTTP request method.
-          default: "GET"
           required: false
+          default_value: GET
         - name: body
           description: HTTP request body.
-          default: ""
           required: false
+          default_value: ''
         - name: headers
           description: HTTP request headers.
-          default: ""
           required: false
+          default_value: ''
         - name: not_follow_redirects
-          description: Redirect handling policy. Controls whether the client follows redirects.
-          default: no
+          description: Redirect handling policy. Controls whether the client follows
+            redirects.
           required: false
+          default_value: no
         - name: tls_skip_verify
-          description: Server certificate chain and hostname validation policy. Controls whether the client performs this check.
-          default: no
+          description: Server certificate chain and hostname validation policy. Controls
+            whether the client performs this check.
           required: false
+          default_value: no
         - name: tls_ca
-          description: Certification authority that the client uses when verifying the server's certificates.
-          default: ""
+          description: Certification authority that the client uses when verifying
+            the server's certificates.
           required: false
+          default_value: ''
         - name: tls_cert
           description: Client TLS certificate.
-          default: ""
           required: false
+          default_value: ''
         - name: tls_key
           description: Client TLS key.
-          default: ""
           required: false
+          default_value: ''
     examples:
       folding:
         title: Config
@@ -97,37 +98,22 @@ setup:
       list:
         - name: Basic
           description: An example configuration.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1/us
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1/us\n"
         - name: HTTP authentication
           description: Local server with basic HTTP authentication.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1/us
-                username: foo
-                password: bar
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1/us\n    username:
+            foo\n    password: bar\n"
         - name: HTTPS with self-signed certificate
           description: Tengine with enabled HTTPS and self-signed certificate.
-          data: |
-            jobs:
-              - name: local
-                url: https://127.0.0.1/us
-                tls_skip_verify: yes
+          config: "jobs:\n  - name: local\n    url: https://127.0.0.1/us\n    tls_skip_verify:
+            yes\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-
-            Local and remote instances.
-          data: |
-            jobs:
-             - name: local
-               url: http://127.0.0.1/us
-
-             - name: remote
-               url: http://203.0.113.10/us
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nLocal and remote instances.\n"
+          config: "jobs:\n - name: local\n   url: http://127.0.0.1/us\n\n - name:
+            remote\n   url: http://203.0.113.10/us\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -135,8 +121,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -147,16 +134,19 @@ metrics:
           dimensions:
             - name: in
             - name: out
+          chart_type: area
         - name: tengine.connections_total
           description: Connections
           unit: connections/s
           dimensions:
             - name: accepted
+          chart_type: line
         - name: tengine.requests_total
           description: Requests
           unit: requests/s
           dimensions:
             - name: processed
+          chart_type: line
         - name: tengine.requests_per_response_code_family_total
           description: Requests Per Response Code Family
           unit: requests/s
@@ -166,6 +156,7 @@ metrics:
             - name: 4xx
             - name: 5xx
             - name: other
+          chart_type: stacked
         - name: tengine.requests_per_response_code_detailed_total
           description: Requests Per Response Code Detailed
           unit: requests/s
@@ -184,19 +175,23 @@ metrics:
             - name: '504'
             - name: '508'
             - name: other
+          chart_type: stacked
         - name: tengine.requests_upstream_total
           description: Number Of Requests Calling For Upstream
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: tengine.tries_upstream_total
           description: Number Of Times Calling For Upstream
           unit: calls/s
           dimensions:
             - name: calls
+          chart_type: line
         - name: tengine.requests_upstream_per_response_code_family_total
           description: Upstream Requests Per Response Code Family
           unit: requests/s
           dimensions:
             - name: 4xx
             - name: 5xx
+          chart_type: stacked

--- a/modules/traefik/metadata.yaml
+++ b/modules/traefik/metadata.yaml
@@ -2,94 +2,93 @@ name: traefik
 title: Traefik collector
 overview:
   application:
-    description: |
-      [Traefik](https://traefik.io/traefik/) is a leading modern reverse proxy and load balancer that makes deploying
-      microservices easy.
+    description: "[Traefik](https://traefik.io/traefik/) is a leading modern reverse
+      proxy and load balancer that makes deploying\nmicroservices easy.\n"
   collector:
-    description: |
-      This module will monitor one or more Traefik instances, depending on your configuration.
+    description: "This module will monitor one or more Traefik instances, depending
+      on your configuration.\n"
 setup:
   prerequisites:
     list:
       - title: Enable built-in Prometheus exporter
-        text: |
-          To enable see [Prometheus exporter](https://doc.traefik.io/traefik/observability/metrics/p1rometheus/) documentation.
+        description: "To enable see [Prometheus exporter](https://doc.traefik.io/traefik/observability/metrics/p1rometheus/)
+          documentation.\n"
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: All options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
-          required: no
+          required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
-          required: no
+          required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: "http://127.0.0.1:8082/metrics"
-          required: yes
+          required: true
+          default_value: http://127.0.0.1:8082/metrics
         - name: timeout
           description: HTTP request timeout.
-          default: 1
-          required: no
+          required: false
+          default_value: 1
         - name: username
           description: Username for basic HTTP authentication.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: password
           description: Password for basic HTTP authentication.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: proxy_url
           description: The Proxie's URL.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: proxy_username
           description: Username for proxy basic HTTP authentication.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: proxy_password
           description: Password for proxy basic HTTP authentication.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: method
           description: HTTP request method.
-          default: "GET"
-          required: no
+          required: false
+          default_value: GET
         - name: body
           description: HTTP request body.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: headers
           description: HTTP request headers.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: not_follow_redirects
           description: Whether to not follow redirects from the server.
-          default: no
-          required: no
+          required: false
+          default_value: no
         - name: tls_skip_verify
           description: Whether to skip verifying server's certificate chain and hostname.
-          default: no
-          required: no
+          required: false
+          default_value: no
         - name: tls_ca
-          description: Certificate authority that client use when verifying server certificates.
-          default: "-"
-          required: no
+          description: Certificate authority that client use when verifying server
+            certificates.
+          required: false
+          default_value: '-'
         - name: tls_cert
           description: Client tls certificate.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
         - name: tls_key
           description: Client tls key.
-          default: "-"
-          required: no
+          required: false
+          default_value: '-'
     examples:
       list:
         - name: Basic
@@ -97,36 +96,27 @@ setup:
           folding:
             title: Example
             enabled: true
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8082/metrics
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8082/metrics\n"
         - name: Basic HTTP auth
           description: Local server with basic HTTP authentication.
           folding:
             title: Example
             enabled: true
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8082/metrics
-                username: foo
-                password: bar
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8082/metrics\n\
+            \    username: foo\n    password: bar\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-
-            Local and remote instances.
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nLocal and remote instances.\n"
           folding:
             title: Example
             enabled: true
-          data: |
-            jobs:
-              - name: local
-                http://127.0.0.1:8082/metrics
-            
-              - name: remote
-                http://192.0.2.0:8082/metrics
+          config: "jobs:\n  - name: local\n    http://127.0.0.1:8082/metrics\n\n \
+            \ - name: remote\n    http://192.0.2.0:8082/metrics\n"
+      folding:
+        title: Config options
+        enabled: true
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -135,7 +125,8 @@ metrics:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: entrypoint, protocol
       description: TBD
       labels: []
@@ -149,6 +140,7 @@ metrics:
             - name: 3xx
             - name: 4xx
             - name: 5xx
+          chart_type: stacked
         - name: traefik.entrypoint_request_duration_average
           description: Average HTTP request processing time
           unit: milliseconds
@@ -158,8 +150,10 @@ metrics:
             - name: 3xx
             - name: 4xx
             - name: 5xx
+          chart_type: stacked
         - name: traefik.entrypoint_open_connections
           description: Open connections
           unit: connections
           dimensions:
             - name: a dimension per HTTP method
+          chart_type: stacked

--- a/modules/unbound/metadata.yaml
+++ b/modules/unbound/metadata.yaml
@@ -2,89 +2,79 @@ name: unbound
 title: Unbound collector
 overview:
   application:
-    description: |
-      [Unbound](https://nlnetlabs.nl/projects/unbound/about/) is a validating, recursive, and caching DNS resolver product
-      from NLnet Labs.
+    description: "[Unbound](https://nlnetlabs.nl/projects/unbound/about/) is a validating,
+      recursive, and caching DNS resolver product\nfrom NLnet Labs.\n"
   collector:
-    description: |
-      This collector monitors one or more Unbound servers, depending on your configuration.
+    description: "This collector monitors one or more Unbound servers, depending on
+      your configuration.\n"
 setup:
   prerequisites:
     list:
       - title: Enable remote control interface
-        text: |
-          Set `control-enable` to yes in [unbound.conf](https://nlnetlabs.nl/documentation/unbound/unbound.conf).
+        description: "Set `control-enable` to yes in [unbound.conf](https://nlnetlabs.nl/documentation/unbound/unbound.conf).\n"
       - title: Check permissions and adjust if necessary
-        text: |
-          If using unix socket:
-
-          - socket should be readable and writeable by `netdata` user
-
-          If using ip socket and TLS is disabled:
-
-          - socket should be accessible via network
-
-          If TLS is enabled, in addition:
-
-          - `control-key-file` should be readable by `netdata` user
-          - `control-cert-file` should be readable by `netdata` user
-
-          For auto-detection parameters from `unbound.conf`:
-
-          - `unbound.conf` should be readable by `netdata` user
-          - if you have several configuration files (include feature) all of them should be readable by `netdata` user
+        description: "If using unix socket:\n\n- socket should be readable and writeable
+          by `netdata` user\n\nIf using ip socket and TLS is disabled:\n\n- socket
+          should be accessible via network\n\nIf TLS is enabled, in addition:\n\n
+          - `control-key-file` should be readable by `netdata` user\n- `control-cert-file`
+          should be readable by `netdata` user\n\nFor auto-detection parameters from
+          `unbound.conf`:\n\n- `unbound.conf` should be readable by `netdata` user\n
+          - if you have several configuration files (include feature) all of them
+          should be readable by `netdata` user\n"
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 5
           required: false
+          default_value: 5
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: address
-          description: "Server address in IP:PORT format."
-          default: 127.0.0.1:8953
+          description: Server address in IP:PORT format.
           required: true
+          default_value: 127.0.0.1:8953
         - name: timeout
           description: Connection/read/write/ssl handshake timeout.
-          default: 1
           required: false
+          default_value: 1
         - name: conf_path
           description: Absolute path to the unbound configuration file.
-          default: "/etc/unbound/unbound.conf"
           required: false
+          default_value: /etc/unbound/unbound.conf
         - name: cumulative_stats
-          description: Statistics collection mode. Should have the same value as the `statistics-cumulative` parameter in the unbound configuration file.
-          default: "/etc/unbound/unbound.conf"
+          description: Statistics collection mode. Should have the same value as the
+            `statistics-cumulative` parameter in the unbound configuration file.
           required: false
+          default_value: /etc/unbound/unbound.conf
         - name: use_tls
           description: Whether to use TLS or not.
-          default: yes
           required: false
+          default_value: yes
         - name: tls_skip_verify
-          description: Server certificate chain and hostname validation policy. Controls whether the client performs this check.
-          default: yes
+          description: Server certificate chain and hostname validation policy. Controls
+            whether the client performs this check.
           required: false
+          default_value: yes
         - name: tls_ca
-          description: Certificate authority that client use when verifying server certificates.
-          default: ""
+          description: Certificate authority that client use when verifying server
+            certificates.
           required: false
+          default_value: ''
         - name: tls_cert
           description: Client tls certificate.
-          default: "/etc/unbound/unbound_control.pem"
           required: false
+          default_value: /etc/unbound/unbound_control.pem
         - name: tls_key
           description: Client tls key.
-          default: "/etc/unbound/unbound_control.key"
           required: false
+          default_value: /etc/unbound/unbound_control.key
     examples:
       folding:
         title: Config
@@ -92,28 +82,17 @@ setup:
       list:
         - name: Basic
           description: An example configuration.
-          data: |
-            jobs:
-              - name: local
-                address: 127.0.0.1:8953
+          config: "jobs:\n  - name: local\n    address: 127.0.0.1:8953\n"
         - name: Unix socket
           description: Connecting through Unix socket.
-          data: |
-            jobs:
-              - name: socket
-                address: /var/run/unbound.sock
+          config: "jobs:\n  - name: socket\n    address: /var/run/unbound.sock\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-            
-            Local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                address: 127.0.0.1:8953
-
-              - name: remote
-                address: 203.0.113.11:8953
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nLocal and remote instances.\n"
+          config: "jobs:\n  - name: local\n    address: 127.0.0.1:8953\n\n  - name:
+            remote\n    address: 203.0.113.11:8953\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -121,8 +100,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -132,11 +112,13 @@ metrics:
           unit: queries
           dimensions:
             - name: queries
+          chart_type: line
         - name: unbound.queries_ip_ratelimited
           description: Rate Limited Queries
           unit: queries
           dimensions:
             - name: ratelimited
+          chart_type: line
         - name: unbound.dnscrypt_queries
           description: DNSCrypt Queries
           unit: queries
@@ -145,72 +127,85 @@ metrics:
             - name: cert
             - name: cleartext
             - name: malformed
+          chart_type: line
         - name: unbound.cache
           description: Cache Statistics
           unit: events
           dimensions:
             - name: hits
             - name: miss
+          chart_type: stacked
         - name: unbound.cache_percentage
           description: Cache Statistics Percentage
           unit: percentage
           dimensions:
             - name: hits
             - name: miss
+          chart_type: stacked
         - name: unbound.prefetch
           description: Cache Prefetches
           unit: prefetches
           dimensions:
             - name: prefetches
+          chart_type: line
         - name: unbound.expired
           description: Replies Served From Expired Cache
           unit: replies
           dimensions:
             - name: expired
+          chart_type: line
         - name: unbound.zero_ttl_replies
           description: Replies Served From Expired Cache
           unit: replies
           dimensions:
             - name: zero_ttl
+          chart_type: line
         - name: unbound.recursive_replies
           description: Replies That Needed Recursive Processing
           unit: replies
           dimensions:
             - name: recursive
+          chart_type: line
         - name: unbound.recursion_time
           description: Time Spent On Recursive Processing
           unit: milliseconds
           dimensions:
             - name: avg
             - name: median
+          chart_type: line
         - name: unbound.request_list_usage
           description: Request List Usage
           unit: queries
           dimensions:
             - name: avg
             - name: max
+          chart_type: line
         - name: unbound.current_request_list_usage
           description: Current Request List Usage
           unit: queries
           dimensions:
             - name: all
             - name: users
+          chart_type: area
         - name: unbound.request_list_jostle_list
           description: Request List Jostle List Events
           unit: queries
           dimensions:
             - name: overwritten
             - name: dropped
+          chart_type: line
         - name: unbound.tcpusage
           description: TCP Handler Buffers
           unit: buffers
           dimensions:
             - name: usage
+          chart_type: line
         - name: unbound.uptime
           description: Uptime
           unit: seconds
           dimensions:
             - name: time
+          chart_type: line
         - name: unbound.cache_memory
           description: Cache Memory
           unit: KB
@@ -219,6 +214,7 @@ metrics:
             - name: rrset
             - name: dnscrypt_nonce
             - name: dnscrypt_shared_secret
+          chart_type: stacked
         - name: unbound.mod_memory
           description: Module Memory
           unit: KB
@@ -228,11 +224,13 @@ metrics:
             - name: validator
             - name: subnet
             - name: ipsec
+          chart_type: stacked
         - name: unbound.mem_streamwait
           description: TCP and TLS Stream Waif Buffer Memory
           unit: KB
           dimensions:
             - name: streamwait
+          chart_type: line
         - name: unbound.cache_count
           description: Cache Items Count
           unit: items
@@ -243,21 +241,25 @@ metrics:
             - name: rrset
             - name: dnscrypt_nonce
             - name: shared_secret
+          chart_type: stacked
         - name: unbound.type_queries
           description: Queries By Type
           unit: queries
           dimensions:
             - name: a dimension per query type
+          chart_type: stacked
         - name: unbound.class_queries
           description: Queries By Class
           unit: queries
           dimensions:
             - name: a dimension per query class
+          chart_type: stacked
         - name: unbound.opcode_queries
           description: Queries By OpCode
           unit: queries
           dimensions:
             - name: a dimension per query opcode
+          chart_type: stacked
         - name: unbound.flag_queries
           description: Queries By Flag
           unit: queries
@@ -270,11 +272,13 @@ metrics:
             - name: z
             - name: ad
             - name: cd
+          chart_type: stacked
         - name: unbound.rcode_answers
           description: Replies By RCode
           unit: replies
           dimensions:
             - name: a dimension per reply rcode
+          chart_type: stacked
     - name: thread
       description: These metrics refer to threads.
       labels: []
@@ -284,11 +288,13 @@ metrics:
           unit: queries
           dimensions:
             - name: queries
+          chart_type: line
         - name: unbound.thread_queries_ip_ratelimited
           description: Thread Rate Limited Queries
           unit: queries
           dimensions:
             - name: ratelimited
+          chart_type: line
         - name: unbound.thread_dnscrypt_queries
           description: Thread DNSCrypt Queries
           unit: queries
@@ -297,64 +303,76 @@ metrics:
             - name: cert
             - name: cleartext
             - name: malformed
+          chart_type: line
         - name: unbound.thread_cache
           description: Cache Statistics
           unit: events
           dimensions:
             - name: hits
             - name: miss
+          chart_type: line
         - name: unbound.thread_cache_percentage
           description: Cache Statistics Percentage
           unit: percentage
           dimensions:
             - name: hits
             - name: miss
+          chart_type: line
         - name: unbound.thread_prefetch
           description: Cache Prefetches
           unit: prefetches
           dimensions:
             - name: prefetches
+          chart_type: line
         - name: unbound.thread_expired
           description: Replies Served From Expired Cache
           unit: replies
           dimensions:
             - name: expired
+          chart_type: line
         - name: unbound.thread_zero_ttl_replies
           description: Replies Served From Expired Cache
           unit: replies
           dimensions:
             - name: zero_ttl
+          chart_type: line
         - name: unbound.thread_recursive_replies
           description: Replies That Needed Recursive Processing
           unit: replies
           dimensions:
             - name: recursive
+          chart_type: line
         - name: unbound.thread_recursion_time
           description: Time Spent On Recursive Processing
           unit: milliseconds
           dimensions:
             - name: avg
             - name: median
+          chart_type: line
         - name: unbound.thread_request_list_usage
           description: Time Spent On Recursive Processing
           unit: queries
           dimensions:
             - name: avg
             - name: max
+          chart_type: line
         - name: unbound.thread_current_request_list_usage
           description: Current Request List Usage
           unit: queries
           dimensions:
             - name: all
             - name: users
+          chart_type: line
         - name: unbound.thread_request_list_jostle_list
           description: Request List Jostle List Events
           unit: queries
           dimensions:
             - name: overwritten
             - name: dropped
+          chart_type: line
         - name: unbound.thread_tcpusage
           description: TCP Handler Buffers
           unit: buffers
           dimensions:
             - name: usage
+          chart_type: line

--- a/modules/vcsa/metadata.yaml
+++ b/modules/vcsa/metadata.yaml
@@ -2,92 +2,93 @@ name: vcsa
 title: vCenter Server Appliance collector
 overview:
   application:
-    description: |
-      The [vCenter Server Appliance](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcsa.doc/GUID-223C2821-BD98-4C7A-936B-7DBE96291BA4.html)
-      is a preconfigured Linux virtual machine, which is optimized for running VMware vCenter Server® and the associated services on Linux.
+    description: "The [vCenter Server Appliance](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcsa.doc/GUID-223C2821-BD98-4C7A-936B-7DBE96291BA4.html)\n
+      is a preconfigured Linux virtual machine, which is optimized for running VMware
+      vCenter Server® and the associated services on Linux.\n"
   collector:
-    description: |
-      This collector monitors [health statistics](https://developer.vmware.com/apis/vsphere-automation/latest/appliance/health/)
-      from one or more vCenter Server Appliance servers, depending on your configuration.
+    description: "This collector monitors [health statistics](https://developer.vmware.com/apis/vsphere-automation/latest/appliance/health/)\n
+      from one or more vCenter Server Appliance servers, depending on your configuration.\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 5
           required: false
+          default_value: 5
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: ""
           required: true
+          default_value: ''
         - name: timeout
           description: HTTP request timeout.
-          default: 1
           required: false
+          default_value: 1
         - name: username
           description: Username for basic HTTP authentication.
-          default: ""
           required: true
+          default_value: ''
         - name: password
           description: Password for basic HTTP authentication.
-          default: ""
           required: true
+          default_value: ''
         - name: proxy_url
           description: Proxy URL.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_username
           description: Username for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_password
           description: Password for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: method
           description: HTTP request method.
-          default: "GET"
           required: false
+          default_value: GET
         - name: body
           description: HTTP request body.
-          default: ""
           required: false
+          default_value: ''
         - name: headers
           description: HTTP request headers.
-          default: ""
           required: false
+          default_value: ''
         - name: not_follow_redirects
-          description: Redirect handling policy. Controls whether the client follows redirects.
-          default: no
+          description: Redirect handling policy. Controls whether the client follows
+            redirects.
           required: false
+          default_value: no
         - name: tls_skip_verify
-          description: Server certificate chain and hostname validation policy. Controls whether the client performs this check.
-          default: no
+          description: Server certificate chain and hostname validation policy. Controls
+            whether the client performs this check.
           required: false
+          default_value: no
         - name: tls_ca
-          description: Certification authority that the client uses when verifying the server's certificates.
-          default: ""
+          description: Certification authority that the client uses when verifying
+            the server's certificates.
           required: false
+          default_value: ''
         - name: tls_cert
           description: Client TLS certificate.
-          default: ""
           required: false
+          default_value: ''
         - name: tls_key
           description: Client TLS key.
-          default: ""
           required: false
+          default_value: ''
     examples:
       folding:
         title: Config
@@ -95,28 +96,17 @@ setup:
       list:
         - name: Basic
           description: An example configuration.
-          data: |
-            jobs:
-              - name: vcsa1
-                url: https://203.0.113.1
-                username: admin@vsphere.local
-                password: password
+          config: "jobs:\n  - name: vcsa1\n    url: https://203.0.113.1\n    username:
+            admin@vsphere.local\n    password: password\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-            
-            Two instances.
-          data: |
-            jobs:
-              - name: vcsa1
-                url: https://203.0.113.1
-                username: admin@vsphere.local
-                password: password
-
-              - name: vcsa2
-                url: https://203.0.113.10
-                username: admin@vsphere.local
-                password: password
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nTwo instances.\n"
+          config: "jobs:\n  - name: vcsa1\n    url: https://203.0.113.1\n    username:
+            admin@vsphere.local\n    password: password\n\n  - name: vcsa2\n    url:
+            https://203.0.113.10\n    username: admin@vsphere.local\n    password:
+            password\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -124,46 +114,43 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
-      description: |
-        These metrics refer to the entire monitored application.
-        <details>
-        <summary>See health statuses</summary>
-        Overall System Health:
-
-        | Numeric |   Text    | Description                                                                                                              |
-        |:-------:|:---------:|:-------------------------------------------------------------------------------------------------------------------------|
-        |  `-1`   | `unknown` | Module failed to decode status.                                                                                          |
-        |   `0`   |  `green`  | All components in the appliance are healthy.                                                                             |
-        |   `1`   | `yellow`  | One or more components in the appliance might become overloaded soon.                                                    |
-        |   `2`   | `orange`  | One or more components in the appliance might be degraded.                                                               |
-        |   `3`   |   `red`   | One or more components in the appliance might be in an unusable status and the appliance might become unresponsive soon. |
-        |   `4`   |  `gray`   | No health data is available.                                                                                             |
-
-        Components Health:
-
-        | Numeric |   Text    | Description                                                  |
-        |:-------:|:---------:|:-------------------------------------------------------------|
-        |  `-1`   | `unknown` | Module failed to decode status.                              |
-        |   `0`   |  `green`  | The component is healthy.                                    |
-        |   `1`   | `yellow`  | The component is healthy, but may have some problems.        |
-        |   `2`   | `orange`  | The component is degraded, and may have serious problems.    |
-        |   `3`   |   `red`   | The component is unavailable, or will stop functioning soon. |
-        |   `4`   |  `gray`   | No health data is available.                                 |
-
-        Software Updates Health:
-
-        | Numeric |   Text    | Description                                          |
-        |:-------:|:---------:|:-----------------------------------------------------|
-        |  `-1`   | `unknown` | Module failed to decode status.                      |
-        |   `0`   |  `green`  | No updates available.                                |
-        |   `2`   | `orange`  | Non-security patches might be available.             |
-        |   `3`   |   `red`   | Security patches might be available.                 |
-        |   `4`   |  `gray`   | An error retrieving information on software updates. |
-
-        </details>
+      description: "These metrics refer to the entire monitored application.\n<details>\n
+        <summary>See health statuses</summary>\nOverall System Health:\n\n| Numeric
+        |   Text    | Description                                                \
+        \                                                              |\n|:-------:|:---------:|:-------------------------------------------------------------------------------------------------------------------------|\n\
+        |  `-1`   | `unknown` | Module failed to decode status.                  \
+        \                                                                        |\n\
+        |   `0`   |  `green`  | All components in the appliance are healthy.     \
+        \                                                                        |\n\
+        |   `1`   | `yellow`  | One or more components in the appliance might become
+        overloaded soon.                                                    |\n| \
+        \  `2`   | `orange`  | One or more components in the appliance might be degraded.\
+        \                                                               |\n|   `3`\
+        \   |   `red`   | One or more components in the appliance might be in an unusable
+        status and the appliance might become unresponsive soon. |\n|   `4`   |  `gray`\
+        \   | No health data is available.                                       \
+        \                                                      |\n\nComponents Health:\n
+        \n| Numeric |   Text    | Description                                    \
+        \              |\n|:-------:|:---------:|:-------------------------------------------------------------|\n\
+        |  `-1`   | `unknown` | Module failed to decode status.                  \
+        \            |\n|   `0`   |  `green`  | The component is healthy.        \
+        \                            |\n|   `1`   | `yellow`  | The component is healthy,
+        but may have some problems.        |\n|   `2`   | `orange`  | The component
+        is degraded, and may have serious problems.    |\n|   `3`   |   `red`   |
+        The component is unavailable, or will stop functioning soon. |\n|   `4`  \
+        \ |  `gray`   | No health data is available.                             \
+        \    |\n\nSoftware Updates Health:\n\n| Numeric |   Text    | Description\
+        \                                          |\n|:-------:|:---------:|:-----------------------------------------------------|\n\
+        |  `-1`   | `unknown` | Module failed to decode status.                  \
+        \    |\n|   `0`   |  `green`  | No updates available.                    \
+        \            |\n|   `2`   | `orange`  | Non-security patches might be available.\
+        \             |\n|   `3`   |   `red`   | Security patches might be available.\
+        \                 |\n|   `4`   |  `gray`   | An error retrieving information
+        on software updates. |\n\n</details>\n"
       labels: []
       metrics:
         - name: vcsa.system_health
@@ -171,6 +158,7 @@ metrics:
           unit: status
           dimensions:
             - name: system
+          chart_type: line
         - name: vcsa.components_health
           description: Components Health
           unit: status
@@ -180,8 +168,10 @@ metrics:
             - name: mem
             - name: storage
             - name: swap
+          chart_type: line
         - name: vcsa.software_updates_health
           description: Software Updates Health
           unit: status
           dimensions:
             - name: software_packages
+          chart_type: line

--- a/modules/vernemq/metadata.yaml
+++ b/modules/vernemq/metadata.yaml
@@ -2,90 +2,92 @@ name: vernemq
 title: VerneMQ collector
 overview:
   application:
-    description: |
-      [VerneMQ](https://vernemq.com) is a high-performance, distributed MQTT broker.
+    description: "[VerneMQ](https://vernemq.com) is a high-performance, distributed
+      MQTT broker.\n"
   collector:
-    description: |
-      This collector monitors one or more VerneMQ instances, depending on your configuration.
+    description: "This collector monitors one or more VerneMQ instances, depending
+      on your configuration.\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: url
           description: Server URL.
-          default: http://127.0.0.1:8888/metrics
           required: true
+          default_value: http://127.0.0.1:8888/metrics
         - name: timeout
           description: HTTP request timeout.
-          default: 1
           required: false
+          default_value: 1
         - name: username
           description: Username for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: password
           description: Password for basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_url
           description: Proxy URL.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_username
           description: Username for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: proxy_password
           description: Password for proxy basic HTTP authentication.
-          default: ""
           required: false
+          default_value: ''
         - name: method
           description: HTTP request method.
-          default: "GET"
           required: false
+          default_value: GET
         - name: body
           description: HTTP request body.
-          default: ""
           required: false
+          default_value: ''
         - name: headers
           description: HTTP request headers.
-          default: ""
           required: false
+          default_value: ''
         - name: not_follow_redirects
-          description: Redirect handling policy. Controls whether the client follows redirects.
-          default: no
+          description: Redirect handling policy. Controls whether the client follows
+            redirects.
           required: false
+          default_value: no
         - name: tls_skip_verify
-          description: Server certificate chain and hostname validation policy. Controls whether the client performs this check.
-          default: no
+          description: Server certificate chain and hostname validation policy. Controls
+            whether the client performs this check.
           required: false
+          default_value: no
         - name: tls_ca
-          description: Certification authority that the client uses when verifying the server's certificates.
-          default: ""
+          description: Certification authority that the client uses when verifying
+            the server's certificates.
           required: false
+          default_value: ''
         - name: tls_cert
           description: Client TLS certificate.
-          default: ""
           required: false
+          default_value: ''
         - name: tls_key
           description: Client TLS key.
-          default: ""
           required: false
+          default_value: ''
     examples:
       folding:
         title: Config
@@ -93,30 +95,18 @@ setup:
       list:
         - name: Basic
           description: An example configuration.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8888/metrics
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8888/metrics\n"
         - name: HTTP authentication
           description: Local instance with basic HTTP authentication.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8888/metrics
-                username: username
-                password: password
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8888/metrics\n\
+            \    username: username\n    password: password\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-            
-            Local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                url: http://127.0.0.1:8888/metrics
-            
-              - name: remote
-                url: http://203.0.113.10:8888/metrics
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nLocal and remote instances.\n"
+          config: "jobs:\n  - name: local\n    url: http://127.0.0.1:8888/metrics\n\
+            \n  - name: remote\n    url: http://203.0.113.10:8888/metrics\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -124,8 +114,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -135,49 +126,58 @@ metrics:
           unit: sockets
           dimensions:
             - name: open
+          chart_type: line
         - name: vernemq.socket_operations
           description: Socket Open and Close Events
           unit: sockets/s
           dimensions:
             - name: open
             - name: close
+          chart_type: line
         - name: vernemq.client_keepalive_expired
           description: Closed Sockets due to Keepalive Time Expired
           unit: sockets/s
           dimensions:
             - name: closed
+          chart_type: line
         - name: vernemq.socket_close_timeout
           description: Closed Sockets due to no CONNECT Frame On Time
           unit: sockets/s
           dimensions:
             - name: closed
+          chart_type: line
         - name: vernemq.socket_errors
           description: Socket Errors
           unit: errors/s
           dimensions:
             - name: errors
+          chart_type: line
         - name: vernemq.queue_processes
           description: Living Queues in an Online or an Offline State
           unit: queue processes
           dimensions:
             - name: queue_processes
+          chart_type: line
         - name: vernemq.queue_processes_operations
           description: Queue Processes Setup and Teardown Events
           unit: events/s
           dimensions:
             - name: setup
             - name: teardown
+          chart_type: line
         - name: vernemq.queue_process_init_from_storage
           description: Queue Processes Initialized from Offline Storage
           unit: queue processes/s
           dimensions:
             - name: queue_processes
+          chart_type: line
         - name: vernemq.queue_messages
           description: Received and Sent PUBLISH Messages
           unit: messages/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: area
         - name: vernemq.queue_undelivered_messages
           description: Undelivered PUBLISH Messages
           unit: messages/s
@@ -185,285 +185,339 @@ metrics:
             - name: dropped
             - name: expired
             - name: unhandled
+          chart_type: stacked
         - name: vernemq.router_subscriptions
           description: Subscriptions in the Routing Table
           unit: subscriptions
           dimensions:
             - name: subscriptions
+          chart_type: line
         - name: vernemq.router_matched_subscriptions
           description: Matched Subscriptions
           unit: subscriptions/s
           dimensions:
             - name: local
             - name: remote
+          chart_type: line
         - name: vernemq.router_memory
           description: Routing Table Memory Usage
           unit: KiB
           dimensions:
             - name: used
+          chart_type: area
         - name: vernemq.average_scheduler_utilization
           description: Average Scheduler Utilization
           unit: percentage
           dimensions:
             - name: utilization
+          chart_type: area
         - name: vernemq.system_utilization_scheduler
           description: Scheduler Utilization
           unit: percentage
           dimensions:
             - name: a dimension per scheduler
+          chart_type: stacked
         - name: vernemq.system_processes
           description: Erlang Processes
           unit: processes
           dimensions:
             - name: processes
+          chart_type: line
         - name: vernemq.system_reductions
           description: Reductions
           unit: ops/s
           dimensions:
             - name: reductions
+          chart_type: line
         - name: vernemq.system_context_switches
           description: Context Switches
           unit: ops/s
           dimensions:
             - name: context_switches
+          chart_type: line
         - name: vernemq.system_io
           description: Received and Sent Traffic through Ports
           unit: kilobits/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: area
         - name: vernemq.system_run_queue
           description: Processes that are Ready to Run on All Run-Queues
           unit: processes
           dimensions:
             - name: ready
+          chart_type: line
         - name: vernemq.system_gc_count
           description: GC Count
           unit: ops/s
           dimensions:
             - name: gc
+          chart_type: line
         - name: vernemq.system_gc_words_reclaimed
           description: GC Words Reclaimed
           unit: ops/s
           dimensions:
             - name: words_reclaimed
+          chart_type: line
         - name: vernemq.system_allocated_memory
           description: Memory Allocated by the Erlang Processes and by the Emulator
           unit: KiB
           dimensions:
             - name: processes
             - name: system
+          chart_type: stacked
         - name: vernemq.bandwidth
           description: Bandwidth
           unit: kilobits/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: area
         - name: vernemq.retain_messages
           description: Stored Retained Messages
           unit: messages
           dimensions:
             - name: messages
+          chart_type: line
         - name: vernemq.retain_memory
           description: Stored Retained Messages Memory Usage
           unit: KiB
           dimensions:
             - name: used
+          chart_type: area
         - name: vernemq.cluster_bandwidth
           description: Communication with Other Cluster Nodes
           unit: kilobits/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: area
         - name: vernemq.cluster_dropped
           description: Traffic Dropped During Communication with Other Cluster Nodes
           unit: kilobits/s
           dimensions:
             - name: dropped
+          chart_type: area
         - name: vernemq.netsplit_unresolved
           description: Unresolved Netsplits
           unit: netsplits
           dimensions:
             - name: unresolved
+          chart_type: line
         - name: vernemq.netsplits
           description: Netsplits
           unit: netsplits/s
           dimensions:
             - name: resolved
             - name: detected
+          chart_type: stacked
         - name: vernemq.mqtt_auth
           description: v5 AUTH
           unit: packets/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: line
         - name: vernemq.mqtt_auth_received_reason
           description: v5 AUTH Received by Reason
           unit: packets/s
           dimensions:
             - name: a dimensions per reason
+          chart_type: stacked
         - name: vernemq.mqtt_auth_sent_reason
           description: v5 AUTH Sent by Reason
           unit: packets/s
           dimensions:
             - name: a dimensions per reason
+          chart_type: stacked
         - name: vernemq.mqtt_connect
           description: v3/v5 CONNECT and CONNACK
           unit: packets/s
           dimensions:
             - name: connect
             - name: connack
+          chart_type: line
         - name: vernemq.mqtt_connack_sent_reason
           description: v3/v5 CONNACK Sent by Reason
           unit: packets/s
           dimensions:
             - name: a dimensions per reason
+          chart_type: stacked
         - name: vernemq.mqtt_disconnect
           description: v3/v5 DISCONNECT
           unit: packets/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: line
         - name: vernemq.mqtt_disconnect_received_reason
           description: v5 DISCONNECT Received by Reason
           unit: packets/s
           dimensions:
             - name: a dimensions per reason
+          chart_type: stacked
         - name: vernemq.mqtt_disconnect_sent_reason
           description: v5 DISCONNECT Sent by Reason
           unit: packets/s
           dimensions:
             - name: a dimensions per reason
+          chart_type: stacked
         - name: vernemq.mqtt_subscribe
           description: v3/v5 SUBSCRIBE and SUBACK
           unit: packets/s
           dimensions:
             - name: subscribe
             - name: suback
+          chart_type: line
         - name: vernemq.mqtt_subscribe_error
           description: v3/v5 Failed SUBSCRIBE Operations due to a Netsplit
           unit: ops/s
           dimensions:
             - name: failed
+          chart_type: line
         - name: vernemq.mqtt_subscribe_auth_error
           description: v3/v5 Unauthorized SUBSCRIBE Attempts
           unit: attempts/s
           dimensions:
             - name: unauth
+          chart_type: line
         - name: vernemq.mqtt_unsubscribe
           description: v3/v5 UNSUBSCRIBE and UNSUBACK
           unit: packets/s
           dimensions:
             - name: unsubscribe
             - name: unsuback
+          chart_type: line
         - name: vernemq.mqtt_unsubscribe
           description: v3/v5 Failed UNSUBSCRIBE Operations due to a Netsplit
           unit: ops/s
           dimensions:
             - name: mqtt_unsubscribe_error
+          chart_type: line
         - name: vernemq.mqtt_publish
           description: v3/v5 QoS 0,1,2 PUBLISH
           unit: packets/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: line
         - name: vernemq.mqtt_publish_errors
           description: v3/v5 Failed PUBLISH Operations due to a Netsplit
           unit: ops/s
           dimensions:
             - name: failed
+          chart_type: line
         - name: vernemq.mqtt_publish_auth_errors
           description: v3/v5 Unauthorized PUBLISH Attempts
           unit: attempts/s
           dimensions:
             - name: unauth
+          chart_type: area
         - name: vernemq.mqtt_puback
           description: v3/v5 QoS 1 PUBACK
           unit: packets/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: line
         - name: vernemq.mqtt_puback_received_reason
           description: v5 PUBACK QoS 1 Received by Reason
           unit: packets/s
           dimensions:
             - name: a dimensions per reason
+          chart_type: stacked
         - name: vernemq.mqtt_puback_sent_reason
           description: v5 PUBACK QoS 1 Sent by Reason
           unit: packets/s
           dimensions:
             - name: a dimensions per reason
+          chart_type: stacked
         - name: vernemq.mqtt_puback_invalid_error
           description: v3/v5 PUBACK QoS 1 Received Unexpected Messages
           unit: messages/s
           dimensions:
             - name: unexpected
+          chart_type: line
         - name: vernemq.mqtt_pubrec
           description: v3/v5 PUBREC QoS 2
           unit: packets/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: line
         - name: vernemq.mqtt_pubrec_received_reason
           description: v5 PUBREC QoS 2 Received by Reason
           unit: packets/s
           dimensions:
             - name: a dimensions per reason
+          chart_type: stacked
         - name: vernemq.mqtt_pubrec_sent_reason
           description: v5 PUBREC QoS 2 Sent by Reason
           unit: packets/s
           dimensions:
             - name: a dimensions per reason
+          chart_type: stacked
         - name: vernemq.mqtt_pubrec_invalid_error
           description: v3 PUBREC QoS 2 Received Unexpected Messages
           unit: messages/s
           dimensions:
             - name: unexpected
+          chart_type: line
         - name: vernemq.mqtt_pubrel
           description: v3/v5 PUBREL QoS 2
           unit: packets/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: line
         - name: vernemq.mqtt_pubrel_received_reason
           description: v5 PUBREL QoS 2 Received by Reason
           unit: packets/s
           dimensions:
             - name: a dimensions per reason
+          chart_type: stacked
         - name: vernemq.mqtt_pubrel_sent_reason
           description: v5 PUBREL QoS 2 Sent by Reason
           unit: packets/s
           dimensions:
             - name: a dimensions per reason
+          chart_type: stacked
         - name: vernemq.mqtt_pubcom
           description: v3/v5 PUBCOMP QoS 2
           unit: packets/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: line
         - name: vernemq.mqtt_pubcomp_received_reason
           description: v5 PUBCOMP QoS 2 Received by Reason
           unit: packets/s
           dimensions:
             - name: a dimensions per reason
+          chart_type: stacked
         - name: vernemq.mqtt_pubcomp_sent_reason
           description: v5 PUBCOMP QoS 2 Sent by Reason
           unit: packets/s
           dimensions:
             - name: a dimensions per reason
+          chart_type: stacked
         - name: vernemq.mqtt_pubcomp_invalid_error
           description: v3/v5 PUBCOMP QoS 2 Received Unexpected Messages
           unit: messages/s
           dimensions:
             - name: unexpected
+          chart_type: line
         - name: vernemq.mqtt_ping
           description: v3/v5 PING
           unit: packets/s
           dimensions:
             - name: pingreq
             - name: pingresp
+          chart_type: line
         - name: vernemq.node_uptime
           description: Node Uptime
           unit: seconds
           dimensions:
             - name: time
+          chart_type: line

--- a/modules/vsphere/metadata.yaml
+++ b/modules/vsphere/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: virtual machine
       description: TBD
       labels: []
@@ -13,11 +68,13 @@ metrics:
           unit: percentage
           dimensions:
             - name: used
+          chart_type: area
         - name: vsphere.vm_mem_usage_percentage
           description: Memory Usage Percentage
           unit: percentage
           dimensions:
             - name: used
+          chart_type: area
         - name: vsphere.vm_mem_usage
           description: Memory Usage
           unit: KiB
@@ -26,56 +83,66 @@ metrics:
             - name: consumed
             - name: active
             - name: shared
+          chart_type: line
         - name: vsphere.vm_mem_swap_rate
           description: VMKernel Memory Swap Rate
           unit: KiB/s
           dimensions:
             - name: in
             - name: out
+          chart_type: area
         - name: vsphere.vm_mem_swap
           description: VMKernel Memory Swap
           unit: KiB
           dimensions:
             - name: swapped
+          chart_type: area
         - name: vsphere.vm_net_bandwidth_total
           description: Network Bandwidth Total
           unit: KiB/s
           dimensions:
             - name: rx
             - name: tx
+          chart_type: area
         - name: vsphere.vm_net_packets_total
           description: Network Packets Total
           unit: packets
           dimensions:
             - name: rx
             - name: tx
+          chart_type: line
         - name: vsphere.vm_net_drops_total
           description: Network Drops Total
           unit: packets
           dimensions:
             - name: rx
             - name: tx
+          chart_type: line
         - name: vsphere.vm_disk_usage_total
           description: Disk Usage Total
           unit: KiB/s
           dimensions:
             - name: read
             - name: write
+          chart_type: area
         - name: vsphere.vm_disk_max_latency
           description: Disk Max Latency
           unit: ms
           dimensions:
             - name: latency
+          chart_type: line
         - name: vsphere.vm_overall_status
           description: Overall Alarm Status
           unit: status
           dimensions:
             - name: status
+          chart_type: line
         - name: vsphere.vm_system_uptime
           description: System Uptime
           unit: seconds
           dimensions:
             - name: time
+          chart_type: line
     - name: host
       description: TBD
       labels: []
@@ -85,11 +152,13 @@ metrics:
           unit: percentage
           dimensions:
             - name: used
+          chart_type: area
         - name: vsphere.host_mem_usage_percentage
           description: Memory Usage Percentage
           unit: percentage
           dimensions:
             - name: used
+          chart_type: area
         - name: vsphere.host_mem_usage
           description: Memory Usage
           unit: KiB
@@ -99,54 +168,64 @@ metrics:
             - name: active
             - name: shared
             - name: sharedcommon
+          chart_type: line
         - name: vsphere.host_mem_swap_rate
           description: VMKernel Memory Swap Rate
           unit: KiB/s
           dimensions:
             - name: in
             - name: out
+          chart_type: area
         - name: vsphere.host_net_bandwidth_total
           description: Network Bandwidth Total
           unit: KiB/s
           dimensions:
             - name: rx
             - name: tx
+          chart_type: line
         - name: vsphere.host_net_packets_total
           description: Network Packets Total
           unit: packets
           dimensions:
             - name: rx
             - name: tx
+          chart_type: line
         - name: vsphere.host_net_drops_total
           description: Network Drops Total
           unit: packets
           dimensions:
             - name: rx
             - name: tx
+          chart_type: line
         - name: vsphere.host_net_errors_total
           description: Network Errors Total
           unit: errors
           dimensions:
             - name: rx
             - name: tx
+          chart_type: line
         - name: vsphere.host_disk_usage_total
           description: Disk Usage Total
           unit: KiB/s
           dimensions:
             - name: read
             - name: write
+          chart_type: area
         - name: vsphere.host_disk_max_latency
           description: Disk Max Latency
           unit: ms
           dimensions:
             - name: latency
+          chart_type: line
         - name: vsphere.host_overall_status
           description: Overall Alarm Status
           unit: status
           dimensions:
             - name: status
+          chart_type: line
         - name: vsphere.host_system_uptime
           description: System Uptime
           unit: seconds
           dimensions:
             - name: time
+          chart_type: line

--- a/modules/weblog/metadata.yaml
+++ b/modules/weblog/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -13,11 +68,13 @@ metrics:
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: web_log.excluded_requests
           description: Excluded Requests
           unit: requests/s
           dimensions:
             - name: unmatched
+          chart_type: stacked
         - name: web_log.type_requests
           description: Requests By Type
           unit: requests/s
@@ -26,6 +83,7 @@ metrics:
             - name: bad
             - name: redirect
             - name: error
+          chart_type: stacked
         - name: web_log.status_code_class_responses
           description: Responses By Status Code Class
           unit: responses/s
@@ -35,37 +93,44 @@ metrics:
             - name: 3xx
             - name: 4xx
             - name: 5xx
+          chart_type: stacked
         - name: web_log.status_code_class_1xx_responses
           description: Informational Responses By Status Code
           unit: responses/s
           dimensions:
             - name: a dimension per 1xx code
+          chart_type: stacked
         - name: web_log.status_code_class_2xx_responses
           description: Successful Responses By Status Code
           unit: responses/s
           dimensions:
             - name: a dimension per 2xx code
+          chart_type: stacked
         - name: web_log.status_code_class_3xx_responses
           description: Redirects Responses By Status Code
           unit: responses/s
           dimensions:
             - name: a dimension per 3xx code
+          chart_type: stacked
         - name: web_log.status_code_class_4xx_responses
           description: Client Errors Responses By Status Code
           unit: responses/s
           dimensions:
             - name: a dimension per 4xx code
+          chart_type: stacked
         - name: web_log.status_code_class_5xx_responses
           description: Server Errors Responses By Status Code
           unit: responses/s
           dimensions:
             - name: a dimension per 5xx code
+          chart_type: stacked
         - name: web_log.bandwidth
           description: Bandwidth
           unit: kilobits/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: area
         - name: web_log.request_processing_time
           description: Request Processing Time
           unit: milliseconds
@@ -73,11 +138,13 @@ metrics:
             - name: min
             - name: max
             - name: avg
+          chart_type: line
         - name: web_log.requests_processing_time_histogram
           description: Requests Processing Time Histogram
           unit: requests/s
           dimensions:
             - name: a dimension per bucket
+          chart_type: line
         - name: web_log.upstream_response_time
           description: Upstream Response Time
           unit: milliseconds
@@ -85,69 +152,82 @@ metrics:
             - name: min
             - name: max
             - name: avg
+          chart_type: line
         - name: web_log.upstream_responses_time_histogram
           description: Upstream Responses Time Histogram
           unit: requests/s
           dimensions:
             - name: a dimension per bucket
+          chart_type: line
         - name: web_log.current_poll_uniq_clients
           description: Current Poll Unique Clients
           unit: clients
           dimensions:
             - name: ipv4
             - name: ipv6
+          chart_type: stacked
         - name: web_log.vhost_requests
           description: Requests By Vhost
           unit: requests/s
           dimensions:
             - name: a dimension per vhost
+          chart_type: stacked
         - name: web_log.port_requests
           description: Requests By Port
           unit: requests/s
           dimensions:
             - name: a dimension per port
+          chart_type: stacked
         - name: web_log.scheme_requests
           description: Requests By Scheme
           unit: requests/s
           dimensions:
             - name: http
             - name: https
+          chart_type: stacked
         - name: web_log.http_method_requests
           description: Requests By HTTP Method
           unit: requests/s
           dimensions:
             - name: a dimension per HTTP method
+          chart_type: stacked
         - name: web_log.http_version_requests
           description: Requests By HTTP Version
           unit: requests/s
           dimensions:
             - name: a dimension per HTTP version
+          chart_type: stacked
         - name: web_log.ip_proto_requests
           description: Requests By IP Protocol
           unit: requests/s
           dimensions:
             - name: ipv4
             - name: ipv6
+          chart_type: stacked
         - name: web_log.ssl_proto_requests
           description: Requests By SSL Connection Protocol
           unit: requests/s
           dimensions:
             - name: a dimension per SSL protocol
+          chart_type: stacked
         - name: web_log.ssl_cipher_suite_requests
           description: Requests By SSL Connection Cipher Suite
           unit: requests/s
           dimensions:
             - name: a dimension per SSL cipher suite
+          chart_type: stacked
         - name: web_log.url_pattern_requests
           description: URL Field Requests By Pattern
           unit: requests/s
           dimensions:
             - name: a dimension per URL pattern
+          chart_type: stacked
         - name: web_log.custom_field_pattern_requests
           description: Custom Field Requests By Pattern
           unit: requests/s
           dimensions:
             - name: a dimension per custom field pattern
+          chart_type: stacked
     - name: custom time field
       description: TBD
       labels: []
@@ -159,11 +239,13 @@ metrics:
             - name: min
             - name: max
             - name: avg
+          chart_type: line
         - name: web_log.custom_time_field_histogram
           description: Custom Time Field Histogram
           unit: observations
           dimensions:
             - name: a dimension per bucket
+          chart_type: line
     - name: URL pattern
       description: TBD
       labels: []
@@ -173,17 +255,20 @@ metrics:
           unit: responses/s
           dimensions:
             - name: a dimension per pattern
+          chart_type: line
         - name: web_log.url_pattern_http_method_requests
           description: Requests By HTTP Method
           unit: requests/s
           dimensions:
             - name: a dimension per HTTP method
+          chart_type: line
         - name: web_log.url_pattern_bandwidth
           description: Bandwidth
           unit: kilobits/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: area
         - name: web_log.url_pattern_request_processing_time
           description: Request Processing Time
           unit: milliseconds
@@ -191,3 +276,4 @@ metrics:
             - name: min
             - name: max
             - name: avg
+          chart_type: line

--- a/modules/whoisquery/metadata.yaml
+++ b/modules/whoisquery/metadata.yaml
@@ -2,48 +2,44 @@ name: whoisquery
 title: Domain name expiry collector
 overview:
   application:
-    description: |
-      A domain name (often simply called a domain) is an easy-to-remember name 
-      that's associated with a physical IP address on the Internet.
-
+    description: "A domain name (often simply called a domain) is an easy-to-remember
+      name \nthat's associated with a physical IP address on the Internet.\n"
   collector:
-    description: |
-      This collector monitors the remaining time before the domain expires.
+    description: "This collector monitors the remaining time before the domain expires.\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: source
           description: Domain address.
-          default: ""
           required: true
+          default_value: ''
         - name: days_until_expiration_warning
           description: Number of days before the alarm status is warning.
-          default: 30
           required: false
+          default_value: 30
         - name: days_until_expiration_critical
           description: Number of days before the alarm status is critical.
-          default: 15
           required: false
+          default_value: 15
         - name: timeout
           description: The query timeout in seconds.
-          default: 5
           required: false
+          default_value: 5
     examples:
       folding:
         title: Config
@@ -51,22 +47,14 @@ setup:
       list:
         - name: Basic
           description: Basic configuration example
-          data: |
-            jobs:
-              - name: my_site
-                source: my_site.com
+          config: "jobs:\n  - name: my_site\n    source: my_site.com\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define more than one job, their names must be unique.
-
-            Check the expiration status of the multiple domains.
-          data: |
-            jobs:
-              - name: my_site1
-                source: my_site1.com
-
-              - name: my_site2
-                source: my_site2.com
+          description: "> **Note**: When you define more than one job, their names
+            must be unique.\n\nCheck the expiration status of the multiple domains.\n"
+          config: "jobs:\n  - name: my_site1\n    source: my_site1.com\n\n  - name:
+            my_site2\n    source: my_site2.com\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -74,8 +62,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: domain
       description: These metrics refer to the configured source.
       labels:
@@ -87,3 +76,4 @@ metrics:
           unit: seconds
           dimensions:
             - name: expiry
+          chart_type: line

--- a/modules/windows/metadata.yaml
+++ b/modules/windows/metadata.yaml
@@ -1,9 +1,64 @@
+meta:
+  plugin_name: ''
+  module_name: ''
+  monitored_instance:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list: []
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list: []
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list: []
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list: []
+troubleshooting:
+  problems:
+    list: []
+alerts: []
 metrics:
   folding:
     title: Metrics
     enabled: false
   description: TBD
-  scope:
+  availability: []
+  scopes:
     - name: global
       description: TBD
       labels: []
@@ -16,131 +71,154 @@ metrics:
             - name: user
             - name: privileged
             - name: interrupt
+          chart_type: stacked
         - name: windows.memory_utilization
           description: Memory Utilization
           unit: bytes
           dimensions:
             - name: available
             - name: used
+          chart_type: stacked
         - name: windows.memory_page_faults
           description: Memory Page Faults
           unit: events/s
           dimensions:
             - name: page_faults
+          chart_type: line
         - name: windows.memory_swap_utilization
           description: Swap Utilization
           unit: bytes
           dimensions:
             - name: available
             - name: used
+          chart_type: stacked
         - name: windows.memory_swap_operations
           description: Swap Operations
           unit: operations/s
           dimensions:
             - name: read
             - name: write
+          chart_type: area
         - name: windows.memory_swap_pages
           description: Swap Pages
           unit: pages/s
           dimensions:
             - name: read
             - name: written
+          chart_type: line
         - name: windows.memory_cached
           description: Cached
           unit: KiB
           dimensions:
             - name: cached
+          chart_type: area
         - name: windows.memory_cache_faults
           description: Cache Faults
           unit: events/s
           dimensions:
             - name: cache_faults
+          chart_type: line
         - name: windows.memory_system_pool
           description: System Memory Pool
           unit: bytes
           dimensions:
             - name: paged
             - name: non-paged
+          chart_type: area
         - name: windows.tcp_conns_established
           description: TCP established connections
           unit: connections
           dimensions:
             - name: ipv4
             - name: ipv6
+          chart_type: line
         - name: windows.tcp_conns_active
           description: TCP active connections
           unit: connections/s
           dimensions:
             - name: ipv4
             - name: ipv6
+          chart_type: line
         - name: windows.tcp_conns_passive
           description: TCP passive connections
           unit: connections/s
           dimensions:
             - name: ipv4
             - name: ipv6
+          chart_type: line
         - name: windows.tcp_conns_failures
           description: TCP connection failures
           unit: failures/s
           dimensions:
             - name: ipv4
             - name: ipv6
+          chart_type: line
         - name: windows.tcp_conns_resets
           description: TCP connections resets
           unit: resets/s
           dimensions:
             - name: ipv4
             - name: ipv6
+          chart_type: line
         - name: windows.tcp_segments_received
           description: Number of TCP segments received
           unit: segments/s
           dimensions:
             - name: ipv4
             - name: ipv6
+          chart_type: line
         - name: windows.tcp_segments_sent
           description: Number of TCP segments sent
           unit: segments/s
           dimensions:
             - name: ipv4
             - name: ipv6
+          chart_type: line
         - name: windows.tcp_segments_retransmitted
           description: Number of TCP segments retransmitted
           unit: segments/s
           dimensions:
             - name: ipv4
             - name: ipv6
+          chart_type: line
         - name: windows.os_processes
           description: Processes
           unit: number
           dimensions:
             - name: processes
+          chart_type: line
         - name: windows.os_users
           description: Number of Users
           unit: users
           dimensions:
             - name: users
+          chart_type: line
         - name: windows.os_visible_memory_usage
           description: Visible Memory Usage
           unit: bytes
           dimensions:
             - name: free
             - name: used
+          chart_type: stacked
         - name: windows.os_paging_files_usage
           description: Paging Files Usage
           unit: bytes
           dimensions:
             - name: free
             - name: used
+          chart_type: stacked
         - name: windows.system_threads
           description: Threads
           unit: number
           dimensions:
             - name: threads
+          chart_type: line
         - name: windows.system_uptime
           description: Uptime
           unit: seconds
           dimensions:
             - name: time
+          chart_type: line
         - name: windows.logon_type_sessions
           description: Active User Logon Sessions By Type
           unit: seconds
@@ -158,46 +236,55 @@ metrics:
             - name: cached_interactive
             - name: cached_remote_interactive
             - name: cached_unlock
+          chart_type: stacked
         - name: windows.processes_cpu_utilization
           description: CPU usage (100% = 1 core)
           unit: percentage
           dimensions:
             - name: a dimension per process
+          chart_type: stacked
         - name: windows.processes_handles
           description: Memory usage
           unit: handles
           dimensions:
             - name: a dimension per process
+          chart_type: stacked
         - name: windows.processes_io_bytes
           description: Total of IO bytes (read, write, other)
           unit: bytes/s
           dimensions:
             - name: a dimension per process
+          chart_type: stacked
         - name: windows.processes_io_operations
           description: Total of IO events (read, write, other)
           unit: operations/s
           dimensions:
             - name: a dimension per process
+          chart_type: stacked
         - name: windows.processes_page_faults
           description: Number of page faults
           unit: pgfaults/s
           dimensions:
             - name: a dimension per process
+          chart_type: stacked
         - name: windows.processes_page_file_bytes
           description: Bytes used in page file(s)
           unit: bytes
           dimensions:
             - name: a dimension per process
+          chart_type: stacked
         - name: windows.processes_pool_bytes
           description: Active threads
           unit: bytes
           dimensions:
             - name: a dimension per process
+          chart_type: stacked
         - name: windows.processes_threads
           description: Number of handles open
           unit: threads
           dimensions:
             - name: a dimension per process
+          chart_type: stacked
         - name: ad.database_operations
           description: AD database operations
           unit: operations/s
@@ -206,6 +293,7 @@ metrics:
             - name: delete
             - name: modify
             - name: recycle
+          chart_type: line
         - name: ad.directory_operations
           description: AD directory operations
           unit: operations/s
@@ -213,319 +301,379 @@ metrics:
             - name: read
             - name: write
             - name: search
+          chart_type: line
         - name: ad.name_cache_lookups
           description: Name cache lookups
           unit: lookups/s
           dimensions:
             - name: lookups
+          chart_type: line
         - name: ad.name_cache_hits
           description: Name cache hits
           unit: hits/s
           dimensions:
             - name: hits
+          chart_type: line
         - name: ad.atq_average_request_latency
           description: Average request processing time
           unit: seconds
           dimensions:
             - name: time
+          chart_type: line
         - name: ad.atq_outstanding_requests
           description: Outstanding requests
           unit: requests
           dimensions:
             - name: outstanding
+          chart_type: line
         - name: ad.dra_replication_intersite_compressed_traffic
           description: DRA replication compressed traffic withing site
           unit: bytes/s
           dimensions:
             - name: inbound
             - name: outbound
+          chart_type: area
         - name: ad.dra_replication_intrasite_compressed_traffic
           description: DRA replication compressed traffic between sites
           unit: bytes/s
           dimensions:
             - name: inbound
             - name: outbound
+          chart_type: area
         - name: ad.dra_replication_sync_objects_remaining
           description: DRA replication full sync objects remaining
           unit: objects
           dimensions:
             - name: inbound
             - name: outbound
+          chart_type: line
         - name: ad.dra_replication_objects_filtered
           description: DRA replication objects filtered
           unit: objects/s
           dimensions:
             - name: inbound
             - name: outbound
+          chart_type: line
         - name: ad.dra_replication_properties_updated
           description: DRA replication properties updated
           unit: properties/s
           dimensions:
             - name: inbound
             - name: outbound
+          chart_type: line
         - name: ad.dra_replication_properties_filtered
           description: DRA replication properties filtered
           unit: properties/s
           dimensions:
             - name: inbound
             - name: outbound
+          chart_type: line
         - name: ad.dra_replication_pending_syncs
           description: DRA replication pending syncs
           unit: syncs
           dimensions:
             - name: pending
+          chart_type: line
         - name: ad.dra_replication_sync_requests
           description: DRA replication sync requests
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: ad.ds_threads
           description: Directory Service threads
           unit: threads
           dimensions:
             - name: in_use
+          chart_type: line
         - name: ad.ldap_last_bind_time
           description: LDAP last successful bind time
           unit: seconds
           dimensions:
             - name: last_bind
+          chart_type: line
         - name: ad.binds
           description: Successful binds
           unit: binds/s
           dimensions:
             - name: binds
+          chart_type: line
         - name: ad.ldap_searches
           description: LDAP client search operations
           unit: searches/s
           dimensions:
             - name: searches
+          chart_type: line
         - name: adfs.ad_login_connection_failures
           description: Connection failures
           unit: failures/s
           dimensions:
             - name: connection
+          chart_type: line
         - name: adfs.certificate_authentications
           description: User Certificate authentications
           unit: authentications/s
           dimensions:
             - name: authentications
+          chart_type: line
         - name: adfs.db_artifact_failures
           description: Connection failures to the artifact database
           unit: failures/s
           dimensions:
             - name: connection
+          chart_type: line
         - name: adfs.db_artifact_query_time_seconds
           description: Time taken for an artifact database query
           unit: seconds/s
           dimensions:
             - name: query_time
+          chart_type: line
         - name: adfs.db_config_failures
           description: Connection failures to the configuration database
           unit: failures/s
           dimensions:
             - name: connection
+          chart_type: line
         - name: adfs.db_config_query_time_seconds
           description: Time taken for a configuration database query
           unit: seconds/s
           dimensions:
             - name: query_time
+          chart_type: line
         - name: adfs.device_authentications
           description: Device authentications
           unit: authentications/s
           dimensions:
             - name: authentications
+          chart_type: line
         - name: adfs.external_authentications
           description: Authentications from external MFA providers
           unit: authentications/s
           dimensions:
             - name: success
             - name: failure
+          chart_type: line
         - name: adfs.federated_authentications
           description: Authentications from Federated Sources
           unit: authentications/s
           dimensions:
             - name: authentications
+          chart_type: line
         - name: adfs.federation_metadata_requests
           description: Federation Metadata requests
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: adfs.oauth_authorization_requests
           description: Incoming requests to the OAuth Authorization endpoint
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: adfs.oauth_client_authentications
           description: OAuth client authentications
           unit: authentications/s
           dimensions:
             - name: success
             - name: failure
+          chart_type: line
         - name: adfs.oauth_client_credentials_requests
           description: OAuth client credentials requests
           unit: requests/s
           dimensions:
             - name: success
             - name: failure
+          chart_type: line
         - name: adfs.oauth_client_privkey_jwt_authentications
           description: OAuth client private key JWT authentications
           unit: authentications/s
           dimensions:
             - name: success
             - name: failure
+          chart_type: line
         - name: adfs.oauth_client_secret_basic_authentications
           description: OAuth client secret basic authentications
           unit: authentications/s
           dimensions:
             - name: success
             - name: failure
+          chart_type: line
         - name: adfs.oauth_client_secret_post_authentications
           description: OAuth client secret post authentications
           unit: authentications/s
           dimensions:
             - name: success
             - name: failure
+          chart_type: line
         - name: adfs.oauth_client_windows_authentications
           description: OAuth client windows integrated authentications
           unit: authentications/s
           dimensions:
             - name: success
             - name: failure
+          chart_type: line
         - name: adfs.oauth_logon_certificate_requests
           description: OAuth logon certificate requests
           unit: requests/s
           dimensions:
             - name: success
             - name: failure
+          chart_type: line
         - name: adfs.oauth_password_grant_requests
           description: OAuth password grant requests
           unit: requests/s
           dimensions:
             - name: success
             - name: failure
+          chart_type: line
         - name: adfs.oauth_token_requests_success
           description: Successful RP token requests over OAuth protocol
           unit: requests/s
           dimensions:
             - name: success
+          chart_type: line
         - name: adfs.passive_requests
           description: Passive requests
           unit: requests/s
           dimensions:
             - name: passive
+          chart_type: line
         - name: adfs.passport_authentications
           description: Microsoft Passport SSO authentications
           unit: authentications/s
           dimensions:
             - name: passport
+          chart_type: line
         - name: adfs.password_change_requests
           description: Password change requests
           unit: requests/s
           dimensions:
             - name: success
             - name: failure
+          chart_type: line
         - name: adfs.samlp_token_requests_success
           description: Successful RP token requests over SAML-P protocol
           unit: requests/s
           dimensions:
             - name: success
+          chart_type: line
         - name: adfs.sso_authentications
           description: SSO authentications
           unit: authentications/s
           dimensions:
             - name: success
             - name: failure
+          chart_type: line
         - name: adfs.token_requests
           description: Token access requests
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: adfs.userpassword_authentications
           description: AD U/P authentications
           unit: authentications/s
           dimensions:
             - name: success
             - name: failure
+          chart_type: line
         - name: adfs.windows_integrated_authentications
           description: Windows integrated authentications using Kerberos or NTLM
           unit: authentications/s
           dimensions:
             - name: authentications
+          chart_type: line
         - name: adfs.wsfed_token_requests_success
           description: Successful RP token requests over WS-Fed protocol
           unit: requests/s
           dimensions:
             - name: success
+          chart_type: line
         - name: adfs.wstrust_token_requests_success
           description: Successful RP token requests over WS-Trust protocol
           unit: requests/s
           dimensions:
             - name: success
+          chart_type: line
         - name: exchange.activesync_ping_cmds_pending
           description: Ping commands pending in queue
           unit: commands
           dimensions:
             - name: pending
+          chart_type: line
         - name: exchange.activesync_requests
           description: HTTP requests received from ASP.NET
           unit: requests/s
           dimensions:
             - name: received
+          chart_type: line
         - name: exchange.activesync_sync_cmds
           description: Sync commands processed
           unit: commands/s
           dimensions:
             - name: processed
+          chart_type: line
         - name: exchange.autodiscover_requests
           description: Autodiscover service requests processed
           unit: requests/s
           dimensions:
             - name: processed
+          chart_type: line
         - name: exchange.avail_service_requests
           description: Requests serviced
           unit: requests/s
           dimensions:
             - name: serviced
+          chart_type: line
         - name: exchange.owa_current_unique_users
           description: Unique users currently logged on to Outlook Web App
           unit: users
           dimensions:
             - name: logged-in
+          chart_type: line
         - name: exchange.owa_requests_total
           description: Requests handled by Outlook Web App
           unit: requests/s
           dimensions:
             - name: handled
+          chart_type: line
         - name: exchange.rpc_active_user_count
           description: Active unique users in the last 2 minutes
           unit: users
           dimensions:
             - name: active
+          chart_type: line
         - name: exchange.rpc_avg_latency
           description: Average latency
           unit: seconds
           dimensions:
             - name: latency
+          chart_type: line
         - name: exchange.rpc_connection_count
           description: Client connections
           unit: connections
           dimensions:
             - name: connections
+          chart_type: line
         - name: exchange.rpc_operations
           description: RPC operations
           unit: operations/s
           dimensions:
             - name: operations
+          chart_type: line
         - name: exchange.rpc_requests
           description: Clients requests currently being processed
           unit: requests
           dimensions:
             - name: processed
+          chart_type: line
         - name: exchange.rpc_user_count
           description: RPC users
           unit: users
           dimensions:
             - name: users
+          chart_type: line
         - name: exchange.transport_queues_active_mail_box_delivery
           description: Active Mailbox Delivery Queue length
           unit: messages/s
@@ -534,6 +682,7 @@ metrics:
             - name: high
             - name: none
             - name: normal
+          chart_type: line
         - name: exchange.transport_queues_external_active_remote_delivery
           description: External Active Remote Delivery Queue length
           unit: messages/s
@@ -542,6 +691,7 @@ metrics:
             - name: high
             - name: none
             - name: normal
+          chart_type: line
         - name: exchange.transport_queues_external_largest_delivery
           description: External Largest Delivery Queue length
           unit: messages/s
@@ -550,6 +700,7 @@ metrics:
             - name: high
             - name: none
             - name: normal
+          chart_type: line
         - name: exchange.transport_queues_internal_active_remote_delivery
           description: Internal Active Remote Delivery Queue length
           unit: messages/s
@@ -558,6 +709,7 @@ metrics:
             - name: high
             - name: none
             - name: normal
+          chart_type: line
         - name: exchange.transport_queues_internal_largest_delivery
           description: Internal Largest Delivery Queue length
           unit: messages/s
@@ -566,6 +718,7 @@ metrics:
             - name: high
             - name: none
             - name: normal
+          chart_type: line
         - name: exchange.transport_queues_retry_mailbox_delivery
           description: Internal Active Remote Delivery Queue length
           unit: messages/s
@@ -574,6 +727,7 @@ metrics:
             - name: high
             - name: none
             - name: normal
+          chart_type: line
         - name: exchange.transport_queues_poison
           description: Poison Queue Length
           unit: messages/s
@@ -582,12 +736,14 @@ metrics:
             - name: high
             - name: none
             - name: normal
+          chart_type: line
         - name: hyperv.vms_health
           description: Virtual machines health status
           unit: vms
           dimensions:
             - name: ok
             - name: critical
+          chart_type: stacked
         - name: hyperv.root_partition_device_space_pages
           description: Root partition pages in the device space
           unit: pages
@@ -595,6 +751,7 @@ metrics:
             - name: 4K
             - name: 2M
             - name: 1G
+          chart_type: line
         - name: hyperv.root_partition_gpa_space_pages
           description: Root partition pages in the GPA space
           unit: pages
@@ -602,61 +759,73 @@ metrics:
             - name: 4K
             - name: 2M
             - name: 1G
+          chart_type: line
         - name: hyperv.root_partition_gpa_space_modifications
           description: Root partition GPA space modifications
           unit: modifications/s
           dimensions:
             - name: gpa
+          chart_type: line
         - name: hyperv.root_partition_attached_devices
           description: Root partition attached devices
           unit: devices
           dimensions:
             - name: attached
+          chart_type: line
         - name: hyperv.root_partition_deposited_pages
           description: Root partition deposited pages
           unit: pages
           dimensions:
             - name: deposited
+          chart_type: line
         - name: hyperv.root_partition_skipped_interrupts
           description: Root partition skipped interrupts
           unit: interrupts
           dimensions:
             - name: skipped
+          chart_type: line
         - name: hyperv.root_partition_device_dma_errors
           description: Root partition illegal DMA requests
           unit: requests
           dimensions:
             - name: illegal_dma
+          chart_type: line
         - name: hyperv.root_partition_device_interrupt_errors
           description: Root partition illegal interrupt requests
           unit: requests
           dimensions:
             - name: illegal_interrupt
+          chart_type: line
         - name: hyperv.root_partition_device_interrupt_throttle_events
           description: Root partition throttled interrupts
           unit: events
           dimensions:
             - name: throttling
+          chart_type: line
         - name: hyperv.root_partition_io_tlb_flush
           description: Root partition flushes of I/O TLBs
           unit: flushes/s
           dimensions:
             - name: flushes
+          chart_type: line
         - name: hyperv.root_partition_address_space
           description: Root partition address spaces in the virtual TLB
           unit: address spaces
           dimensions:
             - name: address_spaces
+          chart_type: line
         - name: hyperv.root_partition_virtual_tlb_flush_entries
           description: Root partition flushes of the entire virtual TLB
           unit: flushes/s
           dimensions:
             - name: flushes
+          chart_type: line
         - name: hyperv.root_partition_virtual_tlb_pages
           description: Root partition pages used by the virtual TLB
           unit: pages
           dimensions:
             - name: used
+          chart_type: line
     - name: cpu core
       description: TBD
       labels:
@@ -671,16 +840,19 @@ metrics:
             - name: user
             - name: privileged
             - name: interrupt
+          chart_type: stacked
         - name: windows.cpu_core_interrupts
           description: Received and Serviced Hardware Interrupts
           unit: interrupts/s
           dimensions:
             - name: interrupts
+          chart_type: line
         - name: windows.cpu_core_dpcs
           description: Received and Serviced Deferred Procedure Calls (DPC)
           unit: dpcs/s
           dimensions:
             - name: dpcs
+          chart_type: line
         - name: windows.cpu_core_cstate
           description: Core Time Spent in Low-Power Idle State
           unit: percentage
@@ -688,6 +860,7 @@ metrics:
             - name: c1
             - name: c2
             - name: c3
+          chart_type: stacked
     - name: logical disk
       description: TBD
       labels:
@@ -700,24 +873,28 @@ metrics:
           dimensions:
             - name: free
             - name: used
+          chart_type: stacked
         - name: windows.logical_disk_bandwidth
           description: Bandwidth
           unit: bytes/s
           dimensions:
             - name: read
             - name: write
+          chart_type: area
         - name: windows.logical_disk_operations
           description: Operations
           unit: operations/s
           dimensions:
             - name: reads
             - name: writes
+          chart_type: line
         - name: windows.logical_disk_latency
           description: Average Read/Write Latency
           unit: seconds
           dimensions:
             - name: read
             - name: write
+          chart_type: line
     - name: network device
       description: TBD
       labels:
@@ -730,24 +907,28 @@ metrics:
           dimensions:
             - name: received
             - name: sent
+          chart_type: area
         - name: windows.net_nic_packets
           description: Packets
           unit: packets/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: line
         - name: windows.net_nic_errors
           description: Errors
           unit: errors/s
           dimensions:
             - name: inbound
             - name: outbound
+          chart_type: line
         - name: windows.net_nic_discarded
           description: Discards
           unit: discards/s
           dimensions:
             - name: inbound
             - name: outbound
+          chart_type: line
     - name: thermalzone
       description: TBD
       labels:
@@ -759,6 +940,7 @@ metrics:
           unit: celsius
           dimensions:
             - name: temperature
+          chart_type: line
     - name: service
       description: TBD
       labels:
@@ -777,6 +959,7 @@ metrics:
             - name: pause_pending
             - name: paused
             - name: unknown
+          chart_type: line
         - name: windows.service_status
           description: Service status
           unit: status
@@ -793,6 +976,7 @@ metrics:
             - name: nonrecover
             - name: no_contact
             - name: lost_comm
+          chart_type: line
     - name: website
       description: TBD
       labels:
@@ -805,60 +989,71 @@ metrics:
           dimensions:
             - name: received
             - name: sent
+          chart_type: area
         - name: iis.website_requests_rate
           description: Website requests rate
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: iis.website_active_connections_count
           description: Website active connections
           unit: connections
           dimensions:
             - name: active
+          chart_type: line
         - name: iis.website_users_count
           description: Website users with pending requests
           unit: users
           dimensions:
             - name: anonymous
             - name: non_anonymous
+          chart_type: stacked
         - name: iis.website_connection_attempts_rate
           description: Website connections attempts
           unit: attempts/s
           dimensions:
             - name: connection
+          chart_type: line
         - name: iis.website_isapi_extension_requests_count
           description: ISAPI extension requests
           unit: requests
           dimensions:
             - name: isapi
+          chart_type: line
         - name: iis.website_isapi_extension_requests_rate
           description: Website extensions request
           unit: requests/s
           dimensions:
             - name: isapi
+          chart_type: line
         - name: iis.website_ftp_file_transfer_rate
           description: Website FTP file transfer rate
           unit: files/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: line
         - name: iis.website_logon_attempts_rate
           description: Website logon attempts
           unit: attempts/s
           dimensions:
             - name: logon
+          chart_type: line
         - name: iis.website_errors_rate
           description: Website errors
           unit: errors/s
           dimensions:
             - name: document_locked
             - name: document_not_found
+          chart_type: stacked
         - name: iis.website_uptime
           description: Website uptime
           unit: seconds
           dimensions:
             - name: document_locked
             - name: document_not_found
+          chart_type: line
     - name: mssql instance
       description: TBD
       labels:
@@ -870,37 +1065,44 @@ metrics:
           unit: splits/s
           dimensions:
             - name: page
+          chart_type: line
         - name: mssql.instance_cache_hit_ratio
           description: Buffer Cache hit ratio
           unit: percentage
           dimensions:
             - name: hit_ratio
+          chart_type: line
         - name: mssql.instance_bufman_checkpoint_pages
           description: Flushed pages
           unit: pages/s
           dimensions:
             - name: flushed
+          chart_type: line
         - name: mssql.instance_bufman_page_life_expectancy
           description: Page life expectancy
           unit: seconds
           dimensions:
             - name: life_expectancy
+          chart_type: line
         - name: mssql.instance_bufman_iops
           description: Number of pages input and output
           unit: iops
           dimensions:
             - name: read
             - name: written
+          chart_type: line
         - name: mssql.instance_blocked_processes
           description: Blocked processes
           unit: processes
           dimensions:
             - name: blocked
+          chart_type: line
         - name: mssql.instance_user_connection
           description: User connections
           unit: connections
           dimensions:
             - name: user
+          chart_type: line
         - name: mssql.instance_locks_lock_wait
           description: Lock requests that required the caller to wait
           unit: locks/s
@@ -919,6 +1121,7 @@ metrics:
             - name: rid
             - name: row_group
             - name: xact
+          chart_type: line
         - name: mssql.instance_locks_deadlocks
           description: Lock requests that resulted in deadlock
           unit: locks/s
@@ -937,26 +1140,31 @@ metrics:
             - name: rid
             - name: row_group
             - name: xact
+          chart_type: line
         - name: mssql.instance_memmgr_connection_memory_bytes
           description: Amount of dynamic memory to maintain connections
           unit: bytes
           dimensions:
             - name: memory
+          chart_type: line
         - name: mssql.instance_memmgr_external_benefit_of_memory
           description: Performance benefit from adding memory to a specific cache
           unit: bytes
           dimensions:
             - name: benefit
+          chart_type: line
         - name: mssql.instance_memmgr_pending_memory_grants
           description: Process waiting for memory grant
           unit: processes
           dimensions:
             - name: pending
+          chart_type: line
         - name: mssql.instance_memmgr_server_memory
           description: Memory committed
           unit: bytes
           dimensions:
             - name: memory
+          chart_type: line
         - name: mssql.instance_sql_errors
           description: Errors
           unit: errors
@@ -965,31 +1173,37 @@ metrics:
             - name: info
             - name: kill_connection
             - name: user
+          chart_type: line
         - name: mssql.instance_sqlstats_auto_parameterization_attempts
           description: Failed auto-parameterization attempts
           unit: attempts/s
           dimensions:
             - name: failed
+          chart_type: line
         - name: mssql.instance_sqlstats_batch_requests
           description: Total of batches requests
           unit: requests/s
           dimensions:
             - name: batch
+          chart_type: line
         - name: mssql.instance_sqlstats_safe_auto_parameterization_attempts
           description: Safe auto-parameterization attempts
           unit: attempts/s
           dimensions:
             - name: safe
+          chart_type: line
         - name: mssql.instance_sqlstats_sql_compilations
           description: SQL compilations
           unit: compilations/s
           dimensions:
             - name: compilations
+          chart_type: line
         - name: mssql.instance_sqlstats_sql_recompilations
           description: SQL re-compilations
           unit: recompiles/s
           dimensions:
             - name: recompiles
+          chart_type: line
     - name: database
       description: TBD
       labels:
@@ -1003,36 +1217,43 @@ metrics:
           unit: transactions
           dimensions:
             - name: active
+          chart_type: line
         - name: mssql.database_backup_restore_operations
           description: Backup IO per database
           unit: operations/s
           dimensions:
             - name: backup
+          chart_type: line
         - name: mssql.database_data_files_size
           description: Current database size
           unit: bytes
           dimensions:
             - name: size
+          chart_type: line
         - name: mssql.database_log_flushed
           description: Log flushed
           unit: bytes/s
           dimensions:
             - name: flushed
+          chart_type: line
         - name: mssql.database_log_flushes
           description: Log flushes
           unit: flushes/s
           dimensions:
             - name: log
+          chart_type: line
         - name: mssql.database_transactions
           description: Transactions
           unit: transactions/s
           dimensions:
             - name: transactions
+          chart_type: line
         - name: mssql.database_write_transactions
           description: Write transactions
           unit: transactions/s
           dimensions:
             - name: write
+          chart_type: line
     - name: certificate template
       description: TBD
       labels:
@@ -1044,67 +1265,80 @@ metrics:
           unit: requests/s
           dimensions:
             - name: requests
+          chart_type: line
         - name: adcs.cert_template_failed_requests
           description: Certificate failed requests processed
           unit: requests/s
           dimensions:
             - name: failed
+          chart_type: line
         - name: adcs.cert_template_issued_requests
           description: Certificate issued requests processed
           unit: requests/s
           dimensions:
             - name: issued
+          chart_type: line
         - name: adcs.cert_template_pending_requests
           description: Certificate pending requests processed
           unit: requests/s
           dimensions:
             - name: pending
+          chart_type: line
         - name: adcs.cert_template_request_processing_time
           description: Certificate last request processing time
           unit: seconds
           dimensions:
             - name: processing_time
+          chart_type: line
         - name: adcs.cert_template_retrievals
           description: Total of certificate retrievals
           unit: retrievals/s
           dimensions:
             - name: retrievals
+          chart_type: line
         - name: adcs.cert_template_retrieval_processing_time
           description: Certificate last retrieval processing time
           unit: seconds
           dimensions:
             - name: processing_time
+          chart_type: line
         - name: adcs.cert_template_request_cryptographic_signing_time
           description: Certificate last signing operation request time
           unit: seconds
           dimensions:
             - name: singing_time
+          chart_type: line
         - name: adcs.cert_template_request_policy_module_processing
           description: Certificate last policy module processing request time
           unit: seconds
           dimensions:
             - name: processing_time
+          chart_type: line
         - name: adcs.cert_template_challenge_responses
           description: Certificate challenge responses
           unit: responses/s
           dimensions:
             - name: challenge
+          chart_type: line
         - name: adcs.cert_template_challenge_response_processing_time
           description: Certificate last challenge response time
           unit: seconds
           dimensions:
             - name: processing_time
+          chart_type: line
         - name: adcs.cert_template_signed_certificate_timestamp_lists
           description: Certificate Signed Certificate Timestamp Lists processed
           unit: lists/s
           dimensions:
             - name: processed
+          chart_type: line
         - name: adcs.cert_template_signed_certificate_timestamp_list_processing_time
           description: Certificate last Signed Certificate Timestamp List process
             time
           unit: seconds
           dimensions:
             - name: processing_time
+          chart_type: line
     - name: process
       description: TBD
       labels:
@@ -1116,221 +1350,265 @@ metrics:
           unit: exceptions/s
           dimensions:
             - name: exceptions
+          chart_type: line
         - name: netframework.clrexception_filters
           description: Executed exception filters
           unit: filters/s
           dimensions:
             - name: filters
+          chart_type: line
         - name: netframework.clrexception_finallys
           description: Executed finally blocks
           unit: finallys/s
           dimensions:
             - name: finallys
+          chart_type: line
         - name: netframework.clrexception_throw_to_catch_depth
           description: Traversed stack frames
           unit: stack_frames/s
           dimensions:
             - name: traversed
+          chart_type: line
         - name: netframework.clrinterop_com_callable_wrappers
           description: COM callable wrappers (CCW)
           unit: ccw/s
           dimensions:
             - name: com_callable_wrappers
+          chart_type: line
         - name: netframework.clrinterop_interop_marshallings
           description: Arguments and return values marshallings
           unit: marshallings/s
           dimensions:
             - name: marshallings
+          chart_type: line
         - name: netframework.clrinterop_interop_stubs_created
           description: Created stubs
           unit: stubs/s
           dimensions:
             - name: created
+          chart_type: line
         - name: netframework.clrjit_methods
           description: JIT-compiled methods
           unit: methods/s
           dimensions:
             - name: jit-compiled
+          chart_type: line
         - name: netframework.clrjit_time
           description: Time spent in JIT compilation
           unit: percentage
           dimensions:
             - name: time
+          chart_type: line
         - name: netframework.clrjit_standard_failures
           description: JIT compiler failures
           unit: failures/s
           dimensions:
             - name: failures
+          chart_type: line
         - name: netframework.clrjit_il_bytes
           description: Compiled Microsoft intermediate language (MSIL) bytes
           unit: bytes/s
           dimensions:
             - name: compiled_msil
+          chart_type: line
         - name: netframework.clrloading_loader_heap_size
           description: Memory committed by class loader
           unit: bytes
           dimensions:
             - name: committed
+          chart_type: line
         - name: netframework.clrloading_appdomains_loaded
           description: Loaded application domains
           unit: domain/s
           dimensions:
             - name: loaded
+          chart_type: line
         - name: netframework.clrloading_appdomains_unloaded
           description: Unloaded application domains
           unit: domain/s
           dimensions:
             - name: unloaded
+          chart_type: line
         - name: netframework.clrloading_assemblies_loaded
           description: Loaded assemblies
           unit: assemblies/s
           dimensions:
             - name: loaded
+          chart_type: line
         - name: netframework.clrloading_classes_loaded
           description: Loaded classes in all assemblies
           unit: classes/s
           dimensions:
             - name: loaded
+          chart_type: line
         - name: netframework.clrloading_class_load_failures
           description: Class load failures
           unit: failures/s
           dimensions:
             - name: class_load
+          chart_type: line
         - name: netframework.clrlocksandthreads_queue_length
           description: Threads waited to acquire a managed lock
           unit: threads/s
           dimensions:
             - name: threads
+          chart_type: line
         - name: netframework.clrlocksandthreads_current_logical_threads
           description: Logical threads
           unit: threads
           dimensions:
             - name: logical
+          chart_type: line
         - name: netframework.clrlocksandthreads_current_physical_threads
           description: Physical threads
           unit: threads
           dimensions:
             - name: physical
+          chart_type: line
         - name: netframework.clrlocksandthreads_recognized_threads
           description: Threads recognized by the runtime
           unit: threads/s
           dimensions:
             - name: threads
+          chart_type: line
         - name: netframework.clrlocksandthreads_contentions
           description: Fails to acquire a managed lock
           unit: contentions/s
           dimensions:
             - name: contentions
+          chart_type: line
         - name: netframework.clrmemory_allocated_bytes
           description: Memory allocated on the garbage collection heap
           unit: bytes/s
           dimensions:
             - name: allocated
+          chart_type: line
         - name: netframework.clrmemory_finalization_survivors
           description: Objects that survived garbage-collection
           unit: objects
           dimensions:
             - name: survived
+          chart_type: line
         - name: netframework.clrmemory_heap_size
           description: Maximum bytes that can be allocated
           unit: bytes
           dimensions:
             - name: heap
+          chart_type: line
         - name: netframework.clrmemory_promoted
           description: Memory promoted to the next generation
           unit: bytes
           dimensions:
             - name: promoted
+          chart_type: line
         - name: netframework.clrmemory_number_gc_handles
           description: Garbage collection handles
           unit: handles
           dimensions:
             - name: used
+          chart_type: line
         - name: netframework.clrmemory_collections
           description: Garbage collections
           unit: gc/s
           dimensions:
             - name: gc
+          chart_type: line
         - name: netframework.clrmemory_induced_gc
           description: Garbage collections induced
           unit: gc/s
           dimensions:
             - name: gc
+          chart_type: line
         - name: netframework.clrmemory_number_pinned_objects
           description: Pinned objects encountered
           unit: objects
           dimensions:
             - name: pinned
+          chart_type: line
         - name: netframework.clrmemory_number_sink_blocks_in_use
           description: Synchronization blocks in use
           unit: blocks
           dimensions:
             - name: used
+          chart_type: line
         - name: netframework.clrmemory_committed
           description: Virtual memory committed by GC
           unit: bytes
           dimensions:
             - name: committed
+          chart_type: line
         - name: netframework.clrmemory_reserved
           description: Virtual memory reserved by GC
           unit: bytes
           dimensions:
             - name: reserved
+          chart_type: line
         - name: netframework.clrmemory_gc_time
           description: Time spent on GC
           unit: percentage
           dimensions:
             - name: time
+          chart_type: line
         - name: netframework.clrremoting_channels
           description: Registered channels
           unit: channels/s
           dimensions:
             - name: registered
+          chart_type: line
         - name: netframework.clrremoting_context_bound_classes_loaded
           description: Loaded context-bound classes
           unit: classes
           dimensions:
             - name: loaded
+          chart_type: line
         - name: netframework.clrremoting_context_bound_objects
           description: Allocated context-bound objects
           unit: objects/s
           dimensions:
             - name: allocated
+          chart_type: line
         - name: netframework.clrremoting_context_proxies
           description: Remoting proxy objects
           unit: objects/s
           dimensions:
             - name: objects
+          chart_type: line
         - name: netframework.clrremoting_contexts
           description: Total of remoting contexts
           unit: contexts
           dimensions:
             - name: contexts
+          chart_type: line
         - name: netframework.clrremoting_remote_calls
           description: Remote Procedure Calls (RPC) invoked
           unit: calls/s
           dimensions:
             - name: rpc
+          chart_type: line
         - name: netframework.clrsecurity_link_time_checks
           description: Link-time code access security checks
           unit: checks/s
           dimensions:
             - name: linktime
+          chart_type: line
         - name: netframework.clrsecurity_checks_time
           description: Time spent performing runtime code access security checks
           unit: percentage
           dimensions:
             - name: time
+          chart_type: line
         - name: netframework.clrsecurity_stack_walk_depth
           description: Depth of the stack
           unit: depth
           dimensions:
             - name: stack
+          chart_type: line
         - name: netframework.clrsecurity_runtime_checks
           description: Runtime code access security checks performed
           unit: checks/s
           dimensions:
             - name: runtime
+          chart_type: line
     - name: exchange workload
       description: TBD
       labels:
@@ -1342,27 +1620,32 @@ metrics:
           unit: tasks
           dimensions:
             - name: active
+          chart_type: line
         - name: exchange.workload_completed_tasks
           description: Workload completed tasks
           unit: tasks/s
           dimensions:
             - name: completed
+          chart_type: line
         - name: exchange.workload_queued_tasks
           description: Workload queued tasks
           unit: tasks/s
           dimensions:
             - name: queued
+          chart_type: line
         - name: exchange.workload_yielded_tasks
           description: Workload yielded tasks
           unit: tasks/s
           dimensions:
             - name: yielded
+          chart_type: line
         - name: exchange.workload_activity_status
           description: Workload activity status
           unit: status
           dimensions:
             - name: active
             - name: paused
+          chart_type: line
     - name: ldap process
       description: TBD
       labels:
@@ -1374,26 +1657,31 @@ metrics:
           unit: operations/s
           dimensions:
             - name: long-running
+          chart_type: line
         - name: exchange.ldap_read_time
           description: Time to send an LDAP read request and receive a response
           unit: seconds
           dimensions:
             - name: read
+          chart_type: line
         - name: exchange.ldap_search_time
           description: Time to send an LDAP search request and receive a response
           unit: seconds
           dimensions:
             - name: search
+          chart_type: line
         - name: exchange.ldap_write_time
           description: Time to send an LDAP search request and receive a response
           unit: seconds
           dimensions:
             - name: write
+          chart_type: line
         - name: exchange.ldap_timeout_errors
           description: LDAP timeout errors
           unit: errors/s
           dimensions:
             - name: timeout
+          chart_type: line
     - name: http proxy
       description: TBD
       labels:
@@ -1405,31 +1693,37 @@ metrics:
           unit: seconds
           dimensions:
             - name: latency
+          chart_type: line
         - name: exchange.http_proxy_avg_cas_processing_latency_sec
           description: Average time spent authenticating CAS
           unit: seconds
           dimensions:
             - name: latency
+          chart_type: line
         - name: exchange.http_proxy_mailbox_proxy_failure_rate
           description: Percentage of failures between this CAS and MBX servers
           unit: percentage
           dimensions:
             - name: failures
+          chart_type: line
         - name: exchange.http_proxy_mailbox_server_locator_avg_latency_sec
           description: Average latency of MailboxServerLocator web service calls
           unit: seconds
           dimensions:
             - name: latency
+          chart_type: line
         - name: exchange.http_proxy_outstanding_proxy_requests
           description: Concurrent outstanding proxy requests
           unit: requests
           dimensions:
             - name: outstanding
+          chart_type: line
         - name: exchange.http_proxy_requests
           description: Number of proxy requests processed each second
           unit: requests/s
           dimensions:
             - name: processed
+          chart_type: line
     - name: vm
       description: TBD
       labels:
@@ -1443,31 +1737,37 @@ metrics:
             - name: gues
             - name: hypervisor
             - name: remote
+          chart_type: stacked
         - name: hyperv.vm_memory_physical
           description: VM assigned memory
           unit: MiB
           dimensions:
             - name: assigned_memory
+          chart_type: line
         - name: hyperv.vm_memory_physical_guest_visible
           description: VM guest visible memory
           unit: MiB
           dimensions:
             - name: visible_memory
+          chart_type: line
         - name: hyperv.vm_memory_pressure_current
           description: VM current pressure
           unit: percentage
           dimensions:
             - name: pressure
+          chart_type: line
         - name: hyperv.vm_vid_physical_pages_allocated
           description: VM physical pages allocated
           unit: pages
           dimensions:
             - name: allocated
+          chart_type: line
         - name: hyperv.vm_vid_remote_physical_pages
           description: VM physical pages not allocated from the preferred NUMA node
           unit: pages
           dimensions:
             - name: remote_physical
+          chart_type: line
     - name: vm device
       description: TBD
       labels:
@@ -1480,17 +1780,20 @@ metrics:
           dimensions:
             - name: read
             - name: written
+          chart_type: area
         - name: hyperv.vm_device_operations
           description: VM storage device IOPS
           unit: operations/s
           dimensions:
             - name: read
             - name: write
+          chart_type: line
         - name: hyperv.vm_device_errors
           description: VM storage device errors
           unit: errors/s
           dimensions:
             - name: errors
+          chart_type: line
     - name: vm interface
       description: TBD
       labels:
@@ -1503,18 +1806,21 @@ metrics:
           dimensions:
             - name: received
             - name: sent
+          chart_type: area
         - name: hyperv.vm_interface_packets
           description: VM interface packets
           unit: packets/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: line
         - name: hyperv.vm_interface_packets_dropped
           description: VM interface packets dropped
           unit: drops/s
           dimensions:
             - name: incoming
             - name: outgoing
+          chart_type: line
     - name: vswitch
       description: TBD
       labels:
@@ -1527,54 +1833,64 @@ metrics:
           dimensions:
             - name: received
             - name: sent
+          chart_type: area
         - name: hyperv.vswitch_packets
           description: Virtual switch packets
           unit: packets/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: line
         - name: hyperv.vswitch_directed_packets
           description: Virtual switch directed packets
           unit: packets/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: line
         - name: hyperv.vswitch_broadcast_packets
           description: Virtual switch broadcast packets
           unit: packets/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: line
         - name: hyperv.vswitch_multicast_packets
           description: Virtual switch multicast packets
           unit: packets/s
           dimensions:
             - name: received
             - name: sent
+          chart_type: line
         - name: hyperv.vswitch_dropped_packets
           description: Virtual switch dropped packets
           unit: drops/s
           dimensions:
             - name: incoming
             - name: outgoing
+          chart_type: line
         - name: hyperv.vswitch_extensions_dropped_packets
           description: Virtual switch extensions dropped packets
           unit: drops/s
           dimensions:
             - name: incoming
             - name: outgoing
+          chart_type: line
         - name: hyperv.vswitch_packets_flooded
           description: Virtual switch flooded packets
           unit: packets/s
           dimensions:
             - name: flooded
+          chart_type: line
         - name: hyperv.vswitch_learned_mac_addresses
           description: Virtual switch learned MAC addresses
           unit: mac addresses/s
           dimensions:
             - name: learned
+          chart_type: line
         - name: hyperv.vswitch_purged_mac_addresses
           description: Virtual switch purged MAC addresses
           unit: mac addresses/s
           dimensions:
             - name: purged
+          chart_type: line

--- a/modules/wireguard/metadata.yaml
+++ b/modules/wireguard/metadata.yaml
@@ -2,38 +2,37 @@ name: wireguard
 title: WireGuard collector
 overview:
   application:
-    description: |
-      [WireGuard](https://www.wireguard.com/) is an extremely simple yet fast and modern VPN that utilizes state-of-the-art
-      cryptography.
-
+    description: "[WireGuard](https://www.wireguard.com/) is an extremely simple yet
+      fast and modern VPN that utilizes state-of-the-art\ncryptography.\n"
   collector:
-    description: |
-      This collector monitors WireGuard VPN network interfaces and peers traffic.
-      CAP_NET_ADMIN capability is required. It is set automatically during installation.
+    description: "This collector monitors WireGuard VPN network interfaces and peers
+      traffic.\nCAP_NET_ADMIN capability is required. It is set automatically during
+      installation.\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
     examples:
       folding:
         title: Config
         enabled: true
       list: []
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -41,8 +40,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: device
       description: These metrics refer to the VPN network interface.
       labels:
@@ -55,11 +55,13 @@ metrics:
           dimensions:
             - name: receive
             - name: transmit
+          chart_type: area
         - name: wireguard.device_peers
           description: Device peers
           unit: peers
           dimensions:
             - name: peers
+          chart_type: line
     - name: peer
       description: These metrics refer to the VPN peer.
       labels:
@@ -74,8 +76,10 @@ metrics:
           dimensions:
             - name: receive
             - name: transmit
+          chart_type: area
         - name: wireguard.peer_latest_handshake_ago
           description: Peer time elapsed since the latest handshake
           unit: seconds
           dimensions:
             - name: time
+          chart_type: line

--- a/modules/x509check/metadata.yaml
+++ b/modules/x509check/metadata.yaml
@@ -2,69 +2,69 @@ name: x509check
 title: x509 certificate collector
 overview:
   application:
-    description: |
-      An X.509 certificate is a digital certificate based on the widely accepted International Telecommunications Union (ITU) X.509 standard.
-
+    description: "An X.509 certificate is a digital certificate based on the widely
+      accepted International Telecommunications Union (ITU) X.509 standard.\n"
   collector:
-    description: |
-      This collector checks the time until a x509 certificate expires and its revocation status.
-
-      Information about X509 certificates can be collected through a local file, TCP, UDP, HTTPS or SMTP protocols.
+    description: "This collector checks the time until a x509 certificate expires
+      and its revocation status.\n\nInformation about X509 certificates can be collected
+      through a local file, TCP, UDP, HTTPS or SMTP protocols.\n"
 setup:
   prerequisites:
     list: []
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: source
-          description: "Certificate source. Allowed schemes: https, tcp, tcp4, tcp6, udp, udp4, udp6, file."
-          default: ""
+          description: 'Certificate source. Allowed schemes: https, tcp, tcp4, tcp6,
+            udp, udp4, udp6, file.'
           required: false
+          default_value: ''
         - name: days_until_expiration_warning
           description: Number of days before the alarm status is warning.
-          default: 30
           required: false
+          default_value: 30
         - name: days_until_expiration_critical
           description: Number of days before the alarm status is critical.
-          default: 15
           required: false
+          default_value: 15
         - name: check_revocation_status
           description: Whether to check the revocation status of the certificate.
-          default: no
           required: false
+          default_value: no
         - name: timeout
           description: SSL connection timeout.
-          default: 2
           required: false
+          default_value: 2
         - name: tls_skip_verify
-          description: Server certificate chain and hostname validation policy. Controls whether the client performs this check.
-          default: no
+          description: Server certificate chain and hostname validation policy. Controls
+            whether the client performs this check.
           required: false
+          default_value: no
         - name: tls_ca
-          description: Certification authority that the client uses when verifying the server's certificates.
-          default: ""
+          description: Certification authority that the client uses when verifying
+            the server's certificates.
           required: false
+          default_value: ''
         - name: tls_cert
           description: Client TLS certificate.
-          default: ""
           required: false
+          default_value: ''
         - name: tls_key
           description: Client TLS key.
-          default: ""
           required: false
+          default_value: ''
     examples:
       folding:
         title: Config
@@ -72,37 +72,22 @@ setup:
       list:
         - name: Website certificate
           description: Website certificate.
-          data: |
-            jobs:
-              - name: my_site_cert
-                source: https://my_site.org:443
+          config: "jobs:\n  - name: my_site_cert\n    source: https://my_site.org:443\n"
         - name: Local file certificate
           description: Local file certificate.
-          data: |
-            jobs:
-              - name: my_file_cert
-                source: file:///home/me/cert.pem
+          config: "jobs:\n  - name: my_file_cert\n    source: file:///home/me/cert.pem\n"
         - name: SMTP certificate
           description: SMTP certificate.
-          data: |
-            jobs:
-              - name: my_smtp_cert
-                source: smtp://smtp.my_mail.org:587
+          config: "jobs:\n  - name: my_smtp_cert\n    source: smtp://smtp.my_mail.org:587\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define more than one job, their names must be unique.
-
-            Check the expiration status of the multiple websites' certificates.
-          data: |
-            jobs:
-              - name: my_site_cert1
-                source: https://my_site1.org:443
-
-              - name: my_site_cert2
-                source: https://my_site1.org:443
-
-              - name: my_site_cert3
-                source: https://my_site3.org:443
+          description: "> **Note**: When you define more than one job, their names
+            must be unique.\n\nCheck the expiration status of the multiple websites'
+            certificates.\n"
+          config: "jobs:\n  - name: my_site_cert1\n    source: https://my_site1.org:443\n\
+            \n  - name: my_site_cert2\n    source: https://my_site1.org:443\n\n  -
+            name: my_site_cert3\n    source: https://my_site3.org:443\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -110,8 +95,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: source
       description: These metrics refer to the configured source.
       labels:
@@ -123,8 +109,10 @@ metrics:
           unit: seconds
           dimensions:
             - name: expiry
+          chart_type: line
         - name: x509check.revocation_status
           description: Revocation Status
           unit: boolean
           dimensions:
             - name: revoked
+          chart_type: line

--- a/modules/zookeeper/metadata.yaml
+++ b/modules/zookeeper/metadata.yaml
@@ -2,63 +2,63 @@ name: zookeeper
 title: Zookeeper collector
 overview:
   application:
-    description: |
-      [ZooKeeper](https://zookeeper.apache.org/) is a centralized service for maintaining configuration information, naming,
-      providing distributed synchronization, and providing group services.
+    description: "[ZooKeeper](https://zookeeper.apache.org/) is a centralized service
+      for maintaining configuration information, naming,\nproviding distributed synchronization,
+      and providing group services.\n"
   collector:
-    description: |
-      This collector monitors one or more ZooKeeper servers, depending on your configuration. It fetches metrics from ZooKeeper
-      by using the [mntr](https://zookeeper.apache.org/doc/r3.4.8/zookeeperAdmin.html#sc_zkCommands) command.
+    description: "This collector monitors one or more ZooKeeper servers, depending
+      on your configuration. It fetches metrics from ZooKeeper\nby using the [mntr](https://zookeeper.apache.org/doc/r3.4.8/zookeeperAdmin.html#sc_zkCommands)
+      command.\n"
 setup:
   prerequisites:
     list:
       - title: Whitelist `mntr` command
-        text: |
-          Add `mntr` to Zookeeper's [4lw.commands.whitelist](https://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_4lw).
+        description: "Add `mntr` to Zookeeper's [4lw.commands.whitelist](https://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_4lw).\n"
   configuration:
     options:
-      description: |
-        The following options can be defined globally: update_every, autodetection_retry.
+      description: "The following options can be defined globally: update_every, autodetection_retry.\n"
       folding:
         title: Config options
         enabled: true
       list:
         - name: update_every
           description: Data collection frequency.
-          default: 1
           required: false
+          default_value: 1
         - name: autodetection_retry
           description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default: 0
           required: false
+          default_value: 0
         - name: address
           description: Server address. The format is IP:PORT.
-          default: 127.0.0.1:2181
           required: true
+          default_value: 127.0.0.1:2181
         - name: timeout
           description: Connection/read/write/ssl handshake timeout.
-          default: 1
           required: false
+          default_value: 1
         - name: use_tls
           description: Whether to use TLS or not.
-          default: no
           required: false
+          default_value: no
         - name: tls_skip_verify
-          description: Server certificate chain and hostname validation policy. Controls whether the client performs this check.
-          default: no
+          description: Server certificate chain and hostname validation policy. Controls
+            whether the client performs this check.
           required: false
+          default_value: no
         - name: tls_ca
-          description: Certification authority that the client uses when verifying the server's certificates.
-          default: ""
+          description: Certification authority that the client uses when verifying
+            the server's certificates.
           required: false
+          default_value: ''
         - name: tls_cert
           description: Client TLS certificate.
-          default: ""
           required: false
+          default_value: ''
         - name: tls_key
           description: Client TLS key.
-          default: ""
           required: false
+          default_value: ''
     examples:
       folding:
         title: Config
@@ -66,30 +66,18 @@ setup:
       list:
         - name: Basic
           description: Local server.
-          data: |
-            jobs:
-              - name: local
-                address: 127.0.0.1:2181
+          config: "jobs:\n  - name: local\n    address: 127.0.0.1:2181\n"
         - name: TLS with self-signed certificate
           description: Zookeeper with TLS and self-signed certificate.
-          data: |
-            jobs:
-              - name: local
-                address: 127.0.0.1:2181
-                use_tls: yes
-                tls_skip_verify: yes
+          config: "jobs:\n  - name: local\n    address: 127.0.0.1:2181\n    use_tls:
+            yes\n    tls_skip_verify: yes\n"
         - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-
-            Collecting metrics from local and remote instances.
-          data: |
-            jobs:
-              - name: local
-                address: 127.0.0.1:2181
-
-              - name: remote
-                address: 192.0.2.1:2181
+          description: "> **Note**: When you define multiple jobs, their names must
+            be unique.\n\nCollecting metrics from local and remote instances.\n"
+          config: "jobs:\n  - name: local\n    address: 127.0.0.1:2181\n\n  - name:
+            remote\n    address: 192.0.2.1:2181\n"
+    file:
+      name: ''
 troubleshooting:
   problems:
     list: []
@@ -97,8 +85,9 @@ metrics:
   folding:
     title: Metrics
     enabled: false
-  description: ""
-  scope:
+  description: ''
+  availability: []
+  scopes:
     - name: global
       description: These metrics refer to the entire monitored application.
       labels: []
@@ -108,6 +97,7 @@ metrics:
           unit: requests
           dimensions:
             - name: outstanding
+          chart_type: line
         - name: zookeeper.requests_latency
           description: Requests Latency
           unit: ms
@@ -115,40 +105,48 @@ metrics:
             - name: min
             - name: avg
             - name: max
+          chart_type: line
         - name: zookeeper.connections
           description: Alive Connections
           unit: connections
           dimensions:
             - name: alive
+          chart_type: line
         - name: zookeeper.packets
           description: Packets
           unit: pps
           dimensions:
             - name: received
             - name: sent
+          chart_type: line
         - name: zookeeper.file_descriptor
           description: Open File Descriptors
           unit: file descriptors
           dimensions:
             - name: open
+          chart_type: line
         - name: zookeeper.nodes
           description: Number of Nodes
           unit: nodes
           dimensions:
             - name: znode
             - name: ephemerals
+          chart_type: line
         - name: zookeeper.watches
           description: Number of Watches
           unit: watches
           dimensions:
             - name: watches
+          chart_type: line
         - name: zookeeper.approximate_data_size
           description: Approximate Data Tree Size
           unit: KiB
           dimensions:
             - name: size
+          chart_type: line
         - name: zookeeper.server_state
           description: Server State
           unit: state
           dimensions:
             - name: state
+          chart_type: line


### PR DESCRIPTION
chart type waas added, multiline strings have `\n`s now, but should work.

Some keys were added, but I can't control ordering in yaml, so they are not sorted. 

In yamls having only metrics I added the empty template to make them pass the schema. 