### PR TITLE
Update modules/prometheus/metadata.yaml to not have conflicting names with native collectors

### DIFF
--- a/modules/prometheus/metadata.yaml
+++ b/modules/prometheus/metadata.yaml
@@ -2323,7 +2323,7 @@ modules:
       most_popular: false
       community: true
       monitored_instance:
-        name: OpenLDAP
+        name: OpenLDAP (community)
         link: https://github.com/tomcz/openldap_exporter
         icon_filename: openldap.svg
         categories:
@@ -5560,7 +5560,7 @@ modules:
       most_popular: false
       community: true
       monitored_instance:
-        name: Memcached
+        name: Memcached (Community)
         link: https://github.com/prometheus/memcached_exporter
         icon_filename: memcached.svg
         categories:
@@ -6339,7 +6339,7 @@ modules:
       most_popular: false
       community: true
       monitored_instance:
-        name: Oracle DB
+        name: Oracle DB (community)
         link: https://github.com/iamseth/oracledb_exporter
         icon_filename: oracle.svg
         categories:

--- a/modules/prometheus/metadata.yaml
+++ b/modules/prometheus/metadata.yaml
@@ -5560,7 +5560,7 @@ modules:
       most_popular: false
       community: true
       monitored_instance:
-        name: Memcached (Community)
+        name: Memcached (community)
         link: https://github.com/prometheus/memcached_exporter
         icon_filename: memcached.svg
         categories:


### PR DESCRIPTION
related discussion: https://netdata-cloud.slack.com/archives/CLVTYCQBD/p1696254773237659

Essentially we don't want to have two integrations named the same, and going to the same category, as it messes up Learn, and also confuses the user imo.