### PR TITLE
Fix newline in table

### DIFF
--- a/modules/elasticsearch/metadata.yaml
+++ b/modules/elasticsearch/metadata.yaml
@@ -243,14 +243,11 @@ modules:
           description: These metrics refer to the cluster node.
           labels:
             - name: cluster_name
-              description: |
-                Name of the cluster. Based on the [Cluster name setting](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#cluster-name).
+              description: 'Name of the cluster. Based on the [Cluster name setting](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#cluster-name).'
             - name: node_name
-              description: |
-                Human-readable identifier for the node. Based on the [Node name setting](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#node-name).
+              description: 'Human-readable identifier for the node. Based on the [Node name setting](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#node-name).'
             - name: host
-              description: |
-                Network host for the node, based on the [Network host setting](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#network.host).
+              description: 'Network host for the node, based on the [Network host setting](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#network.host).'
           metrics:
             - name: elasticsearch.node_indices_indexing
               description: Indexing Operations
@@ -496,8 +493,7 @@ modules:
           description: These metrics refer to the cluster.
           labels:
             - name: cluster_name
-              description: |
-                Name of the cluster. Based on the [Cluster name setting](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#cluster-name).
+              description: 'Name of the cluster. Based on the [Cluster name setting](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#cluster-name).'
           metrics:
             - name: elasticsearch.cluster_health_status
               description: Cluster Status
@@ -591,8 +587,7 @@ modules:
           description: These metrics refer to the index.
           labels:
             - name: cluster_name
-              description: |
-                Name of the cluster. Based on the [Cluster name setting](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#cluster-name).
+              description: 'Name of the cluster. Based on the [Cluster name setting](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#cluster-name).'
             - name: index
               description: Name of the index.
           metrics:


### PR DESCRIPTION
If we use `|` inside description fields that go into tables, and then add a newline in them, then the markdown gets messed up.