### PR TITLE
mysql: Use Performance Schema processlist implementation if available

### DIFF
--- a/modules/mysql/collect_global_vars.go
+++ b/modules/mysql/collect_global_vars.go
@@ -9,7 +9,8 @@ WHERE
   Variable_name LIKE 'max_connections' 
   OR Variable_name LIKE 'table_open_cache' 
   OR Variable_name LIKE 'disabled_storage_engines' 
-  OR Variable_name LIKE 'log_bin';`
+  OR Variable_name LIKE 'log_bin'
+  OR Variable_name LIKE 'performance_schema';`
 )
 
 func (m *MySQL) collectGlobalVariables() error {
@@ -31,6 +32,8 @@ func (m *MySQL) collectGlobalVariables() error {
 				m.varLogBin = value
 			case "max_connections":
 				m.varMaxConns = parseInt(value)
+			case "performance_schema":
+				m.varPerformanceSchema = value
 			case "table_open_cache":
 				m.varTableOpenCache = parseInt(value)
 			}

--- a/modules/mysql/collect_process_list.go
+++ b/modules/mysql/collect_process_list.go
@@ -42,7 +42,7 @@ ORDER BY
 func (m *MySQL) collectProcessListStatistics(mx map[string]int64) error {
 	var q string
 	mysqlMinVer := semver.Version{Major: 8, Minor: 0, Patch: 22}
-	if !m.isMariaDB && m.version.GTE(mysqlMinVer) && m.varPerformanceSchema != "OFF" {
+	if !m.isMariaDB && m.version.GTE(mysqlMinVer) && m.varPerformanceSchema == "ON" {
 		q = queryShowProcessListPS
 	} else {
 		q = queryShowProcessList

--- a/modules/mysql/mysql.go
+++ b/modules/mysql/mysql.go
@@ -89,6 +89,7 @@ type MySQL struct {
 	varTableOpenCache        int64
 	varDisabledStorageEngine string
 	varLogBin                string
+	varPerformanceSchema     string
 }
 
 func (m *MySQL) Init() bool {

--- a/modules/mysql/mysql_test.go
+++ b/modules/mysql/mysql_test.go
@@ -1309,7 +1309,7 @@ func TestMySQL_Collect(t *testing.T) {
 					mockExpect(t, m, queryShowGlobalStatus, dataMySQLV8030GlobalStatus)
 					mockExpect(t, m, queryShowGlobalVariables, dataMySQLV8030GlobalVariables)
 					mockExpect(t, m, queryShowSlaveStatus, dataMySQLV8030SlaveStatusMultiSource)
-					mockExpect(t, m, queryShowProcessList, dataMySQLV8030ProcessList)
+					mockExpect(t, m, queryShowProcessListPS, dataMySQLV8030ProcessList)
 				},
 				check: func(t *testing.T, my *MySQL) {
 					mx := my.Collect()
@@ -1445,7 +1445,7 @@ func TestMySQL_Collect(t *testing.T) {
 					mockExpect(t, m, queryShowGlobalVariables, dataPerconaV8029GlobalVariables)
 					mockExpect(t, m, queryShowSlaveStatus, nil)
 					mockExpect(t, m, queryShowUserStatistics, dataPerconaV8029UserStatistics)
-					mockExpect(t, m, queryShowProcessList, dataPerconaV8029ProcessList)
+					mockExpect(t, m, queryShowProcessListPS, dataPerconaV8029ProcessList)
 				},
 				check: func(t *testing.T, my *MySQL) {
 					mx := my.Collect()

--- a/modules/mysql/testdata/mariadb/v10.8.4-galera-cluster/global_variables.txt
+++ b/modules/mysql/testdata/mariadb/v10.8.4-galera-cluster/global_variables.txt
@@ -1,7 +1,8 @@
-+------------------+-------+
-| Variable_name    | Value |
-+------------------+-------+
-| log_bin          | ON    |
-| max_connections  | 151   |
-| table_open_cache | 2000  |
-+------------------+-------+
++--------------------+-------+
+| Variable_name      | Value |
++--------------------+-------+
+| log_bin            | ON    |
+| max_connections    | 151   |
+| performance_schema | ON    |
+| table_open_cache   | 2000  |
++--------------------+-------+

--- a/modules/mysql/testdata/mariadb/v10.8.4/global_variables.txt
+++ b/modules/mysql/testdata/mariadb/v10.8.4/global_variables.txt
@@ -1,7 +1,8 @@
-+------------------+-------+
-| Variable_name    | Value |
-+------------------+-------+
-| log_bin          | ON    |
-| max_connections  | 151   |
-| table_open_cache | 2000  |
-+------------------+-------+
++--------------------+-------+
+| Variable_name      | Value |
++--------------------+-------+
+| log_bin            | ON    |
+| max_connections    | 151   |
+| performance_schema | ON    |
+| table_open_cache   | 2000  |
++--------------------+-------+

--- a/modules/mysql/testdata/mysql/v8.0.30/global_variables.txt
+++ b/modules/mysql/testdata/mysql/v8.0.30/global_variables.txt
@@ -4,5 +4,6 @@
 | disabled_storage_engines |       |
 | log_bin                  | ON    |
 | max_connections          | 151   |
+| performance_schema       | ON    |
 | table_open_cache         | 4000  |
 +--------------------------+-------+

--- a/modules/mysql/testdata/percona/v8.0.29/global_variables.txt
+++ b/modules/mysql/testdata/percona/v8.0.29/global_variables.txt
@@ -4,5 +4,6 @@
 | disabled_storage_engines |       |
 | log_bin                  | ON    |
 | max_connections          | 151   |
+| performance_schema       | ON    |
 | table_open_cache         | 4000  |
 +--------------------------+-------+


### PR DESCRIPTION
INFORMATION_SCHEMA.PROCESSLIST is deprecated and subject to removal in a future MySQL release. As such, the implementation of SHOW PROCESSLIST which uses that table is also deprecated.
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-35.html#mysqld-8-0-35-deprecation-removal

The new Performace Schema implementation is available since 8.0.22. https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-22.html#mysqld-8-0-22-performance-schema