### PR TITLE
fix(postgres): add "user a member of pg_read_all_stats" check when querying db size for v10+

### DIFF
--- a/modules/postgres/do_query_databases.go
+++ b/modules/postgres/do_query_databases.go
@@ -68,7 +68,7 @@ func (p *Postgres) doQueryDatabaseStats() error {
 }
 
 func (p *Postgres) doQueryDatabaseSize() error {
-	q := queryDatabaseSize()
+	q := queryDatabaseSize(p.pgVersion)
 
 	var db string
 	return p.doQuery(q, func(column, value string, _ bool) {

--- a/modules/postgres/postgres_test.go
+++ b/modules/postgres/postgres_test.go
@@ -179,7 +179,7 @@ func TestPostgres_Check(t *testing.T) {
 				mockExpect(t, m, queryReplicationSlotFiles(140004), dataV140004ReplSlotFiles)
 
 				mockExpect(t, m, queryDatabaseStats(), dataV140004DatabaseStats)
-				mockExpect(t, m, queryDatabaseSize(), dataV140004DatabaseSize)
+				mockExpect(t, m, queryDatabaseSize(140004), dataV140004DatabaseSize)
 				mockExpect(t, m, queryDatabaseConflicts(), dataV140004DatabaseConflicts)
 				mockExpect(t, m, queryDatabaseLocks(), dataV140004DatabaseLocks)
 
@@ -282,7 +282,7 @@ func TestPostgres_Collect(t *testing.T) {
 					mockExpect(t, m, queryReplicationSlotFiles(140004), dataV140004ReplSlotFiles)
 
 					mockExpect(t, m, queryDatabaseStats(), dataV140004DatabaseStats)
-					mockExpect(t, m, queryDatabaseSize(), dataV140004DatabaseSize)
+					mockExpect(t, m, queryDatabaseSize(140004), dataV140004DatabaseSize)
 					mockExpect(t, m, queryDatabaseConflicts(), dataV140004DatabaseConflicts)
 					mockExpect(t, m, queryDatabaseLocks(), dataV140004DatabaseLocks)
 

--- a/modules/postgres/queries.go
+++ b/modules/postgres/queries.go
@@ -470,13 +470,23 @@ WHERE pg_database.datistemplate = false;
 `
 }
 
-func queryDatabaseSize() string {
-	return `
+func queryDatabaseSize(version int) string {
+	if version < pgVersion10 {
+		return `
 SELECT datname,
        pg_database_size(datname) AS size
 FROM pg_database
 WHERE pg_database.datistemplate = false
   AND has_database_privilege((SELECT CURRENT_USER), pg_database.datname, 'connect');
+`
+	}
+	return `
+SELECT datname,
+       pg_database_size(datname) AS size
+FROM pg_database
+WHERE pg_database.datistemplate = false
+  AND (has_database_privilege((SELECT CURRENT_USER), datname, 'connect')
+       OR pg_has_role((SELECT CURRENT_USER), 'pg_read_all_stats', 'MEMBER'));
 `
 }
 


### PR DESCRIPTION
Fixes: netdata/netdata#16506

[pg_database_size()](https://pgpedia.info/p/pg_database_size.html)

> can be executed by any user with the CONNECT privilege for the database, **or (from [PostgreSQL 10](https://pgpedia.info/postgresql-versions/postgresql-10.html)) any user who is member of the pg_read_all_stats role**.

This PR implements the **or** part.