### PR TITLE
remove a space in global settings

### DIFF
--- a/config/go.d/activemq.conf
+++ b/config/go.d/activemq.conf
@@ -178,9 +178,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/apache.conf
+++ b/config/go.d/apache.conf
@@ -147,9 +147,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/bind.conf
+++ b/config/go.d/bind.conf
@@ -156,9 +156,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/cassandra.conf
+++ b/config/go.d/cassandra.conf
@@ -129,9 +129,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 5
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 5
+#autodetection_retry: 0
+#priority: 70000
 #
 
 jobs:

--- a/config/go.d/chrony.conf
+++ b/config/go.d/chrony.conf
@@ -79,9 +79,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/cockroachdb.conf
+++ b/config/go.d/cockroachdb.conf
@@ -147,9 +147,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/consul.conf
+++ b/config/go.d/consul.conf
@@ -165,9 +165,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/coredns.conf
+++ b/config/go.d/coredns.conf
@@ -173,9 +173,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - url: http://127.0.0.1:9153/metrics

--- a/config/go.d/couchbase.conf
+++ b/config/go.d/couchbase.conf
@@ -83,9 +83,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 10
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 10
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/couchdb.conf
+++ b/config/go.d/couchdb.conf
@@ -158,9 +158,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 10
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 10
+#autodetection_retry: 0
+#priority: 70000
 
 # jobs:
 #   - name: local

--- a/config/go.d/dns_query.conf
+++ b/config/go.d/dns_query.conf
@@ -103,9 +103,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 #jobs:
 # - name: example

--- a/config/go.d/dnsdist.conf
+++ b/config/go.d/dnsdist.conf
@@ -147,9 +147,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/dnsmasq.conf
+++ b/config/go.d/dnsmasq.conf
@@ -84,9 +84,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/dnsmasq_dhcp.conf
+++ b/config/go.d/dnsmasq_dhcp.conf
@@ -85,9 +85,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: dnsmasq_dhcp

--- a/config/go.d/docker.conf
+++ b/config/go.d/docker.conf
@@ -83,9 +83,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/docker_engine.conf
+++ b/config/go.d/docker_engine.conf
@@ -147,9 +147,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/dockerhub.conf
+++ b/config/go.d/dockerhub.conf
@@ -153,9 +153,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 #jobs:
 #  - name: local

--- a/config/go.d/elasticsearch.conf
+++ b/config/go.d/elasticsearch.conf
@@ -176,9 +176,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 5
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 5
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/energid.conf
+++ b/config/go.d/energid.conf
@@ -146,9 +146,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 #jobs:
 #  - name: energi

--- a/config/go.d/envoy.conf
+++ b/config/go.d/envoy.conf
@@ -147,9 +147,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/example.conf
+++ b/config/go.d/example.conf
@@ -86,9 +86,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: example

--- a/config/go.d/filecheck.conf
+++ b/config/go.d/filecheck.conf
@@ -88,9 +88,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 10
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 10
+#autodetection_retry: 0
+#priority: 70000
 
 #jobs:
 # - name: files_example

--- a/config/go.d/fluentd.conf
+++ b/config/go.d/fluentd.conf
@@ -153,9 +153,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/freeradius.conf
+++ b/config/go.d/freeradius.conf
@@ -83,9 +83,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/geth.conf
+++ b/config/go.d/geth.conf
@@ -147,9 +147,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: "local"

--- a/config/go.d/haproxy.conf
+++ b/config/go.d/haproxy.conf
@@ -147,9 +147,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/hdfs.conf
+++ b/config/go.d/hdfs.conf
@@ -146,9 +146,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 #
 
 #jobs:

--- a/config/go.d/isc_dhcpd.conf
+++ b/config/go.d/isc_dhcpd.conf
@@ -83,9 +83,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 #jobs:
 # - name: ipv4_example

--- a/config/go.d/k8s_kubelet.conf
+++ b/config/go.d/k8s_kubelet.conf
@@ -147,9 +147,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - url: http://127.0.0.1:10255/metrics

--- a/config/go.d/k8s_state.conf
+++ b/config/go.d/k8s_state.conf
@@ -60,9 +60,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: k8s_state

--- a/config/go.d/lighttpd.conf
+++ b/config/go.d/lighttpd.conf
@@ -147,9 +147,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/logind.conf
+++ b/config/go.d/logind.conf
@@ -70,9 +70,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: logind

--- a/config/go.d/logstash.conf
+++ b/config/go.d/logstash.conf
@@ -147,9 +147,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/mongodb.conf
+++ b/config/go.d/mongodb.conf
@@ -81,9 +81,9 @@
 #  - uri
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/mysql.conf
+++ b/config/go.d/mysql.conf
@@ -85,9 +85,9 @@
 #  - dsn
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 # timeout: 1
 
 jobs:

--- a/config/go.d/nginx.conf
+++ b/config/go.d/nginx.conf
@@ -147,9 +147,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/nginxplus.conf
+++ b/config/go.d/nginxplus.conf
@@ -142,9 +142,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/nginxvts.conf
+++ b/config/go.d/nginxvts.conf
@@ -147,9 +147,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/ntpd.conf
+++ b/config/go.d/ntpd.conf
@@ -78,9 +78,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/nvidia_smi.conf
+++ b/config/go.d/nvidia_smi.conf
@@ -73,9 +73,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: nvidia_smi

--- a/config/go.d/nvme.conf
+++ b/config/go.d/nvme.conf
@@ -73,9 +73,9 @@
 ##
 ## ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 10
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 10
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: nvme

--- a/config/go.d/openvpn.conf
+++ b/config/go.d/openvpn.conf
@@ -104,9 +104,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/openvpn_status_log.conf
+++ b/config/go.d/openvpn_status_log.conf
@@ -102,9 +102,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/pgbouncer.conf
+++ b/config/go.d/pgbouncer.conf
@@ -72,9 +72,9 @@
 #  - dsn
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/phpdaemon.conf
+++ b/config/go.d/phpdaemon.conf
@@ -147,9 +147,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/phpfpm.conf
+++ b/config/go.d/phpfpm.conf
@@ -163,9 +163,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/pihole.conf
+++ b/config/go.d/pihole.conf
@@ -105,10 +105,10 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every        : 5
+#update_every        : 5
 # timeout             : 5
-# autodetection_retry : 0
-# priority            : 70000
+#autodetection_retry : 0
+#priority            : 70000
 
 jobs:
   - name: pihole

--- a/config/go.d/pika.conf
+++ b/config/go.d/pika.conf
@@ -100,9 +100,9 @@
 #  - address
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/ping.conf
+++ b/config/go.d/ping.conf
@@ -98,9 +98,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 5
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 5
+#autodetection_retry: 0
+#priority: 70000
 
 ## Uncomment the following lines to create a data collection config:
 

--- a/config/go.d/portcheck.conf
+++ b/config/go.d/portcheck.conf
@@ -83,9 +83,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 #jobs:
 # - name: job1

--- a/config/go.d/postgres.conf
+++ b/config/go.d/postgres.conf
@@ -85,9 +85,9 @@
 #  - dsn
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   # User postgres

--- a/config/go.d/powerdns.conf
+++ b/config/go.d/powerdns.conf
@@ -147,9 +147,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/powerdns_recursor.conf
+++ b/config/go.d/powerdns_recursor.conf
@@ -147,9 +147,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/prometheus.conf
+++ b/config/go.d/prometheus.conf
@@ -193,9 +193,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 10
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 10
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   # https://github.com/prometheus/prometheus/wiki/Default-port-allocations

--- a/config/go.d/proxysql.conf
+++ b/config/go.d/proxysql.conf
@@ -83,9 +83,9 @@
 #  - dsn
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 # timeout: 1
 
 jobs:

--- a/config/go.d/pulsar.conf
+++ b/config/go.d/pulsar.conf
@@ -162,9 +162,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/rabbitmq.conf
+++ b/config/go.d/rabbitmq.conf
@@ -155,9 +155,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/redis.conf
+++ b/config/go.d/redis.conf
@@ -110,9 +110,9 @@
 #  - address
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/scaleio.conf
+++ b/config/go.d/scaleio.conf
@@ -130,9 +130,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every         : 1
-# autodetection_retry  : 0
-# priority             : 70000
+#update_every         : 1
+#autodetection_retry  : 0
+#priority             : 70000
 
 #jobs:
 #  - name     : local

--- a/config/go.d/snmp.conf
+++ b/config/go.d/snmp.conf
@@ -151,9 +151,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 #jobs:
 #  - name: switch

--- a/config/go.d/solr.conf
+++ b/config/go.d/solr.conf
@@ -147,9 +147,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/springboot2.conf
+++ b/config/go.d/springboot2.conf
@@ -159,9 +159,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/squidlog.conf
+++ b/config/go.d/squidlog.conf
@@ -119,9 +119,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: squidlog

--- a/config/go.d/supervisord.conf
+++ b/config/go.d/supervisord.conf
@@ -105,9 +105,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/systemdunits.conf
+++ b/config/go.d/systemdunits.conf
@@ -81,9 +81,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 10
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 10
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
  - name: service-units

--- a/config/go.d/tengine.conf
+++ b/config/go.d/tengine.conf
@@ -147,9 +147,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/traefik.conf
+++ b/config/go.d/traefik.conf
@@ -147,9 +147,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/unbound.conf
+++ b/config/go.d/unbound.conf
@@ -118,9 +118,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/vcsa.conf
+++ b/config/go.d/vcsa.conf
@@ -116,9 +116,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 #jobs:
 #  - name     : vcsa1

--- a/config/go.d/vernemq.conf
+++ b/config/go.d/vernemq.conf
@@ -147,9 +147,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local

--- a/config/go.d/vsphere.conf
+++ b/config/go.d/vsphere.conf
@@ -157,9 +157,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every        : 20 # do not decrease the value, vmware real-time stats generated at the 20-seconds specificity.
-# autodetection_retry : 0
-# priority            : 70000
+#update_every        : 20 # do not decrease the value, vmware real-time stats generated at the 20-seconds specificity.
+#autodetection_retry : 0
+#priority            : 70000
 
 #jobs:
 #  - name     : vcenter1

--- a/config/go.d/web_log.conf
+++ b/config/go.d/web_log.conf
@@ -181,9 +181,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   # NGINX

--- a/config/go.d/whoisquery.conf
+++ b/config/go.d/whoisquery.conf
@@ -91,9 +91,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 60
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 60
+#autodetection_retry: 0
+#priority: 70000
 #
 
 # jobs:

--- a/config/go.d/windows.conf
+++ b/config/go.d/windows.conf
@@ -129,9 +129,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 5
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 5
+#autodetection_retry: 0
+#priority: 70000
 #
 
 jobs:

--- a/config/go.d/wireguard.conf
+++ b/config/go.d/wireguard.conf
@@ -65,9 +65,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: wireguard

--- a/config/go.d/x509check.conf
+++ b/config/go.d/x509check.conf
@@ -116,9 +116,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 60
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 60
+#autodetection_retry: 0
+#priority: 70000
 
 #jobs:
 #  - name: my_site_cert

--- a/config/go.d/zookeeper.conf
+++ b/config/go.d/zookeeper.conf
@@ -105,9 +105,9 @@
 #
 # ------------------------------------------------MODULE-CONFIGURATION--------------------------------------------------
 
-# update_every: 1
-# autodetection_retry: 0
-# priority: 70000
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
 
 jobs:
   - name: local


### PR DESCRIPTION
Otherwise, it results in an invalid YAML format when you remove the `#` but don't remove the space.