### PR TITLE
openvpn: Ignore "UNDEF" users in every module (extends #1334) 

### DIFF
--- a/modules/openvpn/collect.go
+++ b/modules/openvpn/collect.go
@@ -49,13 +49,11 @@ func (o *OpenVPN) collectUsers(mx map[string]int64) error {
 	}
 
 	now := time.Now().Unix()
-	var name string
 
 	for _, user := range users {
-		if user.Username == "UNDEF" {
-			name = user.CommonName
-		} else {
-			name = user.Username
+		name := user.Username
+		if name == "UNDEF" {
+			continue
 		}
 
 		if !o.perUserMatcher.MatchString(name) {

--- a/modules/openvpn_status_log/collect.go
+++ b/modules/openvpn_status_log/collect.go
@@ -39,6 +39,9 @@ func (o *OpenVPNStatusLog) collectUsers(mx map[string]int64, clients []clientInf
 
 	for _, user := range clients {
 		name := user.commonName
+		if name == "UNDEF" {
+			continue
+		}
 		if !o.perUserMatcher.MatchString(name) {
 			continue
 		}


### PR DESCRIPTION
To follow up on https://github.com/netdata/go.d.plugin/pull/1334#issuecomment-1721616398 I'd suggest those changes.

It also seems @ilyam8 actually added some comment for UNDEF handling
https://github.com/netdata/go.d.plugin/blob/5fa3ff0de80f2a9055c1d1983e0cf1aada48dfbf/modules/openvpn/client/client.go#L127-L130

However if  `username == commonName == "UNDEF"` holds true it could be also just ignored.