### PR TITLE
Update metadata.yaml: fixed "header" configuration name

### DIFF
--- a/modules/httpcheck/metadata.yaml
+++ b/modules/httpcheck/metadata.yaml
@@ -121,8 +121,8 @@ modules:
               description: HTTP request body.
               default_value: ""
               required: false
-            - name: headers
-              description: HTTP request headers.
+            - name: header
+              description: List of HTTP request headers.
               default_value: ""
               required: false
             - name: not_follow_redirects


### PR DESCRIPTION
"headers" did not work for me, but "header" did. When I used "headers", then the graph did not appear. In this comment, I found somebody who uses just "header", which worked for me: [https://github.com/netdata/netdata/issues/3704#issuecomment-387902193](https://github.com/netdata/netdata/issues/3704#issuecomment-387902193)
