### PR TITLE
Update related resources sections to use ids.

### DIFF
--- a/modules/activemq/metadata.yaml
+++ b/modules/activemq/metadata.yaml
@@ -18,10 +18,8 @@ modules:
       related_resources:
         integrations:
           list:
-            - plugin_name: go.d.plugin
-              module_name: httpcheck
-            - plugin_name: apps.plugin
-              module_name: apps
+            - id: collector-go.d.plugin-httpcheck
+            - id: collector-apps.plugin-apps
     overview:
       data_collection:
         metrics_description: This collector monitors ActiveMQ queues and topics.

--- a/modules/apache/metadata.yaml
+++ b/modules/apache/metadata.yaml
@@ -15,12 +15,9 @@ modules:
       related_resources:
         integrations:
           list:
-            - plugin_name: go.d.plugin
-              module_name: weblog
-            - plugin_name: go.d.plugin
-              module_name: httpcheck
-            - plugin_name: apps.plugin
-              module_name: apps
+            - id: collector-go.d.plugin-web_log
+            - id: collector-go.d.plugin-httpcheck
+            - id: collector-apps.plugin-apps
       info_provided_to_referring_integrations:
         description: ""
       most_popular: true

--- a/modules/elasticsearch/metadata.yaml
+++ b/modules/elasticsearch/metadata.yaml
@@ -18,10 +18,8 @@ modules:
       related_resources:
         integrations:
           list:
-            - plugin_name: apps.plugin
-              module_name: apps
-            - plugin_name: cgroups.plugin
-              module_name: cgroups
+            - id: collector-apps.plugin-apps
+            - id: collector-cgroups.plugin-cgroup
       info_provided_to_referring_integrations:
         description: ""
       most_popular: true

--- a/modules/envoy/metadata.yaml
+++ b/modules/envoy/metadata.yaml
@@ -15,8 +15,7 @@ modules:
       related_resources:
         integrations:
           list:
-            - plugin_name: apps.plugin
-              module_name: apps
+            - id: collector-apps.plugin-apps
       info_provided_to_referring_integrations:
         description: ""
       most_popular: true

--- a/modules/geth/metadata.yaml
+++ b/modules/geth/metadata.yaml
@@ -16,8 +16,7 @@ modules:
       related_resources:
         integrations:
           list:
-            - plugin_name: apps.plugin
-              module_name: apps
+            - id: collector-apps.plugin-apps
       info_provided_to_referring_integrations:
         description: ""
       most_popular: true

--- a/modules/k8s_kubelet/metadata.yaml
+++ b/modules/k8s_kubelet/metadata.yaml
@@ -16,8 +16,7 @@ modules:
       related_resources:
         integrations:
           list:
-            - plugin_name: apps.plugin
-              module_name: apps
+            - id: collector-apps.plugin-apps
       info_provided_to_referring_integrations:
         description: ""
       most_popular: true

--- a/modules/k8s_kubeproxy/metadata.yaml
+++ b/modules/k8s_kubeproxy/metadata.yaml
@@ -16,8 +16,7 @@ modules:
       related_resources:
         integrations:
           list:
-            - plugin_name: apps.plugin
-              module_name: apps
+            - id: collector-apps.plugin-apps
       info_provided_to_referring_integrations:
         description: ""
       most_popular: true

--- a/modules/lighttpd/metadata.yaml
+++ b/modules/lighttpd/metadata.yaml
@@ -14,12 +14,9 @@ modules:
       related_resources:
         integrations:
           list:
-            - plugin_name: go.d.plugin
-              module_name: weblog
-            - plugin_name: go.d.plugin
-              module_name: httpcheck
-            - plugin_name: apps.plugin
-              module_name: apps
+            - id: collector-go.d.plugin-web_log
+            - id: collector-go.d.plugin-httpcheck
+            - id: collector-apps.plugin-apps
       info_provided_to_referring_integrations:
         description: ""
       most_popular: true

--- a/modules/mysql/metadata.yaml
+++ b/modules/mysql/metadata.yaml
@@ -13,10 +13,8 @@ modules:
       related_resources:
         integrations:
           list:
-            - plugin_name: apps.plugin
-              module_name: apps
-            - plugin_name: cgroups.plugin
-              module_name: cgroups
+            - id: collector-apps.plugin-apps
+            - id: collector-cgroups.plugin-cgroup
       info_provided_to_referring_integrations:
         description: ""
       keywords:

--- a/modules/nginx/metadata.yaml
+++ b/modules/nginx/metadata.yaml
@@ -12,14 +12,10 @@ modules:
       related_resources:
         integrations:
           list:
-            - plugin_name: go.d.plugin
-              module_name: httpcheck
-            - plugin_name: go.d.plugin
-              module_name: web_log
-            - plugin_name: apps.plugin
-              module_name: apps
-            - plugin_name: cgroups.plugin
-              module_name: cgroups
+            - id: collector-go.d.plugin-web_log
+            - id: collector-go.d.plugin-httpcheck
+            - id: collector-apps.plugin-apps
+            - id: collector-cgroups.plugin-cgroup
       alternative_monitored_instances: []
       info_provided_to_referring_integrations:
         description: ""

--- a/modules/nginxvts/metadata.yaml
+++ b/modules/nginxvts/metadata.yaml
@@ -14,12 +14,9 @@ modules:
       related_resources:
         integrations:
           list:
-            - plugin_name: go.d.plugin
-              module_name: weblog
-            - plugin_name: go.d.plugin
-              module_name: httpcheck
-            - plugin_name: apps.plugin
-              module_name: apps
+            - id: collector-go.d.plugin-web_log
+            - id: collector-go.d.plugin-httpcheck
+            - id: collector-apps.plugin-apps
       info_provided_to_referring_integrations:
         description: ""
       most_popular: true

--- a/modules/postgres/metadata.yaml
+++ b/modules/postgres/metadata.yaml
@@ -12,10 +12,8 @@ modules:
       related_resources:
         integrations:
           list:
-            - plugin_name: apps.plugin
-              module_name: apps
-            - plugin_name: cgroups.plugin
-              module_name: cgroups
+            - id: collector-apps.plugin-apps
+            - id: collector-cgroups.plugin-cgroup
       alternative_monitored_instances: []
       info_provided_to_referring_integrations:
         description: ""

--- a/modules/pulsar/metadata.yaml
+++ b/modules/pulsar/metadata.yaml
@@ -14,8 +14,7 @@ modules:
       related_resources:
         integrations:
           list:
-            - plugin_name: apps.plugin
-              module_name: apps
+            - id: collector-apps.plugin-apps
       info_provided_to_referring_integrations:
         description: ""
       most_popular: true

--- a/modules/redis/metadata.yaml
+++ b/modules/redis/metadata.yaml
@@ -12,10 +12,8 @@ modules:
       related_resources:
         integrations:
           list:
-            - plugin_name: apps.plugin
-              module_name: apps
-            - plugin_name: cgroups.plugin
-              module_name: cgroups
+            - id: collector-apps.plugin-apps
+            - id: collector-cgroups.plugin-cgroup
       alternative_monitored_instances: []
       info_provided_to_referring_integrations:
         description: ""

--- a/modules/springboot2/metadata.yaml
+++ b/modules/springboot2/metadata.yaml
@@ -14,8 +14,7 @@ modules:
       related_resources:
         integrations:
           list:
-            - plugin_name: apps.plugin
-              module_name: apps
+            - id: collector-apps.plugin-apps
       info_provided_to_referring_integrations:
         description: ""
       most_popular: true

--- a/modules/zookeeper/metadata.yaml
+++ b/modules/zookeeper/metadata.yaml
@@ -17,8 +17,7 @@ modules:
       related_resources:
         integrations:
           list:
-            - plugin_name: apps.plugin
-              module_name: apps
+            - id: collector-apps.plugin-apps
     overview:
       data_collection:
         metrics_description: ""


### PR DESCRIPTION
This is the second part of https://github.com/netdata/go.d.plugin/pull/1317. It needs to wait to be merged until after https://github.com/netdata/netdata/pull/15863 gets merged in the agent repo.