### PR TITLE
Do not stop collecting mysql statistics because of timeout

### DIFF
--- a/modules/mysql/collect.go
+++ b/modules/mysql/collect.go
@@ -5,6 +5,7 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"

--- a/modules/mysql/collect.go
+++ b/modules/mysql/collect.go
@@ -68,17 +68,25 @@ func (m *MySQL) collect() (map[string]int64, error) {
 	// TODO: perhaps make a decisions based on privileges? (SHOW GRANTS FOR CURRENT_USER();)
 	if m.doSlaveStatus {
 		if err := m.collectSlaveStatus(mx); err != nil {
-			m.Errorf("error on collecting slave status: %v", err)
-			// TODO: shouldn't disable on any error
-			m.doSlaveStatus = false
+			if errors.Is(err, context.DeadlineExceeded) {
+				m.Warning("Deadline exceeded during slave status collection")
+			} else {
+				m.Errorf("error on collecting slave status: %v", err)
+				// TODO: shouldn't disable on any error
+				m.doSlaveStatus = false
+			}
 		}
 	}
 
 	if m.doUserStatistics {
 		if err := m.collectUserStatistics(mx); err != nil {
-			m.Errorf("error on collecting user statistics: %v", err)
-			// TODO: shouldn't disable on any error
-			m.doUserStatistics = false
+			if errors.Is(err, context.DeadlineExceeded) {
+				m.Warning("Deadline exceeded during user statistics collection")
+			} else {
+				m.Errorf("error on collecting user statistics: %v", err)
+				// TODO: shouldn't disable on any error
+				m.doUserStatistics = false
+			}
 		}
 	}
 

--- a/modules/mysql/collect.go
+++ b/modules/mysql/collect.go
@@ -68,25 +68,15 @@ func (m *MySQL) collect() (map[string]int64, error) {
 	// TODO: perhaps make a decisions based on privileges? (SHOW GRANTS FOR CURRENT_USER();)
 	if m.doSlaveStatus {
 		if err := m.collectSlaveStatus(mx); err != nil {
-			if errors.Is(err, context.DeadlineExceeded) {
-				m.Warning("Deadline exceeded during slave status collection")
-			} else {
-				m.Errorf("error on collecting slave status: %v", err)
-				// TODO: shouldn't disable on any error
-				m.doSlaveStatus = false
-			}
+			m.Warningf("error on collecting slave status: %v", err)
+			m.doSlaveStatus = errors.Is(err, context.DeadlineExceeded)
 		}
 	}
 
 	if m.doUserStatistics {
 		if err := m.collectUserStatistics(mx); err != nil {
-			if errors.Is(err, context.DeadlineExceeded) {
-				m.Warning("Deadline exceeded during user statistics collection")
-			} else {
-				m.Errorf("error on collecting user statistics: %v", err)
-				// TODO: shouldn't disable on any error
-				m.doUserStatistics = false
-			}
+			m.Warningf("error on collecting user statistics: %v", err)
+			m.doUserStatistics = errors.Is(err, context.DeadlineExceeded)
 		}
 	}
 


### PR DESCRIPTION
Sometimes under heavy load on a read replica `SHOW ALL SLAVES STATUS` freeze and does not complete in time. This breaks the statistics collection. If you don't mind, it would be great if timeout errors were not considered so critical