### PR TITLE
openvpn_status_log: Do not count "UNDEF" users

### DIFF
--- a/modules/openvpn_status_log/collect.go
+++ b/modules/openvpn_status_log/collect.go
@@ -57,7 +57,7 @@ func (o *OpenVPNStatusLog) collectUsers(mx map[string]int64, clients []clientInf
 func numOfClients(clients []clientInfo) int64 {
 	var num int64
 	for _, v := range clients {
-		if v.commonName != "" {
+		if v.commonName != "" && v.commonName != "UNDEF" {
 			num++
 		}
 	}


### PR DESCRIPTION
`UNDEF` clients should not be counted, [as it means](https://forums.openvpn.net/viewtopic.php?p=89781#p89781) the connection is not established yet. If you don't use `tls-auth` in the openvpn server config, [random UDP packets or DoS](https://sourceforge.net/p/openvpn/mailman/openvpn-users/thread/alpine.LRH.1.10.0810221455570.5642%40rhlx09.hs-esslingen.de/#msg20611785) could also create a lot of `UNDEF` users in the status files.

The old [python-based openvpn plugin handled this](https://github.com/netdata/netdata/pull/3734) as well and the current `openvpn` module seems to have [special handling](https://github.com/netdata/go.d.plugin/blob/5fa3ff0de80f2a9055c1d1983e0cf1aada48dfbf/modules/openvpn/collect.go#L55) of `UNDEF` too.