### PR TITLE
disable logind on systemd 239 by default

### DIFF
--- a/agent/confgroup/group.go
+++ b/agent/confgroup/group.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/netdata/go.d.plugin/agent/hostinfo"
 	"github.com/netdata/go.d.plugin/agent/module"
 
 	"github.com/ilyam8/hashstructure"
@@ -99,7 +100,7 @@ func firstPositive(value int, others ...int) int {
 }
 
 func urlResolveHostname(rawURL string) string {
-	if hostname == "" || !strings.Contains(rawURL, "hostname") {
+	if hostinfo.Hostname == "" || !strings.Contains(rawURL, "hostname") {
 		return rawURL
 	}
 
@@ -108,13 +109,13 @@ func urlResolveHostname(rawURL string) string {
 		return rawURL
 	}
 
-	u.Host = strings.Replace(u.Host, "hostname", hostname, 1)
+	u.Host = strings.Replace(u.Host, "hostname", hostinfo.Hostname, 1)
 
 	return u.String()
 }
 
 func jobNameResolveHostname(name string) string {
-	if hostname == "" || !strings.Contains(name, "hostname") {
+	if hostinfo.Hostname == "" || !strings.Contains(name, "hostname") {
 		return name
 	}
 
@@ -122,5 +123,5 @@ func jobNameResolveHostname(name string) string {
 		return name
 	}
 
-	return strings.Replace(name, "hostname", hostname, 1)
+	return strings.Replace(name, "hostname", hostinfo.Hostname, 1)
 }

--- a/agent/hostinfo/hostinfo.go
+++ b/agent/hostinfo/hostinfo.go
@@ -1,4 +1,6 @@
-package confgroup
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package hostinfo
 
 import (
 	"bytes"
@@ -7,7 +9,9 @@ import (
 	"time"
 )
 
-var hostname = func() string {
+var Hostname = getHostname()
+
+func getHostname() string {
 	path, err := exec.LookPath("hostname")
 	if err != nil {
 		return ""
@@ -22,4 +26,4 @@ var hostname = func() string {
 	}
 
 	return string(bytes.TrimSpace(bs))
-}()
+}

--- a/agent/hostinfo/hostinfo_common.go
+++ b/agent/hostinfo/hostinfo_common.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !linux
+
+package hostinfo
+
+var SystemdVersion int

--- a/agent/hostinfo/hostinfo_linux.go
+++ b/agent/hostinfo/hostinfo_linux.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build linux
+
+package hostinfo
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+
+	"github.com/coreos/go-systemd/v22/dbus"
+)
+
+var SystemdVersion = getSystemdVersion()
+
+func getSystemdVersion() int {
+	var reVersion = regexp.MustCompile(`[0-9][0-9][0-9]`)
+
+	conn, err := dbus.NewWithContext(context.Background())
+	if err != nil {
+		return 0
+	}
+	defer conn.Close()
+
+	version, err := conn.GetManagerProperty("Version")
+	if err != nil {
+		return 0
+	}
+
+	major := reVersion.FindString(version)
+	if major == "" {
+		return 0
+	}
+
+	ver, err := strconv.Atoi(major)
+	if err != nil {
+		return 0
+	}
+
+	return ver
+}


### PR DESCRIPTION
Fixes: netdata/netdata#15930

Known issue: go.d/logind high CPU usage on Alma Linux 8 (systemd 239).